### PR TITLE
fix(decoration): Python 3.14 compat -- two-pass decoration + TypeError catch

### DIFF
--- a/.project-context/knowledge/gotchas.md
+++ b/.project-context/knowledge/gotchas.md
@@ -29,3 +29,6 @@
 - [visualization] ELK stress layout allocates O(n^2) memory — NEVER use for >100k nodes
 - [utils] `get_tensor_memory_amount()` MUST use `pause_logging()` — `nelement()`/`element_size()` are decorated
 - [utils] Clean function imports (`clean_clone`, `clean_to`) must happen at module load time, before `decorate_all_once()`
+- [decoration] NEVER mutate a namespace while introspecting it -- `inspect.signature()` evaluates annotations lazily (PEP 649, Python 3.14+), so decorated names (e.g. `Tensor.bool`) can shadow builtins in annotation resolution. Collect all introspection data in a separate pass BEFORE decoration begins (#138)
+- [decoration] `decorate_all_once()` idempotency guard must use `_is_decorated` (completion flag), NOT `_orig_to_decorated` (non-empty dict). Partial failure populates the dict without completing decoration; dict-based guard prevents retry and locks in incomplete state (#138)
+- [decoration] `get_func_argnames` must catch both `ValueError` AND `TypeError` from `inspect.signature()` -- TypeError occurs on Python 3.14+ when deferred annotation evaluation resolves class-level names to wrapper functions instead of builtins (#138)

--- a/tests/test_decoration.py
+++ b/tests/test_decoration.py
@@ -7,6 +7,7 @@ exception/interrupt safety.
 """
 
 import gc
+import inspect
 import os
 import signal
 import sys
@@ -18,9 +19,11 @@ import torch
 from torch import nn
 
 import torchlens
+from torchlens.decoration import torch_funcs as torch_funcs_module
 from torchlens import _state, log_forward_pass
 from torchlens.decoration.torch_funcs import (
     decorate_all_once,
+    get_func_argnames,
     patch_detached_references,
     patch_model_instance,
     wrap_torch,
@@ -875,6 +878,82 @@ class TestJITCompat:
 # =========================================================================
 # 9. Decoration Mapping Consistency
 # =========================================================================
+
+
+class TestFuncArgnames:
+    def test_get_func_argnames_tolerates_bad_annotations(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_func_argnames should tolerate ``inspect.signature`` TypeErrors. #138"""
+
+        def fake_func(x: object, *, flag: bool = False) -> None:
+            """fake_func(x, *, flag=False)"""
+
+        original_signature = torch_funcs_module.inspect.signature
+
+        def failing_signature(target: object) -> inspect.Signature:
+            """Raise the simulated PEP 649 failure for the fake function only."""
+            if target is fake_func:
+                raise TypeError("simulated PEP 649 failure")
+            return original_signature(target)
+
+        monkeypatch.setattr(torch_funcs_module.inspect, "signature", failing_signature)
+        _state._func_argnames.pop("fake_func", None)
+
+        get_func_argnames(fake_func, "fake_func")
+
+        assert _state._func_argnames["fake_func"] == ("x", "flag")
+
+    def test_argnames_collected_before_decoration(self) -> None:
+        """Argnames must be collected before decoration mutates torch names. #138"""
+        wrap_torch()
+
+        assert len(_state._func_argnames) > 500
+        assert len(_state._orig_to_decorated) > 1000
+
+
+class TestPartialDecorationRecovery:
+    """Guard against partial decoration leaving the system in an inconsistent
+    state.  The idempotency check in ``decorate_all_once`` must use
+    ``_is_decorated`` (completion flag), NOT ``_orig_to_decorated`` (non-empty
+    dict), so that a midway failure allows retry. #138"""
+
+    def test_is_decorated_false_before_wrapping(self) -> None:
+        """Before any wrapping, _is_decorated must be False."""
+        unwrap_torch()
+        assert _state._is_decorated is False
+
+    def test_is_decorated_true_after_wrapping(self) -> None:
+        """After successful wrapping, _is_decorated must be True."""
+        wrap_torch()
+        assert _state._is_decorated is True
+
+    def test_is_decorated_distinguishes_partial_from_complete(self) -> None:
+        """_is_decorated must be False when _orig_to_decorated is non-empty
+        but decoration was not completed (simulated partial failure)."""
+        wrap_torch()
+        # Simulate partial state: decorated flag cleared, but maps remain
+        _state._is_decorated = False
+        assert len(_state._orig_to_decorated) > 0
+        assert _state._is_decorated is False
+        # decorate_all_once should NOT early-return on non-empty dict
+        decorate_all_once()
+        assert _state._is_decorated is True
+        # Restore clean state
+        wrap_torch()
+
+    def test_unwrap_clears_is_decorated_but_keeps_maps(self) -> None:
+        """unwrap_torch sets _is_decorated=False but preserves maps for
+        re-installation.  This is the legitimate non-empty-dict case."""
+        wrap_torch()
+        assert _state._is_decorated is True
+        unwrap_torch()
+        assert _state._is_decorated is False
+        assert len(_state._orig_to_decorated) > 0
+        assert len(_state._decorated_to_orig) > 0
+        # Re-wrap should succeed via the re-install path
+        wrap_torch()
+        assert _state._is_decorated is True
 
 
 class TestDecorationConsistency:

--- a/torchlens/decoration/torch_funcs.py
+++ b/torchlens/decoration/torch_funcs.py
@@ -501,7 +501,11 @@ def get_func_argnames(orig_func: Callable, func_name: str):
                 argnames.append(name)
         _state._func_argnames[storage_key] = tuple(argnames)
         return
-    except ValueError:
+    except (ValueError, TypeError):
+        # TypeError: Python 3.14+ deferred annotation evaluation (PEP 649)
+        # can fail when class-level names (e.g. Tensor.bool) shadow builtins
+        # during inspect.signature() annotation resolution. Falls back to
+        # docstring parsing below.
         pass
 
     # Fallback: parse argument names from the docstring's first line.
@@ -553,8 +557,12 @@ def decorate_all_once():
 
     Idempotent: returns immediately if already decorated.
     """
-    if _state._orig_to_decorated:
-        return  # already decorated
+    if _state._is_decorated:
+        return  # already fully decorated
+    # NOTE: Do NOT guard on `_orig_to_decorated` being non-empty here.
+    # A prior partial failure may have populated the dict without completing
+    # decoration. Using _is_decorated (set at end of this function) ensures
+    # retry after partial failure (#138).
 
     # Pre-compute type objects for efficient isinstance-like checks below.
     function_class = type(lambda: 0)  # <class 'function'>
@@ -563,6 +571,22 @@ def decorate_all_once():
     wrapper_class = type(torch.Tensor.__getitem__)  # <class 'method-wrapper'>
     getset_class = type(torch.Tensor.real)  # <class 'getset_descriptor'> (properties)
 
+    # --- Pass 1: Collect argument names before any decoration ---
+    # inspect.signature() must run against the pristine torch namespace.
+    # Python 3.14+ (PEP 649) evaluates annotations lazily; if we decorate
+    # Tensor.bool first, then inspect Tensor.dim_order, the annotation
+    # bool | list[...] resolves bool to our wrapper -> TypeError (#138).
+    for namespace_name, func_name in ORIG_TORCH_FUNCS:
+        if func_name.strip("_") in _state._func_argnames:
+            continue
+        namespace_key = namespace_name.replace("torch.", "")
+        local_func_namespace = nested_getattr(torch, namespace_key)
+        if not hasattr(local_func_namespace, func_name):
+            continue
+        orig_func = getattr(local_func_namespace, func_name)
+        get_func_argnames(orig_func, func_name)
+
+    # --- Pass 2: Decorate all functions ---
     for namespace_name, func_name in ORIG_TORCH_FUNCS:
         namespace_key = namespace_name.replace("torch.", "")
         local_func_namespace = nested_getattr(torch, namespace_key)
@@ -573,10 +597,6 @@ def decorate_all_once():
         # Guard against double-decoration (ORIG_TORCH_FUNCS may list duplicates).
         if getattr(orig_func, "tl_is_decorated_function", False):
             continue
-
-        # Pre-compute argnames for metadata capture during logging.
-        if func_name.strip("_") not in _state._func_argnames:
-            get_func_argnames(orig_func, func_name)
 
         if type(orig_func) in [function_class, builtin_class, method_class, wrapper_class]:
             # --- Shared-original deduplication ---


### PR DESCRIPTION
## Summary

Fixes #138 -- `log_forward_pass()` fails on first call under Python 3.14 with `TypeError: unsupported operand type(s) for |: 'function' and 'types.GenericAlias'`.

**Root cause**: Python 3.14 (PEP 649) evaluates annotations lazily. During `decorate_all_once()`, wrapping `Tensor.bool` before inspecting `Tensor.dim_order` caused `inspect.signature()` to resolve `bool` in `bool | list[torch.memory_format]` to the TorchLens wrapper function instead of the builtin type.

**Three fixes:**
- Catch `TypeError` alongside `ValueError` in `get_func_argnames` (safety net for any future annotation-resolution failures)
- Split `decorate_all_once()` into two passes: collect argnames from pristine namespace first, then decorate (eliminates root cause)
- Replace `_orig_to_decorated` dict-emptiness idempotency guard with `_is_decorated` completion flag, so partial decoration failure allows retry instead of locking in incomplete state

## Changes
- `torchlens/decoration/torch_funcs.py` -- two-pass split, TypeError catch, idempotency guard fix
- `tests/test_decoration.py` -- 6 new tests (TypeError tolerance, two-pass structure, partial-decoration recovery, unwrap/rewrap flag consistency)
- `.project-context/knowledge/gotchas.md` -- 3 new entries

## Test plan
- [x] `ruff check` -- all passed
- [x] `ruff format` -- unchanged
- [x] `mypy torchlens/` -- no issues
- [x] `pytest tests/test_decoration.py` -- 90 passed
- [x] `pytest tests/ -m smoke` -- 22 passed
- [ ] `pytest tests/ -m "not slow"` -- running, 20%+ done, zero failures so far