### PR TITLE
feat(io): portable bundle save/load, streaming activations, tabular exports

### DIFF
--- a/.project-context/knowledge/io_architecture.md
+++ b/.project-context/knowledge/io_architecture.md
@@ -1,0 +1,116 @@
+# TorchLens I/O Architecture
+
+Reference plan: `.project-context/plans/io-sprint/plan.md`
+
+## Bundle Layout
+
+Portable save writes a directory bundle, not a tar archive:
+
+```text
+<bundle_dir>/
+  manifest.json
+  metadata.pkl
+  blobs/
+    0000000001.safetensors
+    0000000002.safetensors
+    ...
+```
+
+- `manifest.json`: authoritative index, version policy input, and blob metadata.
+- `metadata.pkl`: scrubbed `ModelLog` state with tensor payloads replaced by refs.
+- `blobs/`: one safetensors file per persisted tensor, keyed by zero-padded blob id.
+
+## Manifest Schema v1
+
+Top-level fields:
+
+```text
+io_format_version: int
+torchlens_version: str
+torch_version: str
+python_version: str
+platform: str
+created_at: str
+bundle_format: "directory"
+n_layers: int
+n_activation_blobs: int
+n_gradient_blobs: int
+n_auxiliary_blobs: int
+tensors: list[TensorEntry]
+unsupported_tensors: list[dict[str, str]]
+```
+
+`TensorEntry` fields:
+
+```text
+blob_id: str
+kind: str
+label: str
+relative_path: str
+backend: "safetensors"
+shape: list[int]
+dtype: str
+device_at_save: str
+layout: str
+bytes: int
+sha256: str
+```
+
+Supported `kind` values this sprint: `activation`, `gradient`, `captured_arg`,
+`child_version`, `rng_state`, `module_arg`, `func_config`.
+
+## Tensor Policy Matrix
+
+| Tensor kind | `strict=True` | `strict=False` |
+| --- | --- | --- |
+| Dense CPU/CUDA tensors with supported dtypes | Save | Save |
+| Non-contiguous tensors | Save after `.contiguous()` | Save after `.contiguous()` |
+| Sparse COO/CSR/CSC/BSR/BSC tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| Quantized tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| Nested tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| Tensor subclasses | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| DTensor/FSDP shard tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| `complex32` tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| Meta tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+| Non-CPU/CUDA device tensors | Raise `TorchLensIOError` | Skip and record in `unsupported_tensors` |
+
+## Version Policy
+
+| Scenario | Load behavior |
+| --- | --- |
+| `io_format_version > current` | Raise `TorchLensIOError` before opening `metadata.pkl` |
+| `io_format_version < current` | Load with `DeprecationWarning` listing missing fields |
+| `io_format_version == current` | Load normally |
+| `torch_version` major mismatch | Raise `TorchLensIOError` before opening `metadata.pkl` |
+| `torch_version` minor mismatch | Load with `UserWarning` |
+| `torchlens_version` newer than runtime | Load with `UserWarning` |
+| `torchlens_version` older than runtime | Load with info log only |
+| `python_version` major mismatch | Attempt load; wrap pickle errors in `TorchLensIOError` with a version hint |
+| Safetensors backend missing | Raise `TorchLensIOError` with install hint |
+| Manifest unparseable | Raise `TorchLensIOError` |
+| Manifest blob id missing on disk | Raise `TorchLensIOError` listing missing blobs |
+| Blob checksum mismatch | Raise `TorchLensIOError` naming the blob id |
+| Unknown extra files in `blobs/` | Warn and continue |
+
+## Fork Callouts
+
+- Fork L: portable bundles are for archival, analysis, and sharing. Portable-loaded
+  logs do not support `validate_forward_pass()` or replay-oriented validation.
+- Fork M: `torchlens.load(..., lazy=True, materialize_nested=False)` leaves nested
+  `BlobRef` values in place. Call `torchlens.rehydrate_nested(model_log)` before
+  resaving or expecting nested tensors to behave like normal tensors.
+- Fork H: lazy resave uses a two-level drift guard. TorchLens records the source
+  manifest sha256 at load time, then rechecks the manifest and each copied blob
+  sha256 before fast-copying lazy refs into a new bundle.
+- Fork K: lazy refs do not keep shared readers open. Each materialization opens,
+  verifies, reads, and closes its blob file independently.
+
+## Operational Shape
+
+The current format intentionally creates many small files. For models with more
+than 10,000 saved layers, or for bundles stored on network filesystems, this can
+be slower than a chunked archive format. That tradeoff is explicit for this
+sprint: random-access lazy loads were prioritized over file-count optimization.
+
+See the sprint plan for deeper rationale, deferred work, and the full fork
+history: `.project-context/plans/io-sprint/plan.md`.

--- a/.project-context/knowledge/io_architecture.md
+++ b/.project-context/knowledge/io_architecture.md
@@ -90,7 +90,13 @@ Supported `kind` values this sprint: `activation`, `gradient`, `captured_arg`,
 | Manifest unparseable | Raise `TorchLensIOError` |
 | Manifest blob id missing on disk | Raise `TorchLensIOError` listing missing blobs |
 | Blob checksum mismatch | Raise `TorchLensIOError` naming the blob id |
-| Unknown extra files in `blobs/` | Warn and continue |
+| Unknown extra files in `blobs/` | Warn and continue unless an extra file sha256 matches a manifest entry, then raise `TorchLensIOError` |
+
+## Security
+
+Portable bundles contain a pickle payload in `metadata.pkl`. Only load bundles
+from trusted sources. Loading an untrusted bundle through `torchlens.load()`
+or `ModelLog.load()` can execute arbitrary code.
 
 ## Fork Callouts
 

--- a/.project-context/plans/if-else-attribution/plan.md
+++ b/.project-context/plans/if-else-attribution/plan.md
@@ -1,0 +1,618 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Version:** v7 (ternary folded in; dagua + ELK deferred per user)
+**History:** `plan_v{1,2,3,5,6}.md`, `review_round_{1,2,3,4,5,6}.md`.
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering (`assert`, `bool()` cast, comprehension filters, `while`, `ifexp`, `match` guards, `unknown`).
+3. Explicit per-pass branch representation on `LayerPassLog`; lossless aggregate representation on `LayerLog` and `ModelLog` (including rolled-edge pass divergence and multi-arm-entry edges).
+4. Render THEN / ELIF / ELSE edge labels in Graphviz. (Dagua bridge + ELK deferred to a future sprint per user direction.)
+5. Comprehensive tests for positive paths, every documented limitation, multi-pass divergence, multi-arm entry, and lifecycle integration.
+6. Strict backward compatibility — no existing field is renamed or removed; old fields derived from new primary structures.
+
+## Out-of-Scope for v1 (explicit limitations)
+
+**In scope — fully attributed:**
+- `if` / `elif` / `else` chains (flattened into one `ConditionalEvent`)
+- **Ternary (`x if cond else y`)** (D18) — `bool_context_kind="ifexp"`, `bool_is_branch=True`; `ConditionalEvent.kind="ifexp"` with arms `{then, else}` (no elif). Column-offset disambiguation required because both arms share a source line.
+
+**Non-branch bool consumers — classified, not attributed:**
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast NOT nested inside `If.test`/elif/IfExp test → `bool_context_kind="bool_cast"`
+
+`bool(tensor_cond)` nested *inside* an `If.test`/elif/IfExp test IS a branch (see D3).
+
+**Source-unavailable — graceful degradation (`bool_context_kind="unknown"`, no attribution):**
+- Jupyter / REPL cells, `exec`/`eval`, `.pyc`-only, native `.so` modules
+- `torch.compile`, `torch.jit.script`, `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel`
+- Monkey-patched `forward` where source resolves to the patch
+
+**Documented false negatives — torchlens cannot see:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred (tracked in `.project-context/todos.md`):**
+- `while` loop body attribution — iteration semantics, needs distinct data model.
+- Dagua bridge conditional-edge integration (`torchlens/visualization/dagua_bridge.py`).
+- ELK conditional edge rendering (`torchlens/visualization/elk_layout.py` — legacy).
+
+Data structures populate unconditionally in v1; only renderer-side integration for dagua and ELK is deferred.
+
+## Decisions (architect-level)
+
+| # | Decision |
+|---|----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` (Python AST has no `Elif` node). |
+| **D3 (REVISED)** | Pre-classify every terminal scalar bool by enclosing AST context. `bool(x)` nested inside `If.test`/elif test / `IfExp.test` normalizes to `if_test`/`elif_test`/`ifexp` + `bool_wrapper_kind="bool_cast"`. Standalone `bool(x)` (not in any branch test) → `bool_cast`. **Branch-participating kinds (`bool_is_branch=True`):** `if_test`, `elif_test`, `ifexp`. All three produce arm-entry edges. |
+| D4 | Attribution uses full `func_call_stack` (every frame), not just the user-facing frame. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregates via unique signatures + pass map. |
+| D6 | Keep every existing field; old fields populated from new primary structures as derived views. |
+| D7 | AST logic lives in new module `torchlens/postprocess/ast_branches.py`. |
+| D8 | File cache keyed by `(filename, stat.st_mtime_ns)`. Process-local. |
+| D9 | AST classification runs whenever `(file, line)` is on `func_call_stack` (which is always, after D18 ungates capture). `save_source_context` only gates rich source-text capture. |
+| **D10 (REVISED)** | Two-stage identifier scheme: `ConditionalKey = (file, func_firstlineno, if_stmt_lineno, if_col_offset)` is the AST-internal structural key used in Phases 5a/5b/5e. Phase 5c is the **sole** step that materializes `ModelLog.conditional_events` and assigns dense per-`ModelLog` `conditional_id: int`. Phase 5c rewrites all `bool_conditional_key` → `bool_conditional_id` and all stack entries `(ConditionalKey, kind)` → `(cond_id, kind)` in one pass. No other code outside `ast_branches.py` sees `ConditionalKey`. |
+| D11 | Graphviz gets ELIF/ELSE labels with explicit precedence (see Visualization). Dagua bridge extended. ELK gets a comment. |
+| D12 | Old post-validation ("clear IF markings if no `ast.If`") is REMOVED; pre-classification makes it unnecessary. |
+| D13 | Branch-entry edges detected by diffing `conditional_branch_stack` across EVERY forward edge, not only edges from branch-start nodes. Legitimate: a single edge can gain MULTIPLE stack entries simultaneously (e.g., `self.bias → x` inside nested `if A: if B:` enters both outer and inner THEN). All gained entries are recorded. |
+| **D14 (REVISED v2)** | `FuncCallLocation` augmented with `code_firstlineno: int` (always) + `code_qualname: Optional[str]` (Python 3.11+; None on 3.9/3.10). Scope resolution in `attribute_op`: (1) exact match on `(filename, code_firstlineno, code_qualname)` if qualname non-None; (2) exact match on `(filename, code_firstlineno, func_name)` IFF exactly one scope matches; (3) if step 2 has zero or multiple candidates, **FAIL CLOSED** — return empty branch stack for that frame (no "smallest containing scope" heuristic). This prevents silent wrong attribution on same-line nested defs/lambdas, especially under 3.9/3.10 where `code_qualname` is absent. |
+| D15 | `ModelLog.conditional_edge_passes` maps `(parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted List[int]` of pass numbers. Rolled-mode renderers consult this for mixed-arm labels. |
+| **D16 (NEW)** | **Cond-id-aware primary structures.** Primary arm-edge representation is `ModelLog.conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]` (`(cond_id, branch_kind) → [(parent, child)]`). Primary per-node child list is `LayerPassLog.cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]` (`cond_id → branch_kind → [child_labels]`). Existing `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` become DERIVED VIEWS computed from the primary structures. This lets a single edge correctly record entry into multiple arms simultaneously (D13). |
+| **D18 (NEW)** | **`col_offset` capture + ternary first-class attribution.** `FuncCallLocation` gains `col_offset: Optional[int]` (captured via `frame.f_code.co_positions()` + `frame.f_lasti` on Python 3.11+; `None` on 3.9/3.10). AST indexing treats `ast.IfExp` as a first-class conditional: classifies its test as `bool_context_kind="ifexp"` with `bool_is_branch=True`, materializes a `ConditionalEvent` with `kind="ifexp"` and arms `{then, else}`. Branch ranges stored as `(start_line, start_col, end_line, end_col)` for BOTH `if_chain` and `ifexp` events; `attribute_op` queries the branch interval tree with the `(line, col)` pair instead of `line` alone. For if-statement arms on different lines, col is redundant but consistent; for ternary arms that share a source line, col is load-bearing. On Python 3.9/3.10 (no `co_positions`), `col_offset=None`; `attribute_op` falls back to line-only matching and **fails closed** when multiple candidate arms match by line alone (e.g., ternary on older Python). |
+| **D17 (REVISED v3)** | **Explicit capture-path ungating + disabled-source state identical to the existing "no source available" contract on `FuncCallLocation`.** Phase 1 unconditionally populates identity fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`, `source_loading_enabled`) on every captured op at `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `source_loading_enabled` mirrors `save_source_context` at capture time. **When `source_loading_enabled=False`:** construction sets `_source_loaded=True` immediately and initializes the same observable state that `_load_source()` produces when source can't be loaded (see `func_call_location.py:149-153,165-169`): `code_context=None`, `source_context="None"` (literal 4-char string — current API), `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`, `_frame_func_obj=None`. Accessors and dunder methods inherit current no-source behavior verbatim — `len==0`, `__getitem__` raises `IndexError`, `__repr__` ends with "code: source unavailable" — with zero disk access. Clearing `_frame_func_obj` at construction eliminates pickle fragility with nested/local function objects (previously only released inside `_load_source()`). This reuses the already-existing no-source contract for complete API/test backward compatibility. D17 is distinct from D9 (AST classification needs identity fields only). |
+
+## Data Model
+
+### `FuncCallLocation` (augmented — D14, D17)
+
+```python
+@dataclass
+class FuncCallLocation:
+    file: str
+    line_number: int
+    func_name: str
+    code_firstlineno: int                 # NEW — frame.f_code.co_firstlineno, always populated
+    code_qualname: Optional[str]          # NEW — frame.f_code.co_qualname (3.11+); None pre-3.11
+    col_offset: Optional[int]             # NEW (D18) — current instruction col_offset
+                                          # (Python 3.11+); None pre-3.11
+    source_loading_enabled: bool          # NEW — mirrors save_source_context at capture time
+    # When source_loading_enabled=False, construction sets _source_loaded=True
+    # immediately with the no-source state already produced by _load_source() when
+    # source can't be loaded (see func_call_location.py:149-153, 165-169):
+    #   code_context=None
+    #   source_context="None"       # literal 4-char string (current API)
+    #   code_context_labeled=""
+    #   call_line=""
+    #   num_context_lines=0
+    #   func_signature=None
+    #   func_docstring=None
+    #   _frame_func_obj=None        # cleared at construction -> safe for pickle
+    # Existing accessor semantics carry over: len(loc)==0,
+    # loc[i] raises IndexError, repr(loc) ends with "code: source unavailable".
+    # No disk access ever; _load_source is effectively never entered.
+```
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                                 # iff bool_context_kind ∈ {"if_test","elif_test"}
+bool_context_kind: Optional[str]                     # 9 kinds + "unknown"
+bool_wrapper_kind: Optional[str]                     # e.g. "bool_cast" when wrapped; else None
+bool_conditional_id: Optional[int]                   # dense; None for non-branch kinds
+
+# Branch attribution (any op)
+conditional_branch_stack: List[Tuple[int, str]]      # [(cond_id, branch_kind), ...] outer→inner
+conditional_branch_depth: int                         # = len(stack)
+
+# PRIMARY per-node arm-child structure (D16)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+    # cond_id → branch_kind → [child labels]
+```
+
+**Preserved (now DERIVED from `cond_branch_children_by_cond`):**
+- `cond_branch_start_children: List[str]` — still the set-of-parents marked by 5d IF-backward flood (UNCHANGED semantics).
+- `cond_branch_then_children: List[str]` — `sorted(set(chain_from_iterable(m["then"] for m in cond_branch_children_by_cond.values() if "then" in m)))`.
+- `cond_branch_elif_children: Dict[int, List[str]]` — aggregate by elif-index across cond_ids.
+- `cond_branch_else_children: List[str]` — analogous.
+
+Also preserved: `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch` (derived `len(conditional_branch_stack) > 0`).
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# Aggregate
+conditional_branch_stacks: List[List[Tuple[int, str]]]     # unique signatures, first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                           # signature → sorted pass numbers
+
+# Per-node cond-id-aware aggregate children (primary — pass-stripped labels)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+```
+
+**Derived views (pass-stripped unions):** `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`.
+
+**Merge rules** (update `_build_layer_logs`):
+- `in_cond_branch`: OR across passes.
+- `conditional_branch_stacks`: unique signatures in first-seen order.
+- `conditional_branch_stack_passes`: accumulate sorted pass numbers per signature.
+- `cond_branch_children_by_cond`: union across passes after stripping `:N` suffix; keep cond_id granularity.
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]            # dense cond_id indexing (D10)
+
+# PRIMARY edge structure (D16)
+conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]
+    # (cond_id, branch_kind) → [(parent, child), ...]
+
+# Rolled-mode pass-divergence (D15)
+conditional_edge_passes: Dict[
+    Tuple[str, str, int, str], List[int]
+]                                                     # (parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted pass numbers
+```
+
+**Preserved (DERIVED from `conditional_arm_edges`):**
+- `conditional_branch_edges: List[Tuple[str, str]]` — IF-edges from 5d (unchanged).
+- `conditional_then_edges: List[Tuple[str, str]]` — `[(p,c) for (cid, bk), edges in conditional_arm_edges.items() if bk=="then" for (p,c) in edges]`.
+- `conditional_elif_edges: List[Tuple[int, int, str, str]]` — `[(cid, int(bk.split("_")[1]), p, c) for (cid, bk), edges if bk.startswith("elif_") for (p,c) in edges]`.
+- `conditional_else_edges: List[Tuple[int, str, str]]` — `[(cid, p, c) for (cid, bk), edges if bk=="else" for (p,c) in edges]`.
+
+`ConditionalEvent`:
+```python
+@dataclass
+class ConditionalEvent:
+    id: int                                                           # dense per-ModelLog
+    kind: Literal["if_chain", "ifexp"]                                # D18 — discriminator
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]                                     # for ifexp: the IfExp node span
+    test_span: Tuple[int, int, int, int]                              # (start_line, start_col, end_line, end_col)
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int, int, int]]               # arm -> (start_line, start_col, end_line, end_col)
+                                                                      # if_chain arms: "then", "elif_1", ..., "else"
+                                                                      # ifexp arms:    "then", "else" (no elif)
+    branch_test_spans: Dict[str, Tuple[int, int, int, int]]           # if_chain: "then", "elif_1", ...
+                                                                      # ifexp:    "then" (the ternary test itself)
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]                                            # labels of bools driving this event
+```
+
+### `constants.py` FIELD_ORDER updates (one commit)
+
+- `LAYER_PASS_LOG_FIELD_ORDER`: add 7 new entries (`bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, `conditional_branch_stack`, `conditional_branch_depth`, `cond_branch_children_by_cond`). Derived fields (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`) stay in FIELD_ORDER — they're materialized for serialization.
+- `MODEL_LOG_FIELD_ORDER`: add 3 new primary entries (`conditional_events`, `conditional_arm_edges`, `conditional_edge_passes`). Derived fields (`conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`) stay.
+- `LAYER_LOG_FIELD_ORDER`: add 4 aggregate entries (`conditional_branch_stacks`, `conditional_branch_stack_passes`, `cond_branch_children_by_cond`, plus the aggregate derived children).
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+    # Returns: (kind, wrapper_kind, conditional_key_or_None, branch_test_kind_or_None)
+def attribute_op(func_call_stack: List[FuncCallLocation]
+                 ) -> List[Tuple[ConditionalKey, str]]: ...
+    # Returns ConditionalKeys, not dense ints. Dense IDs are assigned in Phase 5c.
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+
+ConditionalKey = Tuple[str, int, int, int]   # (file, func_firstlineno, if_stmt_lineno, if_col_offset)
+```
+
+### Postprocess Step 5 restructure (six-phase — revised per D10)
+
+**5a. Build file indexes.**
+For every terminal scalar bool layer, collect filenames from `func_call_stack`. Eagerly build `FileIndex` per file (cache).
+
+**5b. Classify bools (structural keys).**
+For each `is_terminal_bool_layer` scalar bool, **iterating in `ModelLog.layer_list` order for determinism**:
+- Walk frames; call `classify_bool(frame.file, frame.line_number)`; take the most-informative result (innermost non-`unknown` kind).
+- Record on the bool's `LayerPassLog` temporarily:
+  - `bool_context_kind`, `bool_wrapper_kind`, `bool_is_branch`, and a TEMPORARY attribute `_bool_conditional_key` (not in FIELD_ORDER — transient).
+- Collect unique `ConditionalKey`s in **first-seen order** (insertion-ordered dict, not a set).
+
+**5c. Materialize events; assign dense IDs; translate keys → ints. (Sole id-assignment step.)**
+- Build `ModelLog.conditional_events` list: for each unique `ConditionalKey` in the **first-seen order from 5b**, create a `ConditionalEvent` with a dense `id` (0, 1, 2, ...). This guarantees stable `cond_id` assignment across runs on the same model/input.
+- Walk every bool layer with `_bool_conditional_key`: set `bool_conditional_id = events_by_key[_bool_conditional_key].id`; register label in `ConditionalEvent.bool_layers`; delete `_bool_conditional_key`.
+- Also translate `parent_conditional_id` fields inside `ConditionalEvent`s that reference other keys.
+- From this point forward, no `ConditionalKey` escapes `ast_branches.py` — only dense `int` IDs are exposed.
+
+**5d. IF backward flood** (PR #127 behavior, now pre-filtered).
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestor parents with `cond_branch_start_children`; emit `conditional_branch_edges`. Unchanged by D13.
+
+**5e. Forward branch attribution + arm edges.**
+For every op:
+- `stack_keys = attribute_op(func_call_stack)` → list of `(ConditionalKey, kind)`.
+- Translate keys to dense IDs: for each `(key, kind)`, if `key ∈ events_by_key` emit `(events_by_key[key].id, kind)`; otherwise **DROP** the entry. A `ConditionalKey` may be returned by `attribute_op` that was never materialized in 5c — this happens when an op is lexically inside an `if` whose predicate was not driven by a captured tensor bool (the documented false-negative scope: `if self.training:`, `if x.shape[0] > 0:`, `if tensor.item() > 0:`). Dropping unmaterialized keys keeps the attribution consistent with the event set.
+- Assemble `conditional_branch_stack: List[Tuple[int, str]]` from the surviving entries.
+- Set `conditional_branch_depth`, update `in_cond_branch`.
+
+For every forward edge `(parent, child)` (ALL edges — D13):
+- Compute set difference `gained = child.stack - parent.stack` (prefix-order, so elements not in parent's stack in order).
+- Each gained `(cond_id, branch_kind)` triggers:
+  - `ModelLog.conditional_arm_edges[(cond_id, branch_kind)].append((parent.label, child.label))`.
+  - `parent.cond_branch_children_by_cond[cond_id][branch_kind].append(child.label)`.
+- If `parent.stack` has entries not in `child.stack` (branch exit / reconvergence): no edge is recorded; valid per Invariant 6.
+
+**5f. Derived-view materialization + `conditional_edge_passes`.**
+- Compute derived fields (`conditional_then_edges`, `cond_branch_then_children`, etc.) from primary cond-id-aware structures.
+- For rolled-mode awareness, record each arm-edge's pass-stripped form: `conditional_edge_passes[(parent_no_pass, child_no_pass, cond_id, branch_kind)].append(pass_num)`; sort lists at the end.
+
+### Classification algorithm (`classify_bool`)
+
+```python
+def classify_bool(filename: str, line: int) -> BoolClassification:
+    idx = get_file_index(filename)
+    if idx is None:
+        return BoolClassification(kind="unknown", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Walk bool consumers whose span contains `line`, innermost outward.
+    # Each consumer has kind ∈ {if_test, elif_test, assert, bool_cast,
+    #                            comprehension_filter, while, ifexp, match_guard}.
+    consumers = [c for c in idx.bool_consumers if c.span.contains(line)]
+    consumers.sort(key=lambda c: c.depth, reverse=True)   # innermost first
+
+    wrapper = None
+    for consumer in consumers:
+        if consumer.kind == "bool_cast" and wrapper is None:
+            wrapper = "bool_cast"
+            continue   # keep walking outward; bool_cast doesn't decide alone
+        if consumer.kind in {"if_test", "elif_test", "ifexp"}:
+            # D3 revised + D18: all three are branch-participating.
+            return BoolClassification(
+                kind=consumer.kind,
+                wrapper_kind=wrapper,
+                conditional_key=consumer.conditional_key,
+                branch_test_kind=consumer.branch_test_kind,
+            )
+        # any other consumer wins outright (assert/while/ifexp/comp/match)
+        return BoolClassification(kind=consumer.kind, wrapper_kind=wrapper,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Reached here: maybe a standalone bool_cast with no outer branch
+    if wrapper == "bool_cast":
+        return BoolClassification(kind="bool_cast", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+    return BoolClassification(kind="unknown", wrapper_kind=None,
+                               conditional_key=None, branch_test_kind=None)
+```
+
+### Attribution algorithm (`attribute_op`)
+
+Per frame (shallow → deep):
+1. Scope resolution per D14:
+   - `(filename, code_firstlineno, code_qualname)` exact match if `code_qualname` is non-None; otherwise
+   - `(filename, code_firstlineno, func_name)` match IFF exactly one scope in the file index matches; otherwise
+   - **FAIL CLOSED**: skip this frame's contribution entirely (no branch-interval query, no heuristic, no smallest-scope guess). Emit a debug counter for diagnostics.
+2. If scope was resolved: query the scope's branch interval tree with `(frame.line_number, frame.col_offset)` (D18). Branch ranges are `(start_line, start_col, end_line, end_col)` tuples; a query point `(L, C)` matches a range iff `(start_line, start_col) ≤ (L, C) ≤ (end_line, end_col)` under lexicographic comparison. Return list of `(ConditionalKey, branch_kind, nesting_depth)` sorted by nesting depth asc.
+3. **Col-offset degraded mode:** when `frame.col_offset is None` (Python 3.9/3.10) AND the line-only query returns MULTIPLE candidate arms within a SINGLE `ConditionalEvent` (typical only for ternary), **fail closed** for that conditional and drop all of its candidate entries from this frame's result. Line-only queries that return unambiguous single-arm matches (typical for if-statement bodies on distinct lines) proceed normally.
+4. Append results to the aggregate stack (deduplicate adjacent).
+
+## Visualization
+
+### Label precedence (Graphviz — dagua bridge deferred)
+
+1. **Arm-entry label** (highest) — edge appears in `conditional_arm_edges[(cond_id, "then")]` / `elif_N` / `else`:
+   - Single-arm: `THEN` / `ELIF N` / `ELSE`.
+   - Multi-arm on same edge (D13 case): composite like `THEN(cond_outer) · THEN(cond_inner)` — concise form to be agreed; default: `N arms`.
+   - Rolled mode with pass divergence (D15): `THEN(1,3) / ELSE(2)` or `mixed`.
+2. **IF label** — edge is in `conditional_branch_edges`.
+3. **Arg labels** — move from `edge_dict["label"]` to `edge_dict["headlabel"]` / `xlabel` so they don't compete.
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+- Refactor existing `edge_dict["label"]` writes (lines ~985-996 and ~1049-1090) into a single `_compute_edge_label(parent, child, model_log)` function implementing the precedence rules.
+- Move argument-name labels off `label` → `headlabel` / `xlabel`.
+
+### Dagua bridge (deferred)
+
+Per user direction, dagua bridge work (`torchlens/visualization/dagua_bridge.py`) is deferred to a future sprint. The existing bridge continues to use its current `_classify_forward_edge` (returns `"then"` for pre-PR #127 style THEN edges); new conditional structures will not be wired through dagua in v1. Documented in `.project-context/todos.md`.
+
+### ELK (deferred)
+
+Per user direction, ELK rendering (`torchlens/visualization/elk_layout.py`) is deferred. No changes in v1 (not even the documentation comment). Documented in `.project-context/todos.md`.
+
+## Capture / Postprocess Lifecycle (full integration — addresses F4, F9 partials)
+
+Every new label-bearing field must be wired end-to-end. Phase 3 delivers all of this BEFORE Phase 4 (Step 5) can populate data.
+
+### Capture-time defaults (Phase 1)
+
+Files: `torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`, `torchlens/postprocess/graph_traversal.py`.
+- Init every new `LayerPassLog` field with default (empty list, `{}`, `False`, `None`).
+- Remove gating of `func_call_stack` population on `save_source_context` (D17). Populate core fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`) unconditionally. Lazy source-text properties remain gated.
+
+### Raw→final rename (Phase 3, `torchlens/postprocess/labeling.py`)
+
+Extend `_rename_raw_labels_in_place` to rewrite labels in:
+- `conditional_arm_edges` (each `(parent, child)` tuple).
+- `conditional_edge_passes` (keys — positions 0, 1).
+- `conditional_events[*].bool_layers`.
+- `cond_branch_children_by_cond` per `LayerPassLog` (every nested list member).
+- Existing fields (`conditional_branch_edges`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`).
+
+### Cleanup / `keep_unsaved_layers=False` (Phase 3, `torchlens/data_classes/cleanup.py`)
+
+Extend filter logic to scrub every new surface when a label is removed:
+- `conditional_arm_edges`: drop tuples where parent OR child is removed; drop empty keys.
+- `conditional_edge_passes`: drop tuple keys where parent or child is removed.
+- `conditional_events[*].bool_layers`: remove labels.
+- `cond_branch_children_by_cond`: drop removed children; drop empty branch_kind keys; drop empty cond_id keys.
+- `LayerLog.conditional_branch_stack_passes`: unchanged (signatures are cond_id tuples; labels aren't in keys).
+- Also scrub derived views (`cond_branch_then_children`, etc.); they'll be recomputed anyway, but the pruning must be consistent.
+
+### Export (`torchlens/data_classes/interface.py::to_pandas`)
+
+Add columns for: `conditional_branch_depth`, `bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, plus a compact string form of `conditional_branch_stack`.
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+1. **`cond_branch_children_by_cond` ↔ `conditional_arm_edges` bidirectional consistency.**
+   For each `(cond_id, branch_kind) → edges` in `conditional_arm_edges`, every `(parent, child)`: `child ∈ parent.cond_branch_children_by_cond[cond_id][branch_kind]` and vice versa.
+2. **Derived views consistency.**
+   `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` per-node and `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges` on `ModelLog` equal the projections of primary structures.
+3. **Children labels exist in `ModelLog`.**
+4. **Bool classification invariants.**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+   `bool_wrapper_kind is not None` ⟹ `bool_context_kind ∈ {"if_test", "elif_test", "bool_cast"}`.
+5. **Conditional event references are valid.**
+   Every `cond_id` in any stack entry, `bool_conditional_id`, `conditional_arm_edges` key, or `cond_branch_children_by_cond` key has matching `ConditionalEvent.id`.
+6. **Stack monotonicity on every parent→child edge (REVISED).**
+   Exactly one of: child.stack extends parent.stack (entry); parent.stack extends child.stack (exit/reconvergence); stacks equal. Non-prefix reorderings are invalid.
+7. **Elif contiguity on `ConditionalEvent` (per-event, not per-node).**
+   `branch_ranges` and `branch_test_spans` keys for elif arms are contiguous from `elif_1`. Per-node `cond_branch_children_by_cond[cid]` may be sparse — that's legal.
+8. **`bool_layers` back-references (NEW).**
+   For every `ConditionalEvent.bool_layers`: each label exists, and each referenced layer's `bool_conditional_id` equals the event's `id`.
+9. **`LayerLog` aggregate consistency (NEW).**
+   `LayerLog.conditional_branch_stacks` equals exactly the set of distinct `LayerPassLog.conditional_branch_stack` values from that layer's passes.
+   `LayerLog.conditional_branch_stack_passes[sig]` equals the sorted list of pass numbers for which that signature appeared.
+10. **`conditional_edge_passes` exactness (NEW).**
+    For every `(parent_no_pass, child_no_pass, cond_id, branch_kind) → [pass_nums]`:
+    - `pass_nums` is sorted ascending and has no duplicates.
+    - For each `pass_num` there exists an unrolled edge `(parent:pass_num, child:pass_num)` in `conditional_arm_edges[(cond_id, branch_kind)]`.
+    - Every unrolled edge in `conditional_arm_edges` is represented somewhere in `conditional_edge_passes`.
+11. **No orphan `_bool_conditional_key` (NEW, dev-mode).**
+    After 5c, no `LayerPassLog` has a `_bool_conditional_key` attribute. Enforced in dev mode to catch incomplete 5c migrations.
+12. **`LayerLog.cond_branch_children_by_cond` aggregate exactness (NEW).**
+    For every `LayerLog`, `cond_branch_children_by_cond` equals the pass-stripped union of `cond_branch_children_by_cond` across its constituent `LayerPassLog` passes. No cond_id or branch_kind present in any pass is missing from the aggregate; no extraneous entries appear.
+13. **Legacy IF-view consistency (NEW).**
+    `conditional_branch_edges` ↔ `cond_branch_start_children` bidirectionally consistent: every `(parent, bool_label)` tuple in `conditional_branch_edges` has `bool_label ∈ parent.cond_branch_start_children`; and every label in any node's `cond_branch_start_children` corresponds to a tuple with that node as parent in `conditional_branch_edges`.
+
+## Tests
+
+### New file `tests/test_conditional_branches.py` + models in `tests/example_models.py` (or dedicated new file if size warrants)
+
+**Baseline / positive:**
+- `SimpleIfElseModel` / `ElifLadderModel` / `NestedIfThenIfModel` / `NestedInElseModel` / `MultilinePredicateModel` — verify THEN/ELIF/ELSE edges, `conditional_events` entries, branch_ranges correctness.
+
+**Branch-entry via non-predicate ancestors (D13):**
+- `BranchUsesOnlyParameterModel` — `if c: y = self.bias + 1`. Assert `self.bias → y` appears in `conditional_arm_edges[(cid, "then")]`.
+- `BranchUsesOnlyConstantModel` — analogous with a constant.
+- **`MultiArmEntryNestedModel` (NEW — Finding 2):** `if A: if B: y = self.bias + 1`. Assert the single `self.bias → y` edge appears in BOTH `conditional_arm_edges[(outer_id, "then")]` AND `conditional_arm_edges[(inner_id, "then")]`, and `self.bias.cond_branch_children_by_cond` has both `outer_id` and `inner_id` mapping to `[y]`. Verify derived `cond_branch_then_children` also lists `y` (uniquely, not twice).
+
+**Wrapped bool (F2 resolution):**
+- `IfBoolCastModel` — `if bool(x.sum() > 0):`. Assert `bool_is_branch=True`, `bool_context_kind="if_test"`, `bool_wrapper_kind="bool_cast"`.
+
+**Multi-pass / rolled (D15):**
+- `LoopedIfAlternatingModel` — `for i: if i%2`. Per-pass stacks differ; aggregate has 2 signatures.
+- `AlternatingRecurrentIfModel` — recurrent, THEN pass 1 / ELSE pass 2.
+- **`RolledMixedArmModel` (strengthened — F7 resolution):** Assert `ModelLog.conditional_edge_passes` has entries with non-trivial pass lists AND each `(parent_no_pass, child_no_pass, cond_id, branch_kind) → pass_nums` is exactly verifiable — sorted ascending, no duplicates, every `pass_num` corresponds to a real unrolled edge in `conditional_arm_edges[(cond_id, branch_kind)]` on that pass. Assert rolled renderer output (graphviz+dagua) contains a composite label. **D13×D15 interaction:** add a companion scenario where the mixed-pass arm edge is ALSO a multi-arm-entry edge (nested conditional taking different inner arms across passes); assert both dimensions survive end-to-end. **Post-cleanup check:** after `keep_unsaved_layers=False`, assert no pruned labels appear in `conditional_edge_passes` keys.
+
+**Reconvergence (F5):**
+- `ReconvergingBranchesModel` — `if c: x=a else: x=b; y=f(x)`. Invariant 6 passes. Assert `y.conditional_branch_stack == []` and both parents' stacks were non-empty.
+
+**Scope resolution (D14):**
+- `NestedHelperSameNameModel` — two local `helper()` functions, same name, different branches. Assert attribution uses `code_firstlineno`; verify `bool_conditional_id` differs between the two helpers' if-statements.
+- **`NestedQualnameModel` (NEW — replaces LambdaBranchModel):** `class Outer: def forward(self): def helper(self): if cond: op() return helper(self)` — nested function named `helper` with a distinct `code_qualname` from a method also named `helper` elsewhere. Assert attribution distinguishes them via `code_qualname` (Python 3.11+).
+- **`SameLineNestedDefModel` (NEW — D14 fail-closed):** Two local defs with the same `func_name` and same `code_firstlineno` (degenerate case, forceable via `exec` or metaprogramming). Assert D14 step 3 triggers: returns empty branch stack for that frame rather than silently picking one; no `conditional_branch_edges` or arm edges are emitted from that site. Also run this under Python 3.9/3.10 CI (where `code_qualname` is None) to verify fail-closed behavior across supported versions.
+- `DecoratedForwardModel` — decorator on forward. Graceful degradation OR correct attribution.
+
+**False positives — non-branch bools:**
+- `AssertTensorCondModel`, `BoolCastOnlyModel`, `TernaryIfExpModel`, `ComprehensionIfModel`, `WhileLoopModel`, `MatchGuardModel`.
+
+**Compound / negation / walrus:**
+- `NotIfModel`, `AndOrIfModel`, `WalrusIfModel`.
+
+**Ternary (D18 — fully attributed):**
+- `BasicTernaryModel` — `y = a(x) if cond else b(x)`. Assert `ConditionalEvent.kind=="ifexp"`; arms `{then, else}`; ops for `a(x)` attributed to `then`, ops for `b(x)` attributed to `else`.
+- `NestedTernaryModel` — `y = (a if c1 else b) if c2 else d`. Assert 2 `ConditionalEvent`s with `kind=="ifexp"`; correct nesting via `parent_conditional_id` / `parent_branch_kind`.
+- `TernaryInsideIfModel` — `if cond: y = a if c2 else b`. Assert mixed stack: outer `if_chain` THEN + inner `ifexp` then/else.
+- `TernaryWithBoolCastModel` — `y = a if bool(t) else b`. Assert `bool_context_kind="ifexp"`, `bool_wrapper_kind="bool_cast"`, ifexp still attributed.
+- `TernaryPy310FailClosedModel` — (gated on Python version) same-line ternary with no `col_offset` available; assert D18 degraded-mode fail-closed: both arms unattributed, no confident wrong label.
+- `TernaryMultiOpOneLineModel` — `y = (a * b + c) if cond else (d / e - f)`. Assert each op attributed to the correct arm via col_offset.
+
+**Documented false negatives (no attribution):**
+- `PythonBoolModel`, `ItemScalarizationModel`, `TorchWhereModel`, `ShapePredicateModel`.
+
+**save_source_context gating (F1 resolution — STRENGTHENED):**
+- **`SaveSourceContextOffModel` (strengthened):** `save_source_context=False`. Assert `func_call_stack` is NON-EMPTY on every captured op; each `FuncCallLocation` has non-None `file`, `line_number`, `code_firstlineno`, and `source_loading_enabled=False`. Assert every accessor returns the existing no-source state: `loc.code_context is None`, `loc.source_context == "None"` (literal 4-char string per current API at `func_call_location.py:150`), `loc.code_context_labeled == ""`, `loc.call_line == ""`, `loc.num_context_lines == 0`, `loc.func_signature is None`, `loc.func_docstring is None`. Assert `len(loc) == 0`, `loc[0]` raises `IndexError`, and `repr(loc)` ends with `"code: source unavailable"`. Assert `loc._frame_func_obj is None` (cleared at construction per D17). Assert no disk access occurred (e.g., by patching `linecache.getlines` with a sentinel; or by monitoring `_source_loaded=True` straight after construction). Branch attribution populated correctly. **Pickle round-trip:** pickle/unpickle a `ModelLog` captured with `save_source_context=False`; unpickled log round-trips cleanly (exercises the `_frame_func_obj` retention fix).
+- **`SaveSourceContextOffAssertModel`:** `save_source_context=False` + `assert tensor_cond`. No false-positive IF edge.
+
+**Field-lifecycle integration (F4 resolution — STRENGTHENED):**
+- **`KeepUnsavedLayersFalseModel` (strengthened):** `keep_unsaved_layers=False` with conditionals. Assert NO removed label appears anywhere in:
+  - `conditional_arm_edges` (tuples).
+  - `conditional_edge_passes` (tuple keys).
+  - `conditional_events[*].bool_layers`.
+  - `cond_branch_children_by_cond` (any nested list) — check on BOTH `LayerPassLog` AND `LayerLog` aggregates.
+  - `conditional_branch_stack_passes` values on `LayerLog`.
+  - All derived views (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`).
+- `ToPandasConditionalModel` — DataFrame has all conditional columns populated.
+
+**Visualization label precedence (NEW — F8 confirmation):**
+- **`BranchEntryWithArgLabelModel` (NEW):** branch-entry edge that ALSO has an argument label. Assert graphviz renderer output shows branch label in `edge_dict["label"]` and arg label in `edge_dict["headlabel"]` (or `xlabel`) — they do not collide. (Dagua bridge behavior for this case is out of scope; deferred sprint.)
+
+**Smoke:** `@pytest.mark.smoke` on `SimpleIfElseModel`, `ElifLadderModel`.
+
+## Backward Compatibility
+
+- Every existing field retained with identical external semantics.
+- Old fields materialized as derived views from primary cond-id-aware structures. Serialization includes both primary and derived (FIELD_ORDER includes both).
+- `in_cond_branch` remains a direct field; recomputed from `conditional_branch_stack`.
+- `FIELD_ORDER` updates in single commit.
+- Pickle compat: `__setstate__` default-fill for 1 prior minor version. If primary structures are missing on load, reconstruct from legacy derived fields where possible (best-effort for N-1 compat; newer loaders prefer primary).
+
+## Implementation Phases
+
+Each phase gate: tier-1 smoke passes. Tier-2 at phases 4, 6, 9. Tier-3 before PR.
+
+1. **Foundation: fields + capture ungating.**
+   - Add all new fields to `LayerPassLog`, `LayerLog`, `ModelLog`, `FuncCallLocation` + `FIELD_ORDER` updates + defaults.
+   - Ungate `func_call_stack` population in `output_tensors.py`, `source_tensors.py`, `graph_traversal.py` (D17).
+   - Populate `code_firstlineno`, `code_qualname` in stack capture (`utils/introspection.py`).
+   - Gate: existing test suite passes unchanged. New **conditional-branch** fields remain default (empty list/dict, `False`, `None`). New `FuncCallLocation` core identity fields (`code_firstlineno`, `code_qualname`, `source_loading_enabled`) ARE populated per D17; verify via test that `func_call_stack` is non-empty even when `save_source_context=False`, and that lazy source-text properties still return empty/None in that case.
+2. **AST module.**
+   - Write `ast_branches.py` (FileIndex, ConditionalRecord, BoolConsumer index, branch interval trees, classify_bool, attribute_op, cache management).
+   - Unit tests on synthetic source snippets covering all 9 bool-context kinds, flattened elif chains, nested ifs, ternary, match guards, etc.
+   - Gate: `ast_branches` tests pass in isolation.
+3. **Lifecycle wiring (upstream of Step 5 integration).**
+   - Extend `labeling.py::_rename_raw_labels_in_place` for every new field.
+   - Extend `cleanup.py` for every new field.
+   - Extend `interface.py::to_pandas` with new columns.
+   - Integration test: synthetic model with new fields pre-populated manually; `keep_unsaved_layers=False` + `to_pandas()` round-trip.
+   - Gate: lifecycle tests pass.
+4. **Postprocess Step 5 integration (6 phases 5a-5f).**
+   - Restructure `control_flow.py`. 5c is the sole key→id translation.
+   - Wire to `ast_branches.py`.
+   - Remove old post-validation (D12).
+   - Gate: new integration test with `SimpleIfElseModel` passes end-to-end.
+5. **Multi-pass merge + `conditional_edge_passes`.**
+   - Update `_build_layer_logs` for aggregate fields.
+   - Populate `ModelLog.conditional_edge_passes`.
+   - Gate: `AlternatingRecurrentIfModel`, `RolledMixedArmModel` pass.
+6. **Invariants.**
+   - Add 11 checks to `validation/invariants.py`.
+   - Wire into `validate_forward_pass`.
+   - Gate: all tests still pass; invariants catch deliberately-corrupted metadata in unit tests.
+7. **Graphviz rendering.**
+   - Refactor to `_compute_edge_label` precedence function.
+   - Move arg labels to `headlabel`/`xlabel`.
+   - Implement multi-arm and rolled-mixed labels, plus ternary THEN/ELSE.
+   - Gate: visual-diff regression check on existing aesthetic tests.
+8. **(Deferred: Dagua bridge + ELK — per user, not in this sprint.)**
+9. **Integration tests.**
+   - All ~30 conditional tests with assertions.
+   - Gate: all pass; coverage of every listed scenario.
+10. **Documentation.**
+    - Update `AGENTS.md` conditional section.
+    - Update `architecture.md` Step 5 section.
+    - Update `torchlens/user_funcs.py` docstrings: `save_source_context=False` no longer zeros `func_call_stack` — only source-text properties are gated (D17). Any README/API doc references to this behavior get the same update.
+    - User-facing limitations page.
+11. **PR.**
+    - Migration notes with before/after field table.
+    - Compat matrix.
+
+## Deliverables
+
+- 1 new module (~400 lines): `torchlens/postprocess/ast_branches.py`.
+- Modified modules (~10 — dagua_bridge.py and elk_layout.py deferred):
+  - `torchlens/data_classes/{layer_pass_log,layer_log,model_log,func_call_location,cleanup,interface}.py`
+  - `torchlens/constants.py`
+  - `torchlens/postprocess/{control_flow,labeling,graph_traversal}.py`
+  - `torchlens/capture/{source_tensors,output_tensors}.py`
+  - `torchlens/utils/introspection.py`
+  - `torchlens/validation/invariants.py`
+  - `torchlens/visualization/rendering.py` (Graphviz only; dagua + ELK deferred per user)
+- Tests: `tests/test_conditional_branches.py` (~550 lines), ~32 new models.
+- Docs: AGENTS.md, architecture.md, user limitations.
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch | All field additions in one commit. |
+| R2 | Multi-pass regressions on recurrent tests | `AlternatingRecurrentIfModel` / `RolledMixedArmModel` in Phase 5 test gate. |
+| R3 | Source resolution fragile on decorated/wrapped forwards | Use `frame.f_code.co_firstlineno`/`co_qualname` (D14); don't rely on `inspect.getsourcefile(module_class)`. |
+| R4 | `linecache` stale source after edit | Cache by `(filename, mtime)`; invalidate on mismatch; fail-soft to `unknown`. |
+| R5 | Pre-classification misses a syntactic form → silent `unknown` | Unit tests for every kind; dev-mode assertion: line inside `If.test` span but classifier returns `unknown` → log warning. |
+| R6 | Interval tree perf on huge `forward` | Parse once; O(log k + d) query; benchmark `HugeNestedIfModel` in Phase 2. |
+| R7 | Old pickled ModelLogs fail | `__setstate__` default-fill; document window. |
+| R8 | Arg-label relocation to `headlabel` breaks existing aesthetic tests | Visual-diff gate in Phase 7; gate behind a flag if regressions appear. |
+| R9 | D16 primary structure inflates memory on large models | Benchmark; cond-id keys compact; derived views computed on-demand only. |
+| R10 | D17 ungating breaks something depending on empty `func_call_stack` | Phase 1 tests check `func_call_stack` non-empty; audit any code reading it. |
+| R11 | Multi-arm entry edges produce confusing visuals | Dedicated test (`MultiArmEntryNestedModel`) + label precedence rule + user docs. |
+
+## Open Questions for Architect / User
+
+1. ELK: document as unsupported (default). Confirm?
+2. Multi-arm edge label format: `THEN(cond_outer) · THEN(cond_inner)` vs `2 arms` vs a renderer-side decision. Default: readable form with cond name/IDs.
+3. Pickle compat window: 1 prior minor version (default).
+4. v2 scope confirmation: ternary + while + column offsets + ELK parity.
+5. Test model count: ~32. OK?
+6. `code_qualname` fallback on Python 3.9/3.10 (no `co_qualname`): accept identity-fallback to `code_firstlineno` + `func_name`?
+
+---
+
+## CHANGELOG v2 → v3 (addresses `review_round_2.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R2-F1 Conditional ID contract (BLOCKER) | D10 revised + Step 5c is sole key→id translator + `ConditionalKey` explicit type. |
+| R2-F2 Multi-entry edges cond-id-blind (HIGH) | D16 new: `conditional_arm_edges` + `cond_branch_children_by_cond` primary; legacy fields derived. |
+| R2-F3 `code_qualname` not used in matching (MEDIUM) | D14 revised: exact match on `(filename, code_firstlineno, code_qualname)` first; fallbacks explicit. |
+| R2-F4 Cleanup incomplete for D15 (MEDIUM) | Lifecycle/Cleanup section enumerates every new surface; `KeepUnsavedLayersFalseModel` strengthened. |
+| R2 F1 partial (save_source_context capture path) | D17 new: Phase 1 explicitly ungates `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `SaveSourceContextOffModel` strengthened to assert non-empty `func_call_stack`. |
+| R2 F9 partial | Covered by D14 revision and test swap (NestedQualnameModel replacing LambdaBranchModel). |
+| R2 missing invariants (bool_layers back-ref, aggregate stacks, edge_passes exactness) | Invariants 8, 9, 10, 11 added. |
+| R2 phase ordering | Phases reordered: lifecycle wiring is Phase 3, BEFORE Step 5 integration (Phase 4). Phase 1 gate no longer references Phase 5 deliverables. |
+| R2 test gaps | Added `MultiArmEntryNestedModel`, `NestedQualnameModel`, `BranchEntryWithArgLabelModel`; strengthened `SaveSourceContextOffModel`, `KeepUnsavedLayersFalseModel`, `RolledMixedArmModel`. |
+
+## CHANGELOG v3 → v4 (addresses `review_round_3.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R3-F1 5e can attribute via unmaterialized keys (BLOCKER) | Step 5e spec now explicitly DROPS `ConditionalKey`s not in `events_by_key`; rationale and test link to documented false-negative scope. |
+| R3-F2 D17 promises ungated stack but `FuncCallLocation` lazy props eagerly load (HIGH) | D17 revised; `FuncCallLocation` gains `source_loading_enabled: bool`; all lazy props + `__repr__`/`__len__`/`__getitem__` must fail closed when disabled. Phase 1 gate wording updated. |
+| R3-F3 D14 fallback can still silently pick wrong scope on 3.9/3.10 (MEDIUM) | D14 revised v2: step 2 requires unique match; step 3 FAILS CLOSED (no smallest-containing-scope heuristic). New `SameLineNestedDefModel` test exercises the fail-closed path. |
+| R3-F4 Invariants incomplete (MEDIUM) | Added invariants 12 (`LayerLog.cond_branch_children_by_cond` aggregate exactness) and 13 (legacy IF-view consistency). |
+| R3-F5 Phase 1 gate imprecise (MEDIUM) | Gate wording split: conditional-branch fields stay default; `FuncCallLocation` identity fields populated; verify via explicit sub-test. |
+| R3-F6 Nondeterministic `cond_id` assignment (MEDIUM) | 5b/5c spec updated: iterate `ModelLog.layer_list` order, collect keys in first-seen order via insertion-ordered dict (not set). |
+| R3-F7 Docs miss user_funcs.py (LOW) | Phase 10 adds `user_funcs.py` docstring updates + README/API doc corrections. |
+| R3 test gaps (MultiArm/NestedQualname/BranchEntry/SaveSrcOff/KeepUnsaved/RolledMixed) | All six test rows strengthened with concrete assertion lists; `SameLineNestedDefModel` added. |
+
+## CHANGELOG v4 → v5 (addresses `review_round_4.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R4-F1 `source_loading_enabled` incomplete for full `FuncCallLocation` surface (HIGH) | D17 revised v2 + data model expanded to enumerate all 7 lazy accessors (`source_context`, `code_context`, `code_context_labeled`, `call_line`, `num_context_lines`, `func_signature`, `func_docstring`). When disabled, all lazy backing fields are initialized empty at construction (no disk access); `_frame_func_obj` is cleared at construction to prevent pickle fragility with nested/local functions. |
+| R4-F2 `attribute_op` subsection contradicts D14 v2 (MEDIUM) | Algorithm subsection updated: no more "smallest containing scope" heuristic; step 3 fails closed (skips frame) matching D14 v2. |
+| R4-F3 `source_context == []` type contradicts current `str` API (LOW) | `SaveSourceContextOffModel` assertions aligned to `str` types: `source_context == ""` etc. Pickle round-trip also added. |
+| R4 test gap: disabled-source accessor coverage | Strengthened `SaveSourceContextOffModel` now asserts every lazy accessor + `_frame_func_obj is None` + pickle round-trip. |
+
+## CHANGELOG v5 → v6 (addresses `review_round_5.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R5-F1 disabled-source contract contradicted current `code_context` API (MEDIUM) | D17 revised v3 + data-model comment + `SaveSourceContextOffModel` all re-aligned to the current "no source available" contract: `code_context=None`, `source_context="None"` (literal string), `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`, `_frame_func_obj=None`; `len==0`; `__getitem__` raises `IndexError`; `__repr__` ends with "code: source unavailable". No disk access when disabled. |
+
+## CHANGELOG v6 → v7 (user-directed scope changes)
+
+| Change | Rationale |
+|--------|-----------|
+| Ternary (`ast.IfExp`) promoted to fully-attributed (D18, D3 revised) | User: "do v2 now"; ternary is close enough to if/else and benefits from unified attribution model. Column-offset capture enables same-line arm disambiguation. |
+| Column offsets added to `FuncCallLocation` (D18) | Required for ternary arm attribution (both arms share a source line). Python 3.11+ via `co_positions()`; 3.9/3.10 fail-closed for same-line ambiguity. |
+| `ConditionalEvent.kind` discriminator (`"if_chain"` / `"ifexp"`) | Differentiates ternary from if-chains without forking the data model. |
+| `branch_ranges` and `test_span` widened to 4-tuples `(start_line, start_col, end_line, end_col)` | Required for col-aware lookup. Consistent for both `if_chain` and `ifexp`. |
+| While-loop attribution formally deferred (new sprint) | Iteration semantics differ from branch attribution; warrants own plan. Tracked in `.project-context/todos.md`. |
+| Dagua bridge work removed from scope | User directive. `visualization/dagua_bridge.py` untouched in v1. |
+| ELK rendering removed from scope | User directive. `visualization/elk_layout.py` untouched in v1 (not even a comment). |
+| Test matrix gains 6 ternary models | `BasicTernaryModel`, `NestedTernaryModel`, `TernaryInsideIfModel`, `TernaryWithBoolCastModel`, `TernaryPy310FailClosedModel`, `TernaryMultiOpOneLineModel`. |
+| `BranchEntryWithArgLabelModel` simplified to Graphviz-only | Dagua assertion removed. |

--- a/.project-context/plans/if-else-attribution/plan_v1.md
+++ b/.project-context/plans/if-else-attribution/plan_v1.md
@@ -1,0 +1,349 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Status:** draft v1 (pre-adversarial)
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering — distinguish actual branching bool events from incidental bool conversions (`assert`, `bool()`, comprehension filters, `while`, `ifexp`, `match` guards).
+3. Represent branch structure explicitly in torchlens data classes (`LayerPassLog`, `LayerLog`, `ModelLog`).
+4. Render THEN / ELIF / ELSE edge labels in the visualization (Graphviz primary; dagua bridge; ELK documented as unsupported).
+5. Comprehensive test coverage for the positive path AND every documented limitation.
+6. Strict backward compatibility — no existing field is renamed or removed.
+
+## Out-of-Scope for v1 (explicitly documented limitations)
+
+**Non-branch bool consumers — classified but not attributed:**
+- Ternary (`x if cond else y`) → `bool_context_kind="ifexp"`
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast → `bool_context_kind="bool_cast"`
+
+**Source-unavailable situations — graceful degradation (no attribution):**
+- Jupyter / REPL cells (`<ipython-input-...>`)
+- `exec` / `eval`-injected forwards (`<string>`)
+- Byte-compiled only (`.pyc` without `.py`), native `.so` modules
+- `torch.compile` / `torch.jit.script` / `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel` (torchlens is already single-threaded)
+- Monkey-patched `forward` where source resolves to the patch function, not the class body
+
+**Branches torchlens fundamentally cannot see — documented false negatives:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred to v2 (documented, not silently missed):**
+- Column-offset disambiguation for multi-op lines (`x = f(g(h(a)))` with multiple ops in one branch)
+- Ternary (`ast.IfExp`) full attribution — would extend data model; v1 classifies only
+- `while` loop body attribution — different semantics from one-shot branching
+- ELK conditional edge rendering (ELK is legacy; dagua is replacing)
+
+## Decisions (architect-level)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. | Convergent recommendation from all 3 codex agents. Matches TorchScript + coverage.py prior art. Minimal runtime cost. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` | Python AST has no `Elif` node; elif is nested `If` in `orelse`. Flattening prevents line-based confusion between top-level `if` and inner `elif`. |
+| D3 | Pre-classify all terminal scalar bools by AST context BEFORE Step 5 flood. Only `if_test`/`elif_test` participate in branch marking. | Replaces current "mark first, clear later" pattern. Cleaner, fewer false edges, reusable classification. |
+| D4 | Attribution uses **full `func_call_stack`**, not just the user-facing frame. | Catches helper functions: `def helper(): if cond: op()` called from forward. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregate stores a **set of unique signatures** plus a pass-to-signature map. | Same rolled layer can be in THEN on pass 1, ELSE on pass 2. First-pass-wins aggregation is incorrect. |
+| D6 | Keep every existing field (`cond_branch_start_children`, `cond_branch_then_children`, `conditional_branch_edges`, `conditional_then_edges`, `in_cond_branch`). Populate from new fields. | Strict backward compat — downstream code consuming these stays working. `in_cond_branch` becomes a derived property (`len(conditional_branch_stack) > 0`). |
+| D7 | AST indexing/caching lives in a NEW module `torchlens/postprocess/ast_branches.py`. Step 5 (`_mark_conditional_branches`) imports it. | Isolates file-parsing / AST-node logic from graph-flood logic. Testable in isolation. |
+| D8 | Cache key: `(filename, stat.st_mtime_ns)`. Invalidate on mtime change; always reparse on mismatch. Cache lifetime = process-local. | Matches design recommendation. Hot-reload safety. |
+| D9 | AST attribution activation: gated on `save_source_context=True` (same precondition as current PR #127 behavior). | `(file, line)` is already captured on every op via `func_call_stack` even when `save_source_context=False`, but we conservatively keep the gate to avoid surprising new work in the default no-source-context path. Revisit in v2 if user asks. |
+| D10 | Conditional IDs: dense per-`ModelLog` integers. A per-file structural key lives INSIDE the AST index; translates to `ModelLog`-local ID during postprocess. | Simpler data model for users. Structural key is an implementation detail. |
+| D11 | Graphviz gets full ELIF/ELSE edge labels. Dagua bridge gets extended edge classification. ELK gets a one-line comment stating it does not render conditional labels. | Dagua is the active visualization path; ELK is legacy; the user's time is better spent on the current and future renderers. |
+| D12 | Old post-validation step (clear IF markings if no `ast.If` found) is REMOVED. Pre-classification makes it unnecessary. | Cleaner algorithm, no double-checking. |
+
+## Data Model Changes
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                      # True iff bool_context_kind ∈ {"if_test", "elif_test"}
+bool_context_kind: Optional[str]          # one of: "if_test", "elif_test", "assert", "bool_cast",
+                                          #          "comprehension_filter", "while", "ifexp",
+                                          #          "match_guard", "unknown"
+bool_conditional_id: Optional[int]        # id into ModelLog.conditional_events (if_test/elif_test only)
+
+# Branch attribution (meaningful for any op)
+conditional_branch_stack: List[Tuple[int, str]]   # [(cond_id, branch_kind), ...], outer→inner
+conditional_branch_depth: int                      # = len(conditional_branch_stack)
+
+# Per-branch child label lists
+cond_branch_else_children: List[str]
+cond_branch_elif_children: Dict[int, List[str]]    # elif_index (1-based) → child labels
+```
+
+**Preserved (populated from new fields):**
+- `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch`
+- `cond_branch_start_children` — still "edges where a branch is entered from this node"
+- `cond_branch_then_children` — still "children in THEN body only"
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# New aggregate fields
+conditional_branch_stacks: List[List[Tuple[int, str]]]   # unique signatures in first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                         # signature → list of pass numbers
+
+cond_branch_else_children: List[str]                     # union across passes (pass-stripped)
+cond_branch_elif_children: Dict[int, List[str]]          # union across passes (pass-stripped)
+```
+
+**Merge rules** (`_build_layer_logs` update):
+- `in_cond_branch`: OR across passes (if ANY pass has non-empty stack)
+- `conditional_branch_stacks`: unique signatures in first-seen order
+- `conditional_branch_stack_passes`: accumulate
+- `cond_branch_*_children`: UNION across passes after stripping `:N` pass suffix
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]       # list of normalized if-chain records
+conditional_elif_edges: List[Tuple[int, int, str, str]]  # (cond_id, elif_idx, parent, child)
+conditional_else_edges: List[Tuple[int, str, str]]       # (cond_id, parent, child)
+```
+
+where `ConditionalEvent` is a dataclass (or typed dict):
+```python
+@dataclass
+class ConditionalEvent:
+    id: int
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]
+    test_span: Tuple[int, int]
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int]]        # "then", "elif_1", ..., "else" → line range
+    branch_test_spans: Dict[str, Tuple[int, int]]    # "then", "elif_1", ... → test span
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]                            # labels of atomic bools that drove this event
+```
+
+**Preserved (populated from new fields):**
+- `conditional_branch_edges` — still `(parent, bool_layer_label)` pairs
+- `conditional_then_edges` — still `(parent, child)` for THEN edges only
+
+### `constants.py` FIELD_ORDER updates
+
+- `LAYER_PASS_LOG_FIELD_ORDER` — add 7 new entries in the "Conditional info" block
+- `MODEL_LOG_FIELD_ORDER` — add 3 new entries
+- `LAYER_LOG_FIELD_ORDER` — add 5 new aggregate entries (conditional fields now properly tracked, not "hidden")
+
+All field additions must be done in one PR to prevent `FIELD_ORDER_SET` mismatch crashes.
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+def attribute_op(func_call_stack: List[FuncCallLocation]) -> List[Tuple[int, str]]: ...
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+```
+
+**`FileIndex` contents per file:**
+- Parsed `ast.Module`
+- Function-scope list (`FunctionDef`, `AsyncFunctionDef`, `Lambda` with usable spans)
+- Normalized `ConditionalRecord` list (flattened if/elif/else chains)
+- Bool-consumer index: every `ast.If.test`, `ast.While.test`, `ast.IfExp.test`, `ast.Assert.test`, comprehension `if` filters, `match_case.guard`, direct `bool(...)` calls — each tagged with kind
+- Per-function branch interval tree (centered interval tree keyed by line → list of `(cond_id, branch_kind, nesting_depth)`)
+
+**`classify_bool(filename, line)` algorithm:**
+1. Get `FileIndex` (parse + cache if new).
+2. Find innermost AST bool consumer whose source span contains `line`.
+3. Return `(kind, maybe_cond_id, maybe_branch_test_kind)` where `kind` is one of the 9 context kinds above.
+
+**`attribute_op(func_call_stack)` algorithm:**
+1. For each frame (shallow → deep): look up scope, query branch interval tree at `frame.line_number`.
+2. Concatenate per-frame stacks, deduplicating adjacent repeats.
+3. Return the merged stack.
+
+### Postprocess Step 5 restructure
+
+Rename the current monolithic `_mark_conditional_branches` into 5 sub-phases:
+
+**5a. Build file indexes**
+For every internally-terminated scalar bool, collect source filenames across its `func_call_stack`. Eagerly build `FileIndex` for each (amortizes cache cost).
+
+**5b. Classify bools**
+For each `is_terminal_bool_layer` scalar bool:
+- Call `classify_bool(file, line)` on each frame; take the innermost non-`unknown` kind.
+- Set `bool_context_kind`, `bool_is_branch`, `bool_conditional_id`.
+- If kind is `if_test` or `elif_test`, register this bool in `ModelLog.conditional_events[cond_id].bool_layers`.
+
+**5c. Emit conditional_events**
+For each unique `bool_conditional_id`, materialize a `ConditionalEvent` from the `FileIndex` (translate structural key → dense `ModelLog`-local id).
+
+**5d. IF edge backward flood** (unchanged from PR #127, but now source-selected)
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestors with `cond_branch_start_children` and emit `conditional_branch_edges`.
+
+**5e. Branch attribution forward**
+For every op, call `attribute_op(func_call_stack)`. Set `conditional_branch_stack`, `conditional_branch_depth`.
+
+For each branch-start node's children, diff parent vs child stack to determine which branch was entered:
+- If child gained `(cond_id, "then")`: add to `cond_branch_then_children`, emit `conditional_then_edges`.
+- If child gained `(cond_id, "elif_N")`: add to `cond_branch_elif_children[N]`, emit `conditional_elif_edges`.
+- If child gained `(cond_id, "else")`: add to `cond_branch_else_children`, emit `conditional_else_edges`.
+
+### Multi-pass `LayerLog` merge
+
+Update `_build_layer_logs` to compute aggregate conditional fields per the rules in the Data Model section.
+
+## Visualization
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+Extend the existing IF/THEN edge-label block at lines 985-996:
+- Match child against `cond_branch_elif_children[n]` → label `ELIF n`
+- Match child against `cond_branch_else_children` → label `ELSE`
+- Respect rolled mode (strip `:N` suffix)
+
+Same font size/bold/underline as existing IF/THEN labels.
+
+### Dagua bridge (`torchlens/visualization/dagua_bridge.py`)
+
+Extend `_classify_forward_edge`:
+- Return `"elif_1"`, `"elif_2"`, ... for elif child matches
+- Return `"else"` for else child matches
+
+Dagua's rendering backend handles the styling; no changes needed there.
+
+### ELK (`torchlens/visualization/elk_layout.py`)
+
+Add a single comment near the top documenting:
+```python
+# ELK renderer does NOT render conditional branch edge labels (IF/THEN/ELIF/ELSE).
+# For branch-aware visualization use vis_renderer="graphviz" (default) or
+# the dagua renderer.
+```
+
+No functional change. ELK is legacy (dagua replacement in progress).
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+Add consistency checks (existing invariant pattern, run in `validate_forward_pass`):
+
+1. **cond_branch_X_children ↔ conditional_X_edges bidirectional consistency**
+   For each `(parent, child)` in `conditional_then_edges`, `child ∈ parent.cond_branch_then_children`.
+   Same for elif and else.
+2. **Children labels exist in ModelLog**
+   Every label in `cond_branch_*_children` corresponds to an actual `LayerPassLog`.
+3. **Bool classification invariants**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+4. **Stack-depth self-consistency**
+   `conditional_branch_depth == len(conditional_branch_stack)`.
+   `in_cond_branch == (conditional_branch_depth > 0)`.
+5. **Conditional event references are valid**
+   Every `cond_id` in any `conditional_branch_stack` entry, any `bool_conditional_id`, or any edge list has a matching `ModelLog.conditional_events[i].id`.
+6. **Branch stack monotonicity**
+   For a parent→child edge, the child's stack contains the parent's stack as a prefix (or enters a new branch, which is the edge-classification case).
+7. **Elif index contiguity**
+   For a given `cond_id`, `cond_branch_elif_children` keys are contiguous from 1.
+
+## Test Matrix
+
+### New file: `tests/test_conditional_branches.py`
+
+Test models added to `tests/example_models.py` (or a new `example_conditional_models.py` if that file grows too large).
+
+Each test runs `log_forward_pass(..., save_source_context=True)` and asserts on specific fields.
+
+| Test Model | Purpose | Assert |
+|------------|---------|--------|
+| `SimpleIfElseModel` | baseline `if/else` | THEN + ELSE edges present, `conditional_events` has 1 entry |
+| `ElifLadderModel` | `if/elif/elif/else` | ELIF 1, ELIF 2, ELSE edges; `branch_ranges` has all 4 arms |
+| `NestedIfThenIfModel` | `if A: if B: ...` | 2 conditional_events, stack depth 2 inside inner body |
+| `NestedInElseModel` | `if A: ... else: if B: ...` | 2 events, inner nested under `else` branch kind |
+| `MultilinePredicateModel` | `if (a \n and b \n):` | test span spans 3 lines, resolves to one conditional |
+| `LoopedIfAlternatingModel` | `for i: if i%2: ...` | per-pass `conditional_branch_stack` differs; aggregate has 2 signatures |
+| `AlternatingRecurrentIfModel` | recurrent, THEN on pass 1, ELSE on pass 2 | `LayerLog.conditional_branch_stacks` has both; `conditional_branch_stack_passes` maps correctly |
+| `EarlyReturnIfModel` | `if cond: return x` | THEN child marked; ops after if aren't attributed (there are none on this path) |
+| `HelperBranchModel` | helper fn called from forward contains the `if` | attribution uses helper's frame, not forward's |
+| `NotIfModel` | `if not cond:` | bool classified as `if_test`, THEN attribution works |
+| `AndOrIfModel` | `if a and b:` | multiple bools share same `cond_id`, both `bool_is_branch=True` |
+| `WalrusIfModel` | `if (x := expr) > 0:` | normal attribution |
+| `AssertTensorCondModel` | `assert tensor_cond` | `bool_context_kind="assert"`, `bool_is_branch=False`, no IF/THEN edges emitted |
+| `BoolCastOnlyModel` | `flag = bool(tensor)` | `bool_context_kind="bool_cast"`, no edges |
+| `TernaryIfExpModel` | `y = a if cond else b` | `bool_context_kind="ifexp"`, no edges |
+| `ComprehensionIfModel` | `[f(x) for x in xs if pred(x)]` | `bool_context_kind="comprehension_filter"`, no edges |
+| `WhileLoopModel` | `while tensor_cond:` | `bool_context_kind="while"`, no edges |
+| `PythonBoolModel` | `if self.flag:` (no tensor) | no bool events captured, no edges |
+| `ItemScalarizationModel` | `if tensor.item() > 0:` | no bool events captured, no edges (documented false negative) |
+| `TorchWhereModel` | `x = torch.where(cond, a, b)` | no conditional_events |
+| `ShapePredicateModel` | `if x.shape[0] > 0:` | no conditional_events (documented false negative) |
+| `ReconvergingBranchesModel` | `if cond: x=a else: x=b; y=f(x)` | `y` outside branches, x-children correctly attributed to THEN vs ELSE |
+| `DecoratedForwardModel` | `@decorator` on forward | best-effort; either graceful degradation or correct attribution |
+| `SaveSourceContextOffModel` | `save_source_context=False` | no branch attribution runs; `conditional_branch_stack=[]` on all ops; existing `in_cond_branch` flood still works for IF edges |
+
+### Smoke coverage
+
+Add 1-2 tests with `@pytest.mark.smoke` — a simple `if/else` model + an `if/elif/else` ladder. Both assert on new fields.
+
+## Backward Compatibility
+
+- Every existing field retained with identical semantics.
+- Old fields populated from new. `in_cond_branch` is now derived (`@property`) but can stay as a direct field for serialization compat; updated per pass via attribution.
+- `FIELD_ORDER` tuples updated in the same PR as class definitions.
+- Pickle compat: a loader-side default fill (`__setstate__` or `__post_init__` that fills missing fields with empty defaults) lets older pickles load into new classes. Document as "load-with-defaults for N-1 minor version only."
+
+## Implementation Phases
+
+1. **Foundation** — new fields + `constants.py` updates + default `__init__` values. Run smoke tests. No behavior change yet (new fields stay empty).
+2. **AST module** — `ast_branches.py` + unit tests (Test the indexer, classifier, attributor in isolation on synthetic source snippets).
+3. **Postprocess integration** — restructure Step 5 into 5a-5e. Wire in classification and attribution.
+4. **Multi-pass merge** — `_build_layer_logs` updates.
+5. **Invariants** — add 7 new consistency checks.
+6. **Graphviz rendering** — extend edge labels.
+7. **Dagua bridge** — extend edge classification.
+8. **Integration tests** — all 24 models with assertions.
+9. **Documentation** — update `AGENTS.md` conditional section, architecture.md, a user-facing "conditional handling limitations" page.
+10. **PR** — with explicit migration notes for any downstream consumers.
+
+Each phase: pass tier-1 smoke tests before moving to the next. Tier-2 test suite at phases 3, 5, and 8. Tier-3 before PR.
+
+## Open Questions for Architect (me) / User
+
+(Listed here for adversarial-review input and optional user input. I'll make defaults but surface for override.)
+
+1. **ELK support**: Default = document limitation. Confirm?
+2. **conditional_id**: Default = dense per-`ModelLog` int. Confirm vs structural key?
+3. **Save-source-context gate**: Default = keep gate (PR #127 convention). Should AST attribution activate unconditionally instead?
+4. **Pickle version compat**: Default = "load-with-defaults for 1 minor version." Acceptable, or stricter?
+5. **v2 scope**: confirm ternary + while + column offsets + ELK go to v2?
+6. **Test model count**: 24 is aggressive. Acceptable, or should we trim?
+
+## Deliverables
+
+- 1 new module: `torchlens/postprocess/ast_branches.py` (~300 lines)
+- Modified modules (~5): `layer_pass_log.py`, `layer_log.py`, `model_log.py`, `constants.py`, `control_flow.py`, `_build_layer_logs`, `validation/invariants.py`, `visualization/rendering.py`, `visualization/dagua_bridge.py`
+- Test additions: `tests/test_conditional_branches.py` (~400 lines), `tests/example_models.py` additions (~24 new small models)
+- Docs: `AGENTS.md` conditional section update, `architecture.md` Step 5 update, user-facing limitations page in docs/
+- PR with migration notes and explicit "Before/After" table of conditional-related fields
+
+## Risks (tracked)
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch causes hard crashes on any partial rollout | Do all field additions in ONE commit; run full test suite before pushing |
+| R2 | Multi-pass merge semantics cause subtle regressions on recurrent tests | Add `AlternatingRecurrentIfModel` test early; run tier-2 suite |
+| R3 | Source-line resolution for decorated/wrapped forwards produces wrong `FileIndex` lookups | Require frame source via `frame.f_code.co_filename` + `f_lineno`, not `inspect.getsourcefile(module_class)` |
+| R4 | `linecache` serves stale source after file edit, AST parses new; mismatch produces confident-wrong attribution | Cache by `(filename, mtime)`; on mtime change invalidate; on `linecache` miss fail-soft to `bool_context_kind="unknown"` |
+| R5 | Pre-classification misses a syntactic form and silently emits `unknown` for a real `if_test` | Explicit unit tests for every enumerated bool-consumer kind; strict `raise` (in dev mode) when classifier returns `unknown` but line is syntactically inside an `If.test` |
+| R6 | Interval tree perf regresses on 1000-line `forward` | Parse once per file; interval tree query is `O(log k + d)`; benchmark on `HugeNestedIfModel` |
+| R7 | Old pickled ModelLogs fail to load | `__setstate__` default-fill; document load-with-defaults window |

--- a/.project-context/plans/if-else-attribution/plan_v2.md
+++ b/.project-context/plans/if-else-attribution/plan_v2.md
@@ -1,0 +1,513 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Version:** v2 (post-adversarial-review-1)
+**Change log:** See `CHANGELOG_v1_to_v2` at the bottom for findings addressed.
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering — distinguish actual branching bool events from incidental bool conversions (`assert`, `bool()`, comprehension filters, `while`, `ifexp`, `match` guards).
+3. Represent branch structure explicitly in torchlens data classes (`LayerPassLog`, `LayerLog`, `ModelLog`).
+4. Render THEN / ELIF / ELSE edge labels in the visualization (Graphviz primary; dagua bridge; ELK documented as unsupported).
+5. Comprehensive test coverage for the positive path AND every documented limitation.
+6. Strict backward compatibility — no existing field is renamed or removed.
+
+## Out-of-Scope for v1 (explicitly documented limitations)
+
+**Non-branch bool consumers — classified but not attributed:**
+- Ternary (`x if cond else y`) → `bool_context_kind="ifexp"`
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast NOT nested inside `If.test` → `bool_context_kind="bool_cast"`
+
+**Note:** `bool(tensor_cond)` nested *inside* an `If.test`/`elif` test IS a branch. See D3 below.
+
+**Source-unavailable situations — graceful degradation (no attribution, `bool_context_kind="unknown"`):**
+- Jupyter / REPL cells (`<ipython-input-...>`)
+- `exec` / `eval`-injected forwards (`<string>`)
+- Byte-compiled only (`.pyc` without `.py`), native `.so` modules
+- `torch.compile` / `torch.jit.script` / `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel` (torchlens is already single-threaded)
+- Monkey-patched `forward` where source resolves to the patch function, not the class body
+
+**Branches torchlens fundamentally cannot see — documented false negatives:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred to v2 (documented, not silently missed):**
+- Column-offset disambiguation for multi-op lines
+- Ternary (`ast.IfExp`) full attribution — data model extension
+- `while` loop body attribution — different semantics
+- ELK conditional edge rendering (legacy; dagua is replacing)
+
+## Decisions (architect-level)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. | Convergent recommendation from all 3 research agents. Matches TorchScript + coverage.py prior art. Minimal runtime cost. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` | Python AST has no `Elif` node; elif is nested `If` in `orelse`. Flattening prevents line-based confusion. |
+| **D3 (revised)** | **Pre-classify bools by enclosing AST context. For `bool(x)` nested inside an `If.test` or elif test: classify as `if_test`/`elif_test` with a secondary `bool_wrapper_kind="bool_cast"` marker. Standalone `bool(x)` (not in an If-test) classifies as `bool_cast`.** | Fixes adversarial Finding 2: `if bool(tensor_cond):` is a real branch and must not be suppressed. Wrapper context preserved separately. |
+| D4 | Attribution uses **full `func_call_stack`**, not just the user-facing frame. | Catches helper functions: `def helper(): if cond: op()` called from forward. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregate stores a **set of unique signatures** plus a pass-to-signature map. | Same rolled layer can be in THEN on pass 1, ELSE on pass 2. First-pass-wins is incorrect. |
+| D6 | Keep every existing field (`cond_branch_start_children`, `cond_branch_then_children`, `conditional_branch_edges`, `conditional_then_edges`, `in_cond_branch`). Populate from new fields. | Strict backward compat. |
+| D7 | AST indexing/caching lives in a NEW module `torchlens/postprocess/ast_branches.py`. Step 5 imports it. | Isolates AST logic from graph-flood logic; testable. |
+| D8 | Cache key: `(filename, stat.st_mtime_ns)`. Invalidate on mtime change. Cache lifetime = process-local. | Hot-reload safety. |
+| **D9 (revised)** | **AST classification runs whenever `(file, line)` is available on `func_call_stack` (which is always, even with `save_source_context=False`). `save_source_context` only gates rich source-text capture for user-facing display.** | Fixes adversarial Finding 1: D3+D12 require classification to always run; gating on `save_source_context` re-introduces false positives. (file, line) is already captured unconditionally via `FuncCallLocation`. |
+| D10 | Conditional IDs: dense per-`ModelLog` integers. Structural key `(file, func_start, if_lineno, col_offset)` is an AST-index-internal detail; translated to dense ID during postprocess. | Simple external model. |
+| D11 | Graphviz gets ELIF/ELSE labels with explicit precedence rules (see Visualization). Dagua bridge gets extended edge classification. ELK gets a comment documenting it as unsupported. | Dagua is active; ELK is legacy. |
+| D12 | Old post-validation ("clear IF markings if no `ast.If`") is REMOVED. Pre-classification makes it unnecessary. | Cleaner algorithm. |
+| **D13 (NEW)** | **Branch-entry edges are detected by diffing `conditional_branch_stack` across EVERY forward edge `(parent, child)`, NOT only edges out of branch-start nodes.** | Fixes adversarial Finding 3: branch-local ops may depend on parameters/buffers/constants (e.g. `y = self.bias + 1` inside `if`). The `self.bias→y` edge must be classified correctly even though `self.bias` is not in the predicate's dataflow. |
+| **D14 (NEW)** | **Augment `FuncCallLocation` with `code_firstlineno: int` (captured via `frame.f_code.co_firstlineno`) and `code_qualname: str` (best-effort via `frame.f_code.co_qualname` on Python 3.11+, fallback to `co_name`). These identify a scope by its code-object identity, not just line number.** | Fixes adversarial Finding 9: nested helpers with the same name, lambdas, and decorated wrappers cannot be resolved by line alone. |
+| **D15 (NEW)** | **Add `ModelLog.conditional_edge_passes` map: `(parent_no_pass_label, child_no_pass_label, cond_id, branch_kind) → List[int]` of pass numbers that took that arm on that rolled edge. Rolled-mode renderers consult this for mixed-arm edges and produce composite labels like `THEN(1,3) / ELSE(2)`.** | Fixes adversarial Finding 7: unioned child lists hide pass-level arm divergence in rolled mode. |
+
+## Data Model Changes
+
+### `FuncCallLocation` — augmented (D14)
+
+```python
+@dataclass
+class FuncCallLocation:
+    file: str
+    line_number: int
+    func_name: str
+    code_firstlineno: int                 # NEW: frame.f_code.co_firstlineno
+    code_qualname: Optional[str]          # NEW: frame.f_code.co_qualname on 3.11+, else None
+    # existing lazy properties: source_context, func_signature, etc.
+```
+
+**Population:** `utils/introspection.py` stack-capture path. Both new fields are always captured; do NOT gate on `save_source_context` (per D9).
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                      # True iff bool_context_kind ∈ {"if_test", "elif_test"}
+bool_context_kind: Optional[str]          # one of: "if_test", "elif_test", "assert", "bool_cast",
+                                          #          "comprehension_filter", "while", "ifexp",
+                                          #          "match_guard", "unknown"
+bool_wrapper_kind: Optional[str]          # NEW (D3 revision): e.g. "bool_cast" when classified as
+                                          # if_test/elif_test but wrapped in a bool() call.
+                                          # None if no wrapper.
+bool_conditional_id: Optional[int]        # id into ModelLog.conditional_events (if_test/elif_test only)
+
+# Branch attribution (meaningful for any op)
+conditional_branch_stack: List[Tuple[int, str]]   # [(cond_id, branch_kind), ...], outer→inner
+conditional_branch_depth: int                      # = len(conditional_branch_stack)
+
+# Per-branch child label lists
+cond_branch_else_children: List[str]
+cond_branch_elif_children: Dict[int, List[str]]    # elif_index (1-based) → child labels
+```
+
+**Preserved (populated from new fields):**
+- `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch`
+- `cond_branch_start_children` — still "edges where a branch is entered from this node"
+- `cond_branch_then_children` — still "children in THEN body only"
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# New aggregate fields
+conditional_branch_stacks: List[List[Tuple[int, str]]]   # unique signatures in first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                         # signature → list of pass numbers
+
+cond_branch_else_children: List[str]                     # union across passes (pass-stripped)
+cond_branch_elif_children: Dict[int, List[str]]          # union across passes (pass-stripped)
+```
+
+**Merge rules** (`_build_layer_logs` update):
+- `in_cond_branch`: OR across passes
+- `conditional_branch_stacks`: unique signatures in first-seen order
+- `conditional_branch_stack_passes`: accumulate
+- `cond_branch_*_children`: UNION across passes after stripping `:N` pass suffix
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]       # normalized if-chain records
+conditional_elif_edges: List[Tuple[int, int, str, str]]  # (cond_id, elif_idx, parent, child)
+conditional_else_edges: List[Tuple[int, str, str]]       # (cond_id, parent, child)
+
+# NEW (D15): pass-level rolled-edge arm map
+conditional_edge_passes: Dict[
+    Tuple[str, str, int, str], List[int]
+]                                                 # (parent_no_pass, child_no_pass, cond_id, branch_kind) → [pass_nums]
+```
+
+`ConditionalEvent` (dataclass or typed dict):
+```python
+@dataclass
+class ConditionalEvent:
+    id: int
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]
+    test_span: Tuple[int, int]
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int]]        # "then", "elif_1", ..., "else" → line range
+    branch_test_spans: Dict[str, Tuple[int, int]]    # "then", "elif_1", ... → test span
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]
+```
+
+**Preserved (populated from new fields):**
+- `conditional_branch_edges` — still `(parent, bool_layer_label)` pairs
+- `conditional_then_edges` — still `(parent, child)` for THEN edges only
+
+### `constants.py` FIELD_ORDER updates
+
+- `LAYER_PASS_LOG_FIELD_ORDER` — add 8 new entries (including `bool_wrapper_kind`)
+- `MODEL_LOG_FIELD_ORDER` — add 4 new entries (including `conditional_edge_passes`)
+- `LAYER_LOG_FIELD_ORDER` — add 5 new aggregate entries
+
+All field additions done in ONE commit to prevent `FIELD_ORDER_SET` mismatch crashes.
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+def attribute_op(func_call_stack: List[FuncCallLocation]) -> List[Tuple[int, str]]: ...
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+```
+
+**`FileIndex` contents per file:**
+- Parsed `ast.Module`
+- Function-scope list keyed by `(code_firstlineno, qualname)` (NOT by line span alone — D14)
+- Normalized `ConditionalRecord` list (flattened if/elif/else chains)
+- Bool-consumer index: every AST node that evaluates to bool (`If.test`, `While.test`, `IfExp.test`, `Assert.test`, comprehension `if`, `match_case.guard`, direct `bool(...)` calls) — each tagged with kind
+- Per-function branch interval tree (centered interval tree keyed by line → list of `(cond_id, branch_kind, nesting_depth)`)
+
+**`classify_bool(filename, line)` algorithm (D3 revision):**
+1. Get `FileIndex`.
+2. Walk bool consumers whose source span contains `line`, from **innermost outward**.
+3. Determine the classification:
+   - If the innermost non-`bool_cast` consumer is an `If.test` or flattened `elif` test → `kind = if_test` or `elif_test`, `wrapper_kind = "bool_cast"` if `bool_cast` is on the inner stack, else `None`.
+   - If the innermost consumer IS `bool_cast` AND there's no enclosing `If.test`/`elif_test` → `kind = "bool_cast"`, `wrapper_kind = None`.
+   - Otherwise use the innermost kind directly: `assert`, `comprehension_filter`, `while`, `ifexp`, `match_guard`.
+   - If no consumer contains `line` → `kind = "unknown"`.
+4. Return `BoolClassification(kind, wrapper_kind, maybe_cond_id, maybe_branch_test_kind)`.
+
+**`attribute_op(func_call_stack)` algorithm:**
+1. For each frame (shallow → deep):
+   - Resolve scope by `(filename, code_firstlineno, func_name)` — exact match preferred; fallback to smallest containing scope by line (D14).
+   - Query branch interval tree at `frame.line_number`.
+2. Concatenate per-frame stacks, deduplicating adjacent repeats.
+3. Return the merged stack.
+
+### Postprocess Step 5 restructure (revised: D13)
+
+**5a. Build file indexes**
+For every internally-terminated scalar bool, collect source filenames across its `func_call_stack`. Eagerly build `FileIndex` for each.
+
+**5b. Classify bools (D3 revision)**
+For each `is_terminal_bool_layer` scalar bool:
+- Call `classify_bool(file, line)` on each frame; take the innermost matching classification.
+- Set `bool_context_kind`, `bool_wrapper_kind`, `bool_is_branch`, `bool_conditional_id`.
+- If `bool_is_branch=True`, register in `ModelLog.conditional_events[cond_id].bool_layers`.
+
+**5c. Emit conditional_events**
+For each unique `bool_conditional_id`, materialize a `ConditionalEvent` from the `FileIndex` (translate structural key → dense `ModelLog`-local id).
+
+**5d. IF edge backward flood** (PR #127 behavior, now source-filtered)
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestors with `cond_branch_start_children` and emit `conditional_branch_edges`.
+
+**5e. Branch attribution forward (D13 revision)**
+For every op, compute `conditional_branch_stack` via `attribute_op(func_call_stack)`. Set `conditional_branch_stack`, `conditional_branch_depth`.
+
+**Edge-level branch detection — inspect EVERY forward edge `(parent, child)`:**
+- Compute `parent_stack`, `child_stack`.
+- If `child_stack` has `(cond_id, kind)` entries that `parent_stack` doesn't → those are **branch-entry** edges.
+  - For each gained `(cond_id, "then")` → add child to `parent.cond_branch_then_children`, emit `conditional_then_edges`.
+  - For each gained `(cond_id, "elif_N")` → add child to `parent.cond_branch_elif_children[N]`, emit `conditional_elif_edges`.
+  - For each gained `(cond_id, "else")` → add child to `parent.cond_branch_else_children`, emit `conditional_else_edges`.
+- If `parent_stack` has entries that `child_stack` doesn't → **branch-exit / reconvergence**. No edge list is emitted (these edges are normal, non-labeled).
+- Populate `conditional_edge_passes` (D15) keyed by pass-stripped labels.
+
+**Note:** `cond_branch_start_children` (from 5d) and `cond_branch_then_children`/elif/else (from 5e) are related but distinct: 5d marks the parents of the predicate bool (IF edges in backward flood), 5e marks branch-entry edges (forward, stack-diff based). A node can participate in both if it sits at the divergence.
+
+### Multi-pass `LayerLog` merge
+
+Update `_build_layer_logs` per the rules in the Data Model section. Also populate `ModelLog.conditional_edge_passes` during this step.
+
+## Visualization
+
+### Label precedence rules (addresses adversarial Finding 8)
+
+Edge-label composition, in priority order:
+
+1. **Branch-entry label** (highest) — if the edge appears in any of:
+   - `conditional_then_edges` → `THEN`
+   - `conditional_elif_edges` (with elif_idx = N) → `ELIF N`
+   - `conditional_else_edges` → `ELSE`
+   - Multiple branch kinds across passes (rolled mode only, via `conditional_edge_passes`) → composite label `THEN(1,3) / ELSE(2)` or `mixed`.
+   An edge with a branch-entry label does NOT simultaneously show `IF`.
+2. **IF label** (second) — edge is in `conditional_branch_edges` (predicate-chain edge).
+3. **Arg-label overlay** (compatible with above) — argument names (e.g., `arg0`) move from `label` to `headlabel` / `xlabel` so they never compete with branch labels.
+
+In rolled mode, if `conditional_edge_passes` shows the edge took different arms across passes, use a composite label (per above). If a single arm across all passes, use the plain label.
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+Extend the existing IF/THEN edge-label block (currently `rendering.py:985-996`):
+- Move argument labels from `edge_dict["label"]` (currently lines 1049-1090) to `edge_dict["headlabel"]` or `edge_dict["xlabel"]`. This separates semantic concerns.
+- Refactor the IF/THEN decision into a precedence function:
+  ```python
+  def _compute_branch_label(parent, child, edge_passes) -> Optional[str]: ...
+  ```
+- For rolled mode: consult `conditional_edge_passes` before emitting a plain label.
+
+### Dagua bridge (`torchlens/visualization/dagua_bridge.py`)
+
+Extend `_classify_forward_edge` with the same precedence. Returns `"then"`, `"elif_1"`, ..., `"else"`, or `"mixed"` for conflicting arms across passes. Dagua's rendering backend handles styling.
+
+### ELK (`torchlens/visualization/elk_layout.py`)
+
+Add a comment near the top:
+```python
+# ELK renderer does NOT render conditional branch edge labels (IF/THEN/ELIF/ELSE).
+# For branch-aware visualization use vis_renderer="graphviz" (default) or
+# the dagua renderer.
+```
+
+No functional change. Legacy.
+
+## Capture / Postprocess Integration (addresses adversarial Finding 4)
+
+Every new label-bearing field must be wired through the full field lifecycle:
+
+1. **Capture-time defaults** (`torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`):
+   Add init defaults for ALL new `LayerPassLog` fields (empty list, False, None).
+
+2. **Raw→final rename** (`torchlens/postprocess/labeling.py`):
+   Extend `_rename_raw_labels_in_place` to also rewrite labels in:
+   - `cond_branch_else_children` (each list member)
+   - `cond_branch_elif_children` (each value's list members)
+   - `conditional_elif_edges` (positions 2, 3)
+   - `conditional_else_edges` (positions 1, 2)
+   - `conditional_edge_passes` (dict keys — positions 0, 1 of the tuple)
+   - `conditional_events[*].bool_layers`
+
+3. **Cleanup / keep_unsaved_layers=False** (`torchlens/data_classes/cleanup.py`):
+   Extend the conditional-edge filtering logic to prune the new edge lists when referenced labels are removed.
+
+4. **Export** (`torchlens/data_classes/interface.py::to_pandas`):
+   Add columns for `conditional_branch_depth`, `bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, and a compact string rendering of `conditional_branch_stack`.
+
+**Phase 1 gate**: every new field must be verified wired through rename AND cleanup before Phase 1 is declared green. Add an integration test with `keep_unsaved_layers=False` to catch missed wiring.
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+Add consistency checks (run in `validate_forward_pass`):
+
+1. **cond_branch_X_children ↔ conditional_X_edges bidirectional consistency**
+   For each `(parent, child)` in `conditional_then_edges`, `child ∈ parent.cond_branch_then_children`. Same for elif and else.
+2. **Children labels exist in ModelLog**
+   Every label in `cond_branch_*_children` corresponds to an actual `LayerPassLog`.
+3. **Bool classification invariants**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+   `bool_wrapper_kind is not None` ⟹ `bool_context_kind in {"if_test", "elif_test", "bool_cast"}`.
+4. **Stack-depth self-consistency**
+   `conditional_branch_depth == len(conditional_branch_stack)`.
+   `in_cond_branch == (conditional_branch_depth > 0)`.
+5. **Conditional event references are valid**
+   Every `cond_id` in any stack entry, `bool_conditional_id`, or edge list has a matching `ModelLog.conditional_events[i].id`.
+6. **Branch stack monotonicity (REVISED — Finding 5)**
+   For every parent→child edge, ONE of the two stacks is a prefix of the other:
+   - child_stack extends parent_stack → branch-entry
+   - parent_stack extends child_stack → branch-exit / reconvergence
+   - stacks equal → inside same branch level
+   Rejecting both directions (as v1 did) is wrong because reconvergence is legal.
+7. **Elif index contiguity (REVISED — Finding 6 — moved to ConditionalEvent)**
+   For each `ConditionalEvent`, `branch_ranges` keys for elif arms are contiguous from `elif_1`. `cond_branch_elif_children` per-node map MAY have sparse keys (legitimate — a parent may only have children in `elif_2`).
+8. **Rolled-edge pass consistency (NEW)**
+   Every entry in `conditional_edge_passes` must reference a real rolled edge in the unrolled graph.
+
+## Test Matrix
+
+### New file: `tests/test_conditional_branches.py`
+
+Test models live in `tests/example_models.py` (or a new `example_conditional_models.py`).
+
+All tests run `log_forward_pass(..., save_source_context=True)` unless otherwise noted. Classification is expected to work even with `save_source_context=False`; that's verified explicitly by two tests.
+
+**Baseline / positive:**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `SimpleIfElseModel` | `if/else` | THEN + ELSE edges, `conditional_events` has 1 entry |
+| `ElifLadderModel` | `if/elif/elif/else` | ELIF 1, ELIF 2, ELSE; `branch_ranges` has all 4 arms |
+| `NestedIfThenIfModel` | `if A: if B:` | 2 events, stack depth 2 inside inner body |
+| `NestedInElseModel` | `if A: ...else: if B:` | 2 events, inner's `parent_branch_kind="else"` |
+| `MultilinePredicateModel` | `if (a \n and b \n):` | test span 3 lines, resolves to one conditional |
+
+**Branch-entry via non-predicate ancestors (Finding 3):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `BranchUsesOnlyParameterModel` | `if c: y = self.bias + 1` | `self.bias → y` edge labeled THEN; `y ∈ parent.cond_branch_then_children` |
+| `BranchUsesOnlyConstantModel` | `if c: y = x * 2.0` (2.0 is constant) | similar — branch-entry edge labeled |
+
+**Wrapped bool (Finding 2):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `IfBoolCastModel` | `if bool(x.sum() > 0):` | `bool_is_branch=True`, `bool_context_kind="if_test"`, `bool_wrapper_kind="bool_cast"`, THEN edges emitted |
+
+**Multi-pass / recurrent (Finding 7):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `LoopedIfAlternatingModel` | `for i: if i%2: ...` | per-pass stacks differ; aggregate has 2 signatures |
+| `AlternatingRecurrentIfModel` | recurrent, THEN pass 1 / ELSE pass 2 | `conditional_branch_stacks` has both; `conditional_branch_stack_passes` maps correctly; `conditional_edge_passes` shows pass divergence on rolled edges |
+| `RolledMixedArmModel` | same rolled edge takes THEN one pass and ELSE another | rolled-mode renderer emits composite label |
+
+**Reconvergence (Finding 5):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `ReconvergingBranchesModel` | `if c: x=a else: x=b; y=f(x)` | invariant 6 passes (prefix-drop allowed); `y` has empty stack but parents `a`, `b` had non-empty stacks |
+
+**Scope resolution (Finding 9):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `NestedHelperSameNameModel` | two local `helper()` with same name in different branches | attribution uses `code_firstlineno`, not line-only |
+| `LambdaBranchModel` | `lambda x: op(x) if cond else op2(x)` in forward | lambda scope resolved distinctly |
+| `DecoratedForwardModel` | `@decorator` on forward | scope resolves to real forward, not decorator wrapper; best-effort |
+
+**False positives — non-branch bools:**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `AssertTensorCondModel` | `assert tensor_cond` | `bool_context_kind="assert"`, `bool_is_branch=False`, no IF/THEN edges |
+| `BoolCastOnlyModel` | `flag = bool(tensor)` (no enclosing if) | `bool_context_kind="bool_cast"`, `bool_is_branch=False` |
+| `TernaryIfExpModel` | `y = a if cond else b` | `bool_context_kind="ifexp"`, no edges |
+| `ComprehensionIfModel` | `[f(x) for x in xs if pred(x)]` | `bool_context_kind="comprehension_filter"`, no edges |
+| `WhileLoopModel` | `while tensor_cond:` | `bool_context_kind="while"`, no edges |
+| `MatchGuardModel` | `match v: case x if tensor_cond: ...` | `bool_context_kind="match_guard"`, no edges |
+
+**Compound / negation / walrus:**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `NotIfModel` | `if not cond:` | `bool_context_kind="if_test"`, THEN attribution correct |
+| `AndOrIfModel` | `if a and b:` | multiple bools share same `cond_id`, both `bool_is_branch=True` |
+| `WalrusIfModel` | `if (x := expr) > 0:` | normal attribution |
+
+**Documented false negatives (no attribution expected):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `PythonBoolModel` | `if self.flag:` (no tensor) | no bool events captured, no edges |
+| `ItemScalarizationModel` | `if tensor.item() > 0:` | no bool events captured (documented limitation) |
+| `TorchWhereModel` | `x = torch.where(cond, a, b)` | no conditional_events |
+| `ShapePredicateModel` | `if x.shape[0] > 0:` | no conditional_events |
+
+**save_source_context gating (Finding 1):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `SaveSourceContextOffModel` | `save_source_context=False` | AST classification STILL runs (because only file+line needed); branch attribution populated; source_context field empty |
+| `SaveSourceContextOffAssertModel` | `save_source_context=False`, `assert tensor_cond` | classification works; no false-positive IF edge emitted |
+
+**Field-lifecycle integration (Finding 4):**
+| Test | Purpose | Assertions |
+|------|---------|-----------|
+| `KeepUnsavedLayersFalseModel` | `keep_unsaved_layers=False` with conditionals | new edge lists properly pruned; no dangling labels |
+| `ToPandasConditionalModel` | `to_pandas()` with conditionals | DataFrame has conditional columns populated |
+
+**Smoke:**
+Add `@pytest.mark.smoke` to `SimpleIfElseModel` and `ElifLadderModel`.
+
+## Backward Compatibility
+
+- Every existing field retained with identical semantics. Verify by running the existing test suite post-implementation.
+- Old fields populated from new. `in_cond_branch` remains a real field (for serialization compat) but is recomputed from `conditional_branch_stack`.
+- `FIELD_ORDER` tuples updated in same commit as class definitions.
+- Pickle compat: `__setstate__` default-fill on each affected class. Missing new fields get empty defaults. Document as "load-with-defaults for 1 prior minor version."
+
+## Implementation Phases
+
+1. **Foundation** — new fields on all classes + `constants.py` updates + `__init__` defaults + capture-time defaults (`source_tensors.py`, `output_tensors.py`) + `FuncCallLocation` augmentation with `code_firstlineno`/`code_qualname`. Update `utils/introspection.py` stack-capture. Run tier-1 smoke; verify no crashes. New fields stay empty.
+2. **AST module** — `ast_branches.py` with file indexing, classification, attribution. Unit tests on synthetic source snippets (no model needed). Cover every edge case in the classifier.
+3. **Postprocess integration** — restructure Step 5 into 5a-5e per spec. Wire classification and edge-level attribution. Remove post-validation (D12).
+4. **Multi-pass merge + rolled edges** — `_build_layer_logs` updates + `conditional_edge_passes` population.
+5. **Rename / cleanup / export wiring** — `labeling.py`, `cleanup.py`, `interface.py::to_pandas`. Integration test with `keep_unsaved_layers=False`.
+6. **Invariants** — add 8 new consistency checks.
+7. **Graphviz rendering** — label precedence function; move arg labels to headlabel; ELIF/ELSE support; rolled-mode composite labels.
+8. **Dagua bridge** — extend edge classification.
+9. **Integration tests** — all ~30 models with assertions.
+10. **Documentation** — update `AGENTS.md` conditional section, `architecture.md`, user-facing limitations page.
+11. **PR** — with migration notes.
+
+Each phase: tier-1 smoke before moving on. Tier-2 at phases 3, 5, 7, 9. Tier-3 before PR.
+
+## Deliverables
+
+- 1 new module: `torchlens/postprocess/ast_branches.py` (~400 lines)
+- Modified modules (~10):
+  - `torchlens/data_classes/layer_pass_log.py`
+  - `torchlens/data_classes/layer_log.py`
+  - `torchlens/data_classes/model_log.py`
+  - `torchlens/data_classes/func_call_location.py` (augmentation)
+  - `torchlens/data_classes/cleanup.py` (new field filtering)
+  - `torchlens/data_classes/interface.py` (`to_pandas` updates)
+  - `torchlens/constants.py` (FIELD_ORDER)
+  - `torchlens/postprocess/control_flow.py` (Step 5 restructure)
+  - `torchlens/postprocess/labeling.py` (rename new fields)
+  - `torchlens/capture/source_tensors.py` (init defaults)
+  - `torchlens/capture/output_tensors.py` (init defaults)
+  - `torchlens/utils/introspection.py` (augmented stack capture)
+  - `torchlens/validation/invariants.py` (new checks)
+  - `torchlens/visualization/rendering.py` (label precedence + new labels)
+  - `torchlens/visualization/dagua_bridge.py` (edge classification)
+  - `torchlens/visualization/elk_layout.py` (comment only)
+- Tests: `tests/test_conditional_branches.py` (~500 lines), `tests/example_models.py` additions (~30 new small models)
+- Docs: AGENTS.md, architecture.md, user-facing limitations page
+- PR with migration notes
+
+## Risks (tracked)
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch on partial rollout | All field additions in ONE commit; full test suite before push |
+| R2 | Multi-pass merge regressions on recurrent tests | `AlternatingRecurrentIfModel` in early phases; tier-2 suite |
+| R3 | Source-line resolution fragile for decorated/wrapped forwards | Use `frame.f_code.co_filename` + `co_firstlineno` (D14); don't rely on `inspect.getsourcefile(module_class)` |
+| R4 | `linecache` serves stale source after edit | Cache by `(filename, mtime)`; on mtime change invalidate; fail-soft to `unknown` on mismatch |
+| R5 | Pre-classification misses a syntactic form → silent `unknown` for real `if_test` | Dev-mode assertion: if line is inside `If.test` span but classifier returns `unknown`, log warning. Unit tests for each enumerated kind. |
+| R6 | Interval tree perf regresses on huge `forward` | One-time file parse; O(log k + d) query; benchmark `HugeNestedIfModel` |
+| R7 | Old pickled ModelLogs fail to load | `__setstate__` default-fill; document window |
+| R8 | Arg-label relocation to headlabel breaks existing visual output | Gate behind a flag, OR verify with visual diff on existing aesthetic tests |
+| R9 | Edge-level attribution (D13) produces too many edge entries on dense branch bodies | Benchmark; batch emit |
+
+## Open Questions for Architect / User
+
+1. **ELK support**: Default = document limitation. Confirm?
+2. **conditional_id**: Default = dense per-`ModelLog` int. Confirm vs structural key?
+3. **Pickle compat window**: 1 minor version (default). OK?
+4. **v2 scope confirmation**: ternary + while + column offsets + ELK parity → v2?
+5. **Test model count**: ~30 models. OK?
+
+---
+
+## CHANGELOG_v1_to_v2
+
+Addresses adversarial review round 1 (`review_round_1.md`):
+
+| Finding | Severity | Fix in v2 |
+|---------|----------|-----------|
+| F1 D3/D9/D12 contradiction | blocker | D9 revised: AST classification always runs when `(file, line)` available; `save_source_context` only gates rich text. |
+| F2 `if bool(tensor_cond):` misclassified | high | D3 revised + new `bool_wrapper_kind` field; wrapped bools normalize to `if_test` with wrapper marker. |
+| F3 Step 5e too narrow | blocker | New D13: branch-entry detection on ALL forward edges, not just branch-start children. |
+| F4 Rename/cleanup/export not wired | high | New "Capture/Postprocess Integration" section; Phase 1 gate; modified-modules list expanded. |
+| F5 Invariant 6 rejects reconvergence | high | Invariant 6 revised: allow either direction of prefix. |
+| F6 Invariant 7 on wrong structure | medium | Invariant 7 moved from per-node map to `ConditionalEvent`. |
+| F7 Rolled-mode loses pass arms | high | New D15: `ModelLog.conditional_edge_passes`; visualization precedence adds composite labels. |
+| F8 Viz precedence unspecified | medium | New "Label precedence rules" section; arg labels move to headlabel; refactor existing label-overwrite code. |
+| F9 FuncCallLocation too weak | high | New D14: augment with `code_firstlineno` + `code_qualname`; scope resolution by identity first, line second. |

--- a/.project-context/plans/if-else-attribution/plan_v3.md
+++ b/.project-context/plans/if-else-attribution/plan_v3.md
@@ -1,0 +1,535 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Version:** v3 (post-adversarial-review-2)
+**History:** `plan_v1.md`, `plan_v2.md`, `review_round_1.md`, `review_round_2.md`.
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering (`assert`, `bool()` cast, comprehension filters, `while`, `ifexp`, `match` guards, `unknown`).
+3. Explicit per-pass branch representation on `LayerPassLog`; lossless aggregate representation on `LayerLog` and `ModelLog` (including rolled-edge pass divergence and multi-arm-entry edges).
+4. Render THEN / ELIF / ELSE edge labels in Graphviz (primary) + dagua bridge; ELK documented as unsupported.
+5. Comprehensive tests for positive paths, every documented limitation, multi-pass divergence, multi-arm entry, and lifecycle integration.
+6. Strict backward compatibility — no existing field is renamed or removed; old fields derived from new primary structures.
+
+## Out-of-Scope for v1 (explicit limitations)
+
+**Non-branch bool consumers — classified, not attributed:**
+- Ternary (`x if cond else y`) → `bool_context_kind="ifexp"`
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast NOT nested inside `If.test` → `bool_context_kind="bool_cast"`
+
+`bool(tensor_cond)` nested *inside* an `If.test`/elif test IS a branch (see D3).
+
+**Source-unavailable — graceful degradation (`bool_context_kind="unknown"`, no attribution):**
+- Jupyter / REPL cells, `exec`/`eval`, `.pyc`-only, native `.so` modules
+- `torch.compile`, `torch.jit.script`, `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel`
+- Monkey-patched `forward` where source resolves to the patch
+
+**Documented false negatives — torchlens cannot see:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred to v2 release:**
+- Column-offset disambiguation for multi-op lines
+- `ast.IfExp` full attribution
+- `while` loop body attribution
+- ELK conditional edge rendering
+
+## Decisions (architect-level)
+
+| # | Decision |
+|---|----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` (Python AST has no `Elif` node). |
+| D3 | Pre-classify every terminal scalar bool by enclosing AST context. `bool(x)` nested inside `If.test`/elif test normalizes to `if_test`/`elif_test` + `bool_wrapper_kind="bool_cast"`. Standalone `bool(x)` → `bool_cast`. |
+| D4 | Attribution uses full `func_call_stack` (every frame), not just the user-facing frame. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregates via unique signatures + pass map. |
+| D6 | Keep every existing field; old fields populated from new primary structures as derived views. |
+| D7 | AST logic lives in new module `torchlens/postprocess/ast_branches.py`. |
+| D8 | File cache keyed by `(filename, stat.st_mtime_ns)`. Process-local. |
+| D9 | AST classification runs whenever `(file, line)` is on `func_call_stack` (which is always, after D18 ungates capture). `save_source_context` only gates rich source-text capture. |
+| **D10 (REVISED)** | Two-stage identifier scheme: `ConditionalKey = (file, func_firstlineno, if_stmt_lineno, if_col_offset)` is the AST-internal structural key used in Phases 5a/5b/5e. Phase 5c is the **sole** step that materializes `ModelLog.conditional_events` and assigns dense per-`ModelLog` `conditional_id: int`. Phase 5c rewrites all `bool_conditional_key` → `bool_conditional_id` and all stack entries `(ConditionalKey, kind)` → `(cond_id, kind)` in one pass. No other code outside `ast_branches.py` sees `ConditionalKey`. |
+| D11 | Graphviz gets ELIF/ELSE labels with explicit precedence (see Visualization). Dagua bridge extended. ELK gets a comment. |
+| D12 | Old post-validation ("clear IF markings if no `ast.If`") is REMOVED; pre-classification makes it unnecessary. |
+| D13 | Branch-entry edges detected by diffing `conditional_branch_stack` across EVERY forward edge, not only edges from branch-start nodes. Legitimate: a single edge can gain MULTIPLE stack entries simultaneously (e.g., `self.bias → x` inside nested `if A: if B:` enters both outer and inner THEN). All gained entries are recorded. |
+| **D14 (REVISED)** | `FuncCallLocation` augmented with `code_firstlineno: int` (always) + `code_qualname: Optional[str]` (Python 3.11+; None on 3.9/3.10). Scope resolution in `attribute_op` is: (1) exact match on `(filename, code_firstlineno, code_qualname)` if qualname non-None; (2) fallback on `(filename, code_firstlineno, func_name)`; (3) last-resort smallest-scope containing `line_number`. |
+| D15 | `ModelLog.conditional_edge_passes` maps `(parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted List[int]` of pass numbers. Rolled-mode renderers consult this for mixed-arm labels. |
+| **D16 (NEW)** | **Cond-id-aware primary structures.** Primary arm-edge representation is `ModelLog.conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]` (`(cond_id, branch_kind) → [(parent, child)]`). Primary per-node child list is `LayerPassLog.cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]` (`cond_id → branch_kind → [child_labels]`). Existing `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` become DERIVED VIEWS computed from the primary structures. This lets a single edge correctly record entry into multiple arms simultaneously (D13). |
+| **D17 (NEW)** | **Explicit capture-path ungating.** `output_tensors.py:311`, `source_tensors.py:169`, and `graph_traversal.py:67` currently gate `func_call_stack` population on `save_source_context`. Phase 1 unconditionally populates `(file, line_number, func_name, code_firstlineno, code_qualname)` on every captured op. Only the lazy `source_context` / `func_signature` / `code_context` properties remain gated. |
+
+## Data Model
+
+### `FuncCallLocation` (augmented — D14, D17)
+
+```python
+@dataclass
+class FuncCallLocation:
+    file: str
+    line_number: int
+    func_name: str
+    code_firstlineno: int                 # NEW — frame.f_code.co_firstlineno, always populated
+    code_qualname: Optional[str]          # NEW — frame.f_code.co_qualname (3.11+); None pre-3.11
+    # lazy: source_context, func_signature, code_context (still gated on save_source_context)
+```
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                                 # iff bool_context_kind ∈ {"if_test","elif_test"}
+bool_context_kind: Optional[str]                     # 9 kinds + "unknown"
+bool_wrapper_kind: Optional[str]                     # e.g. "bool_cast" when wrapped; else None
+bool_conditional_id: Optional[int]                   # dense; None for non-branch kinds
+
+# Branch attribution (any op)
+conditional_branch_stack: List[Tuple[int, str]]      # [(cond_id, branch_kind), ...] outer→inner
+conditional_branch_depth: int                         # = len(stack)
+
+# PRIMARY per-node arm-child structure (D16)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+    # cond_id → branch_kind → [child labels]
+```
+
+**Preserved (now DERIVED from `cond_branch_children_by_cond`):**
+- `cond_branch_start_children: List[str]` — still the set-of-parents marked by 5d IF-backward flood (UNCHANGED semantics).
+- `cond_branch_then_children: List[str]` — `sorted(set(chain_from_iterable(m["then"] for m in cond_branch_children_by_cond.values() if "then" in m)))`.
+- `cond_branch_elif_children: Dict[int, List[str]]` — aggregate by elif-index across cond_ids.
+- `cond_branch_else_children: List[str]` — analogous.
+
+Also preserved: `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch` (derived `len(conditional_branch_stack) > 0`).
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# Aggregate
+conditional_branch_stacks: List[List[Tuple[int, str]]]     # unique signatures, first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                           # signature → sorted pass numbers
+
+# Per-node cond-id-aware aggregate children (primary — pass-stripped labels)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+```
+
+**Derived views (pass-stripped unions):** `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`.
+
+**Merge rules** (update `_build_layer_logs`):
+- `in_cond_branch`: OR across passes.
+- `conditional_branch_stacks`: unique signatures in first-seen order.
+- `conditional_branch_stack_passes`: accumulate sorted pass numbers per signature.
+- `cond_branch_children_by_cond`: union across passes after stripping `:N` suffix; keep cond_id granularity.
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]            # dense cond_id indexing (D10)
+
+# PRIMARY edge structure (D16)
+conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]
+    # (cond_id, branch_kind) → [(parent, child), ...]
+
+# Rolled-mode pass-divergence (D15)
+conditional_edge_passes: Dict[
+    Tuple[str, str, int, str], List[int]
+]                                                     # (parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted pass numbers
+```
+
+**Preserved (DERIVED from `conditional_arm_edges`):**
+- `conditional_branch_edges: List[Tuple[str, str]]` — IF-edges from 5d (unchanged).
+- `conditional_then_edges: List[Tuple[str, str]]` — `[(p,c) for (cid, bk), edges in conditional_arm_edges.items() if bk=="then" for (p,c) in edges]`.
+- `conditional_elif_edges: List[Tuple[int, int, str, str]]` — `[(cid, int(bk.split("_")[1]), p, c) for (cid, bk), edges if bk.startswith("elif_") for (p,c) in edges]`.
+- `conditional_else_edges: List[Tuple[int, str, str]]` — `[(cid, p, c) for (cid, bk), edges if bk=="else" for (p,c) in edges]`.
+
+`ConditionalEvent`:
+```python
+@dataclass
+class ConditionalEvent:
+    id: int                                                           # dense per-ModelLog
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]
+    test_span: Tuple[int, int]
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int]]                         # "then", "elif_1", ..., "else"
+    branch_test_spans: Dict[str, Tuple[int, int]]                     # "then", "elif_1", ...
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]                                            # labels of bools driving this event
+```
+
+### `constants.py` FIELD_ORDER updates (one commit)
+
+- `LAYER_PASS_LOG_FIELD_ORDER`: add 7 new entries (`bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, `conditional_branch_stack`, `conditional_branch_depth`, `cond_branch_children_by_cond`). Derived fields (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`) stay in FIELD_ORDER — they're materialized for serialization.
+- `MODEL_LOG_FIELD_ORDER`: add 3 new primary entries (`conditional_events`, `conditional_arm_edges`, `conditional_edge_passes`). Derived fields (`conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`) stay.
+- `LAYER_LOG_FIELD_ORDER`: add 4 aggregate entries (`conditional_branch_stacks`, `conditional_branch_stack_passes`, `cond_branch_children_by_cond`, plus the aggregate derived children).
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+    # Returns: (kind, wrapper_kind, conditional_key_or_None, branch_test_kind_or_None)
+def attribute_op(func_call_stack: List[FuncCallLocation]
+                 ) -> List[Tuple[ConditionalKey, str]]: ...
+    # Returns ConditionalKeys, not dense ints. Dense IDs are assigned in Phase 5c.
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+
+ConditionalKey = Tuple[str, int, int, int]   # (file, func_firstlineno, if_stmt_lineno, if_col_offset)
+```
+
+### Postprocess Step 5 restructure (six-phase — revised per D10)
+
+**5a. Build file indexes.**
+For every terminal scalar bool layer, collect filenames from `func_call_stack`. Eagerly build `FileIndex` per file (cache).
+
+**5b. Classify bools (structural keys).**
+For each `is_terminal_bool_layer` scalar bool:
+- Walk frames; call `classify_bool(frame.file, frame.line_number)`; take the most-informative result (innermost non-`unknown` kind).
+- Record on the bool's `LayerPassLog` temporarily:
+  - `bool_context_kind`, `bool_wrapper_kind`, `bool_is_branch`, and a TEMPORARY attribute `_bool_conditional_key` (not in FIELD_ORDER — transient).
+- Collect the set of unique `ConditionalKey`s seen during 5b.
+
+**5c. Materialize events; assign dense IDs; translate keys → ints. (Sole id-assignment step.)**
+- Build `ModelLog.conditional_events` list: for each unique `ConditionalKey` collected in 5b, create a `ConditionalEvent` with a dense `id` (0, 1, 2, ...).
+- Walk every bool layer with `_bool_conditional_key`: set `bool_conditional_id = events_by_key[_bool_conditional_key].id`; register label in `ConditionalEvent.bool_layers`; delete `_bool_conditional_key`.
+- Also translate `parent_conditional_id` fields inside `ConditionalEvent`s that reference other keys.
+- From this point forward, no `ConditionalKey` escapes `ast_branches.py` — only dense `int` IDs are exposed.
+
+**5d. IF backward flood** (PR #127 behavior, now pre-filtered).
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestor parents with `cond_branch_start_children`; emit `conditional_branch_edges`. Unchanged by D13.
+
+**5e. Forward branch attribution + arm edges.**
+For every op:
+- `stack_keys = attribute_op(func_call_stack)` → list of `(ConditionalKey, kind)`.
+- Translate keys to dense IDs via `events_by_key`: `conditional_branch_stack: List[Tuple[int, str]]`.
+- Set `conditional_branch_depth`, update `in_cond_branch`.
+
+For every forward edge `(parent, child)` (ALL edges — D13):
+- Compute set difference `gained = child.stack - parent.stack` (prefix-order, so elements not in parent's stack in order).
+- Each gained `(cond_id, branch_kind)` triggers:
+  - `ModelLog.conditional_arm_edges[(cond_id, branch_kind)].append((parent.label, child.label))`.
+  - `parent.cond_branch_children_by_cond[cond_id][branch_kind].append(child.label)`.
+- If `parent.stack` has entries not in `child.stack` (branch exit / reconvergence): no edge is recorded; valid per Invariant 6.
+
+**5f. Derived-view materialization + `conditional_edge_passes`.**
+- Compute derived fields (`conditional_then_edges`, `cond_branch_then_children`, etc.) from primary cond-id-aware structures.
+- For rolled-mode awareness, record each arm-edge's pass-stripped form: `conditional_edge_passes[(parent_no_pass, child_no_pass, cond_id, branch_kind)].append(pass_num)`; sort lists at the end.
+
+### Classification algorithm (`classify_bool`)
+
+```python
+def classify_bool(filename: str, line: int) -> BoolClassification:
+    idx = get_file_index(filename)
+    if idx is None:
+        return BoolClassification(kind="unknown", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Walk bool consumers whose span contains `line`, innermost outward.
+    # Each consumer has kind ∈ {if_test, elif_test, assert, bool_cast,
+    #                            comprehension_filter, while, ifexp, match_guard}.
+    consumers = [c for c in idx.bool_consumers if c.span.contains(line)]
+    consumers.sort(key=lambda c: c.depth, reverse=True)   # innermost first
+
+    wrapper = None
+    for consumer in consumers:
+        if consumer.kind == "bool_cast" and wrapper is None:
+            wrapper = "bool_cast"
+            continue   # keep walking outward; bool_cast doesn't decide alone
+        if consumer.kind in {"if_test", "elif_test"}:
+            return BoolClassification(
+                kind=consumer.kind,
+                wrapper_kind=wrapper,
+                conditional_key=consumer.conditional_key,
+                branch_test_kind=consumer.branch_test_kind,
+            )
+        # any other consumer wins outright (assert/while/ifexp/comp/match)
+        return BoolClassification(kind=consumer.kind, wrapper_kind=wrapper,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Reached here: maybe a standalone bool_cast with no outer branch
+    if wrapper == "bool_cast":
+        return BoolClassification(kind="bool_cast", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+    return BoolClassification(kind="unknown", wrapper_kind=None,
+                               conditional_key=None, branch_test_kind=None)
+```
+
+### Attribution algorithm (`attribute_op`)
+
+Per frame (shallow → deep):
+1. Scope resolution — try each in order until a hit:
+   - `(filename, code_firstlineno, code_qualname)` exact if qualname non-None;
+   - else `(filename, code_firstlineno, func_name)`;
+   - else smallest function scope containing `line_number`.
+2. Query branch-interval tree at `frame.line_number` → list of `(ConditionalKey, branch_kind, nesting_depth)` sorted by nesting depth asc.
+3. Append to the aggregate stack (deduplicate adjacent).
+
+## Visualization
+
+### Label precedence (Graphviz + dagua bridge)
+
+1. **Arm-entry label** (highest) — edge appears in `conditional_arm_edges[(cond_id, "then")]` / `elif_N` / `else`:
+   - Single-arm: `THEN` / `ELIF N` / `ELSE`.
+   - Multi-arm on same edge (D13 case): composite like `THEN(cond_outer) · THEN(cond_inner)` — concise form to be agreed; default: `N arms`.
+   - Rolled mode with pass divergence (D15): `THEN(1,3) / ELSE(2)` or `mixed`.
+2. **IF label** — edge is in `conditional_branch_edges`.
+3. **Arg labels** — move from `edge_dict["label"]` to `edge_dict["headlabel"]` / `xlabel` so they don't compete.
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+- Refactor existing `edge_dict["label"]` writes (lines ~985-996 and ~1049-1090) into a single `_compute_edge_label(parent, child, model_log)` function implementing the precedence rules.
+- Move argument-name labels off `label` → `headlabel` / `xlabel`.
+
+### Dagua bridge (`torchlens/visualization/dagua_bridge.py`)
+
+- Extend `_classify_forward_edge` to return new edge kinds: `"elif_N"`, `"else"`, `"multi_arm"`, `"mixed_pass"`.
+
+### ELK (`torchlens/visualization/elk_layout.py`)
+
+- Single comment: ELK does not render conditional edge labels.
+
+## Capture / Postprocess Lifecycle (full integration — addresses F4, F9 partials)
+
+Every new label-bearing field must be wired end-to-end. Phase 3 delivers all of this BEFORE Phase 4 (Step 5) can populate data.
+
+### Capture-time defaults (Phase 1)
+
+Files: `torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`, `torchlens/postprocess/graph_traversal.py`.
+- Init every new `LayerPassLog` field with default (empty list, `{}`, `False`, `None`).
+- Remove gating of `func_call_stack` population on `save_source_context` (D17). Populate core fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`) unconditionally. Lazy source-text properties remain gated.
+
+### Raw→final rename (Phase 3, `torchlens/postprocess/labeling.py`)
+
+Extend `_rename_raw_labels_in_place` to rewrite labels in:
+- `conditional_arm_edges` (each `(parent, child)` tuple).
+- `conditional_edge_passes` (keys — positions 0, 1).
+- `conditional_events[*].bool_layers`.
+- `cond_branch_children_by_cond` per `LayerPassLog` (every nested list member).
+- Existing fields (`conditional_branch_edges`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`).
+
+### Cleanup / `keep_unsaved_layers=False` (Phase 3, `torchlens/data_classes/cleanup.py`)
+
+Extend filter logic to scrub every new surface when a label is removed:
+- `conditional_arm_edges`: drop tuples where parent OR child is removed; drop empty keys.
+- `conditional_edge_passes`: drop tuple keys where parent or child is removed.
+- `conditional_events[*].bool_layers`: remove labels.
+- `cond_branch_children_by_cond`: drop removed children; drop empty branch_kind keys; drop empty cond_id keys.
+- `LayerLog.conditional_branch_stack_passes`: unchanged (signatures are cond_id tuples; labels aren't in keys).
+- Also scrub derived views (`cond_branch_then_children`, etc.); they'll be recomputed anyway, but the pruning must be consistent.
+
+### Export (`torchlens/data_classes/interface.py::to_pandas`)
+
+Add columns for: `conditional_branch_depth`, `bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, plus a compact string form of `conditional_branch_stack`.
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+1. **`cond_branch_children_by_cond` ↔ `conditional_arm_edges` bidirectional consistency.**
+   For each `(cond_id, branch_kind) → edges` in `conditional_arm_edges`, every `(parent, child)`: `child ∈ parent.cond_branch_children_by_cond[cond_id][branch_kind]` and vice versa.
+2. **Derived views consistency.**
+   `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` per-node and `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges` on `ModelLog` equal the projections of primary structures.
+3. **Children labels exist in `ModelLog`.**
+4. **Bool classification invariants.**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+   `bool_wrapper_kind is not None` ⟹ `bool_context_kind ∈ {"if_test", "elif_test", "bool_cast"}`.
+5. **Conditional event references are valid.**
+   Every `cond_id` in any stack entry, `bool_conditional_id`, `conditional_arm_edges` key, or `cond_branch_children_by_cond` key has matching `ConditionalEvent.id`.
+6. **Stack monotonicity on every parent→child edge (REVISED).**
+   Exactly one of: child.stack extends parent.stack (entry); parent.stack extends child.stack (exit/reconvergence); stacks equal. Non-prefix reorderings are invalid.
+7. **Elif contiguity on `ConditionalEvent` (per-event, not per-node).**
+   `branch_ranges` and `branch_test_spans` keys for elif arms are contiguous from `elif_1`. Per-node `cond_branch_children_by_cond[cid]` may be sparse — that's legal.
+8. **`bool_layers` back-references (NEW).**
+   For every `ConditionalEvent.bool_layers`: each label exists, and each referenced layer's `bool_conditional_id` equals the event's `id`.
+9. **`LayerLog` aggregate consistency (NEW).**
+   `LayerLog.conditional_branch_stacks` equals exactly the set of distinct `LayerPassLog.conditional_branch_stack` values from that layer's passes.
+   `LayerLog.conditional_branch_stack_passes[sig]` equals the sorted list of pass numbers for which that signature appeared.
+10. **`conditional_edge_passes` exactness (NEW).**
+    For every `(parent_no_pass, child_no_pass, cond_id, branch_kind) → [pass_nums]`:
+    - `pass_nums` is sorted ascending and has no duplicates.
+    - For each `pass_num` there exists an unrolled edge `(parent:pass_num, child:pass_num)` in `conditional_arm_edges[(cond_id, branch_kind)]`.
+    - Every unrolled edge in `conditional_arm_edges` is represented somewhere in `conditional_edge_passes`.
+11. **No orphan `_bool_conditional_key` (NEW, dev-mode).**
+    After 5c, no `LayerPassLog` has a `_bool_conditional_key` attribute. Enforced in dev mode to catch incomplete 5c migrations.
+
+## Tests
+
+### New file `tests/test_conditional_branches.py` + models in `tests/example_models.py` (or dedicated new file if size warrants)
+
+**Baseline / positive:**
+- `SimpleIfElseModel` / `ElifLadderModel` / `NestedIfThenIfModel` / `NestedInElseModel` / `MultilinePredicateModel` — verify THEN/ELIF/ELSE edges, `conditional_events` entries, branch_ranges correctness.
+
+**Branch-entry via non-predicate ancestors (D13):**
+- `BranchUsesOnlyParameterModel` — `if c: y = self.bias + 1`. Assert `self.bias → y` appears in `conditional_arm_edges[(cid, "then")]`.
+- `BranchUsesOnlyConstantModel` — analogous with a constant.
+- **`MultiArmEntryNestedModel` (NEW — Finding 2):** `if A: if B: y = self.bias + 1`. Assert the single `self.bias → y` edge appears in BOTH `conditional_arm_edges[(outer_id, "then")]` AND `conditional_arm_edges[(inner_id, "then")]`, and `self.bias.cond_branch_children_by_cond` has both `outer_id` and `inner_id` mapping to `[y]`. Verify derived `cond_branch_then_children` also lists `y` (uniquely, not twice).
+
+**Wrapped bool (F2 resolution):**
+- `IfBoolCastModel` — `if bool(x.sum() > 0):`. Assert `bool_is_branch=True`, `bool_context_kind="if_test"`, `bool_wrapper_kind="bool_cast"`.
+
+**Multi-pass / rolled (D15):**
+- `LoopedIfAlternatingModel` — `for i: if i%2`. Per-pass stacks differ; aggregate has 2 signatures.
+- `AlternatingRecurrentIfModel` — recurrent, THEN pass 1 / ELSE pass 2.
+- **`RolledMixedArmModel` (strengthened — F7 resolution):** Assert `ModelLog.conditional_edge_passes` has entries with non-trivial pass lists. Assert rolled renderer output (graphviz+dagua) contains a composite label. **Post-cleanup check:** after `keep_unsaved_layers=False`, assert no pruned labels appear in `conditional_edge_passes` keys.
+
+**Reconvergence (F5):**
+- `ReconvergingBranchesModel` — `if c: x=a else: x=b; y=f(x)`. Invariant 6 passes. Assert `y.conditional_branch_stack == []` and both parents' stacks were non-empty.
+
+**Scope resolution (D14):**
+- `NestedHelperSameNameModel` — two local `helper()` functions, same name, different branches. Assert attribution uses `code_firstlineno`; verify `bool_conditional_id` differs between the two helpers' if-statements.
+- **`NestedQualnameModel` (NEW — replaces LambdaBranchModel):** `class Outer: def forward(self): def helper(self): if cond: op() return helper(self)` — nested function named `helper` with a distinct `code_qualname` from a method also named `helper` elsewhere. Assert attribution distinguishes them via `code_qualname`.
+- `DecoratedForwardModel` — decorator on forward. Graceful degradation OR correct attribution.
+
+**False positives — non-branch bools:**
+- `AssertTensorCondModel`, `BoolCastOnlyModel`, `TernaryIfExpModel`, `ComprehensionIfModel`, `WhileLoopModel`, `MatchGuardModel`.
+
+**Compound / negation / walrus:**
+- `NotIfModel`, `AndOrIfModel`, `WalrusIfModel`.
+
+**Documented false negatives (no attribution):**
+- `PythonBoolModel`, `ItemScalarizationModel`, `TorchWhereModel`, `ShapePredicateModel`.
+
+**save_source_context gating (F1 resolution — STRENGTHENED):**
+- **`SaveSourceContextOffModel` (strengthened):** `save_source_context=False`. Assert `func_call_stack` is NON-EMPTY on every captured op and each `FuncCallLocation` has non-None `file`, `line_number`, `code_firstlineno`. Branch attribution populated; source_context lazy property empty.
+- **`SaveSourceContextOffAssertModel`:** `save_source_context=False` + `assert tensor_cond`. No false-positive IF edge.
+
+**Field-lifecycle integration (F4 resolution — STRENGTHENED):**
+- **`KeepUnsavedLayersFalseModel` (strengthened):** `keep_unsaved_layers=False` with conditionals. Assert NO removed label appears in:
+  - `conditional_arm_edges` (tuples).
+  - `conditional_edge_passes` (tuple keys).
+  - `conditional_events[*].bool_layers`.
+  - `cond_branch_children_by_cond` (any nested list).
+  - All derived views.
+- `ToPandasConditionalModel` — DataFrame has all conditional columns populated.
+
+**Visualization label precedence (NEW — F8 confirmation):**
+- **`BranchEntryWithArgLabelModel` (NEW):** branch-entry edge that ALSO has an argument label. Assert renderer output shows branch label in `label` slot and arg label in `headlabel`/`xlabel`. Test both graphviz and dagua bridge.
+
+**Smoke:** `@pytest.mark.smoke` on `SimpleIfElseModel`, `ElifLadderModel`.
+
+## Backward Compatibility
+
+- Every existing field retained with identical external semantics.
+- Old fields materialized as derived views from primary cond-id-aware structures. Serialization includes both primary and derived (FIELD_ORDER includes both).
+- `in_cond_branch` remains a direct field; recomputed from `conditional_branch_stack`.
+- `FIELD_ORDER` updates in single commit.
+- Pickle compat: `__setstate__` default-fill for 1 prior minor version. If primary structures are missing on load, reconstruct from legacy derived fields where possible (best-effort for N-1 compat; newer loaders prefer primary).
+
+## Implementation Phases
+
+Each phase gate: tier-1 smoke passes. Tier-2 at phases 4, 6, 9. Tier-3 before PR.
+
+1. **Foundation: fields + capture ungating.**
+   - Add all new fields to `LayerPassLog`, `LayerLog`, `ModelLog`, `FuncCallLocation` + `FIELD_ORDER` updates + defaults.
+   - Ungate `func_call_stack` population in `output_tensors.py`, `source_tensors.py`, `graph_traversal.py` (D17).
+   - Populate `code_firstlineno`, `code_qualname` in stack capture (`utils/introspection.py`).
+   - Gate: existing test suite passes unchanged; new fields are empty on every op.
+2. **AST module.**
+   - Write `ast_branches.py` (FileIndex, ConditionalRecord, BoolConsumer index, branch interval trees, classify_bool, attribute_op, cache management).
+   - Unit tests on synthetic source snippets covering all 9 bool-context kinds, flattened elif chains, nested ifs, ternary, match guards, etc.
+   - Gate: `ast_branches` tests pass in isolation.
+3. **Lifecycle wiring (upstream of Step 5 integration).**
+   - Extend `labeling.py::_rename_raw_labels_in_place` for every new field.
+   - Extend `cleanup.py` for every new field.
+   - Extend `interface.py::to_pandas` with new columns.
+   - Integration test: synthetic model with new fields pre-populated manually; `keep_unsaved_layers=False` + `to_pandas()` round-trip.
+   - Gate: lifecycle tests pass.
+4. **Postprocess Step 5 integration (6 phases 5a-5f).**
+   - Restructure `control_flow.py`. 5c is the sole key→id translation.
+   - Wire to `ast_branches.py`.
+   - Remove old post-validation (D12).
+   - Gate: new integration test with `SimpleIfElseModel` passes end-to-end.
+5. **Multi-pass merge + `conditional_edge_passes`.**
+   - Update `_build_layer_logs` for aggregate fields.
+   - Populate `ModelLog.conditional_edge_passes`.
+   - Gate: `AlternatingRecurrentIfModel`, `RolledMixedArmModel` pass.
+6. **Invariants.**
+   - Add 11 checks to `validation/invariants.py`.
+   - Wire into `validate_forward_pass`.
+   - Gate: all tests still pass; invariants catch deliberately-corrupted metadata in unit tests.
+7. **Graphviz rendering.**
+   - Refactor to `_compute_edge_label` precedence function.
+   - Move arg labels to `headlabel`/`xlabel`.
+   - Implement multi-arm and rolled-mixed labels.
+   - Gate: visual-diff regression check on existing aesthetic tests.
+8. **Dagua bridge.**
+   - Extend `_classify_forward_edge` with new edge kinds.
+   - Gate: existing dagua tests still pass; new conditional coverage.
+9. **Integration tests.**
+   - All ~30 conditional tests with assertions.
+   - Gate: all pass; coverage of every listed scenario.
+10. **Documentation.**
+    - Update `AGENTS.md` conditional section.
+    - Update `architecture.md` Step 5 section.
+    - User-facing limitations page.
+11. **PR.**
+    - Migration notes with before/after field table.
+    - Compat matrix.
+
+## Deliverables
+
+- 1 new module (~400 lines): `torchlens/postprocess/ast_branches.py`.
+- Modified modules (~11):
+  - `torchlens/data_classes/{layer_pass_log,layer_log,model_log,func_call_location,cleanup,interface}.py`
+  - `torchlens/constants.py`
+  - `torchlens/postprocess/{control_flow,labeling,graph_traversal}.py`
+  - `torchlens/capture/{source_tensors,output_tensors}.py`
+  - `torchlens/utils/introspection.py`
+  - `torchlens/validation/invariants.py`
+  - `torchlens/visualization/{rendering,dagua_bridge,elk_layout}.py`
+- Tests: `tests/test_conditional_branches.py` (~550 lines), ~32 new models.
+- Docs: AGENTS.md, architecture.md, user limitations.
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch | All field additions in one commit. |
+| R2 | Multi-pass regressions on recurrent tests | `AlternatingRecurrentIfModel` / `RolledMixedArmModel` in Phase 5 test gate. |
+| R3 | Source resolution fragile on decorated/wrapped forwards | Use `frame.f_code.co_firstlineno`/`co_qualname` (D14); don't rely on `inspect.getsourcefile(module_class)`. |
+| R4 | `linecache` stale source after edit | Cache by `(filename, mtime)`; invalidate on mismatch; fail-soft to `unknown`. |
+| R5 | Pre-classification misses a syntactic form → silent `unknown` | Unit tests for every kind; dev-mode assertion: line inside `If.test` span but classifier returns `unknown` → log warning. |
+| R6 | Interval tree perf on huge `forward` | Parse once; O(log k + d) query; benchmark `HugeNestedIfModel` in Phase 2. |
+| R7 | Old pickled ModelLogs fail | `__setstate__` default-fill; document window. |
+| R8 | Arg-label relocation to `headlabel` breaks existing aesthetic tests | Visual-diff gate in Phase 7; gate behind a flag if regressions appear. |
+| R9 | D16 primary structure inflates memory on large models | Benchmark; cond-id keys compact; derived views computed on-demand only. |
+| R10 | D17 ungating breaks something depending on empty `func_call_stack` | Phase 1 tests check `func_call_stack` non-empty; audit any code reading it. |
+| R11 | Multi-arm entry edges produce confusing visuals | Dedicated test (`MultiArmEntryNestedModel`) + label precedence rule + user docs. |
+
+## Open Questions for Architect / User
+
+1. ELK: document as unsupported (default). Confirm?
+2. Multi-arm edge label format: `THEN(cond_outer) · THEN(cond_inner)` vs `2 arms` vs a renderer-side decision. Default: readable form with cond name/IDs.
+3. Pickle compat window: 1 prior minor version (default).
+4. v2 scope confirmation: ternary + while + column offsets + ELK parity.
+5. Test model count: ~32. OK?
+6. `code_qualname` fallback on Python 3.9/3.10 (no `co_qualname`): accept identity-fallback to `code_firstlineno` + `func_name`?
+
+---
+
+## CHANGELOG v2 → v3 (addresses `review_round_2.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R2-F1 Conditional ID contract (BLOCKER) | D10 revised + Step 5c is sole key→id translator + `ConditionalKey` explicit type. |
+| R2-F2 Multi-entry edges cond-id-blind (HIGH) | D16 new: `conditional_arm_edges` + `cond_branch_children_by_cond` primary; legacy fields derived. |
+| R2-F3 `code_qualname` not used in matching (MEDIUM) | D14 revised: exact match on `(filename, code_firstlineno, code_qualname)` first; fallbacks explicit. |
+| R2-F4 Cleanup incomplete for D15 (MEDIUM) | Lifecycle/Cleanup section enumerates every new surface; `KeepUnsavedLayersFalseModel` strengthened. |
+| R2 F1 partial (save_source_context capture path) | D17 new: Phase 1 explicitly ungates `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `SaveSourceContextOffModel` strengthened to assert non-empty `func_call_stack`. |
+| R2 F9 partial | Covered by D14 revision and test swap (NestedQualnameModel replacing LambdaBranchModel). |
+| R2 missing invariants (bool_layers back-ref, aggregate stacks, edge_passes exactness) | Invariants 8, 9, 10, 11 added. |
+| R2 phase ordering | Phases reordered: lifecycle wiring is Phase 3, BEFORE Step 5 integration (Phase 4). Phase 1 gate no longer references Phase 5 deliverables. |
+| R2 test gaps | Added `MultiArmEntryNestedModel`, `NestedQualnameModel`, `BranchEntryWithArgLabelModel`; strengthened `SaveSourceContextOffModel`, `KeepUnsavedLayersFalseModel`, `RolledMixedArmModel`. |

--- a/.project-context/plans/if-else-attribution/plan_v5.md
+++ b/.project-context/plans/if-else-attribution/plan_v5.md
@@ -1,0 +1,575 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Version:** v5 (post-adversarial-review-4)
+**History:** `plan_v1.md`, `plan_v2.md`, `plan_v3.md`, `review_round_{1,2,3,4}.md`.
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering (`assert`, `bool()` cast, comprehension filters, `while`, `ifexp`, `match` guards, `unknown`).
+3. Explicit per-pass branch representation on `LayerPassLog`; lossless aggregate representation on `LayerLog` and `ModelLog` (including rolled-edge pass divergence and multi-arm-entry edges).
+4. Render THEN / ELIF / ELSE edge labels in Graphviz (primary) + dagua bridge; ELK documented as unsupported.
+5. Comprehensive tests for positive paths, every documented limitation, multi-pass divergence, multi-arm entry, and lifecycle integration.
+6. Strict backward compatibility — no existing field is renamed or removed; old fields derived from new primary structures.
+
+## Out-of-Scope for v1 (explicit limitations)
+
+**Non-branch bool consumers — classified, not attributed:**
+- Ternary (`x if cond else y`) → `bool_context_kind="ifexp"`
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast NOT nested inside `If.test` → `bool_context_kind="bool_cast"`
+
+`bool(tensor_cond)` nested *inside* an `If.test`/elif test IS a branch (see D3).
+
+**Source-unavailable — graceful degradation (`bool_context_kind="unknown"`, no attribution):**
+- Jupyter / REPL cells, `exec`/`eval`, `.pyc`-only, native `.so` modules
+- `torch.compile`, `torch.jit.script`, `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel`
+- Monkey-patched `forward` where source resolves to the patch
+
+**Documented false negatives — torchlens cannot see:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred to v2 release:**
+- Column-offset disambiguation for multi-op lines
+- `ast.IfExp` full attribution
+- `while` loop body attribution
+- ELK conditional edge rendering
+
+## Decisions (architect-level)
+
+| # | Decision |
+|---|----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` (Python AST has no `Elif` node). |
+| D3 | Pre-classify every terminal scalar bool by enclosing AST context. `bool(x)` nested inside `If.test`/elif test normalizes to `if_test`/`elif_test` + `bool_wrapper_kind="bool_cast"`. Standalone `bool(x)` → `bool_cast`. |
+| D4 | Attribution uses full `func_call_stack` (every frame), not just the user-facing frame. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregates via unique signatures + pass map. |
+| D6 | Keep every existing field; old fields populated from new primary structures as derived views. |
+| D7 | AST logic lives in new module `torchlens/postprocess/ast_branches.py`. |
+| D8 | File cache keyed by `(filename, stat.st_mtime_ns)`. Process-local. |
+| D9 | AST classification runs whenever `(file, line)` is on `func_call_stack` (which is always, after D18 ungates capture). `save_source_context` only gates rich source-text capture. |
+| **D10 (REVISED)** | Two-stage identifier scheme: `ConditionalKey = (file, func_firstlineno, if_stmt_lineno, if_col_offset)` is the AST-internal structural key used in Phases 5a/5b/5e. Phase 5c is the **sole** step that materializes `ModelLog.conditional_events` and assigns dense per-`ModelLog` `conditional_id: int`. Phase 5c rewrites all `bool_conditional_key` → `bool_conditional_id` and all stack entries `(ConditionalKey, kind)` → `(cond_id, kind)` in one pass. No other code outside `ast_branches.py` sees `ConditionalKey`. |
+| D11 | Graphviz gets ELIF/ELSE labels with explicit precedence (see Visualization). Dagua bridge extended. ELK gets a comment. |
+| D12 | Old post-validation ("clear IF markings if no `ast.If`") is REMOVED; pre-classification makes it unnecessary. |
+| D13 | Branch-entry edges detected by diffing `conditional_branch_stack` across EVERY forward edge, not only edges from branch-start nodes. Legitimate: a single edge can gain MULTIPLE stack entries simultaneously (e.g., `self.bias → x` inside nested `if A: if B:` enters both outer and inner THEN). All gained entries are recorded. |
+| **D14 (REVISED v2)** | `FuncCallLocation` augmented with `code_firstlineno: int` (always) + `code_qualname: Optional[str]` (Python 3.11+; None on 3.9/3.10). Scope resolution in `attribute_op`: (1) exact match on `(filename, code_firstlineno, code_qualname)` if qualname non-None; (2) exact match on `(filename, code_firstlineno, func_name)` IFF exactly one scope matches; (3) if step 2 has zero or multiple candidates, **FAIL CLOSED** — return empty branch stack for that frame (no "smallest containing scope" heuristic). This prevents silent wrong attribution on same-line nested defs/lambdas, especially under 3.9/3.10 where `code_qualname` is absent. |
+| D15 | `ModelLog.conditional_edge_passes` maps `(parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted List[int]` of pass numbers. Rolled-mode renderers consult this for mixed-arm labels. |
+| **D16 (NEW)** | **Cond-id-aware primary structures.** Primary arm-edge representation is `ModelLog.conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]` (`(cond_id, branch_kind) → [(parent, child)]`). Primary per-node child list is `LayerPassLog.cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]` (`cond_id → branch_kind → [child_labels]`). Existing `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` become DERIVED VIEWS computed from the primary structures. This lets a single edge correctly record entry into multiple arms simultaneously (D13). |
+| **D17 (REVISED v2)** | **Explicit capture-path ungating + fully-specified disabled-source state on `FuncCallLocation`.** Phase 1 unconditionally populates identity fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`, `source_loading_enabled`) on every captured op at `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `source_loading_enabled` mirrors `save_source_context` at capture time. **When `source_loading_enabled=False`:** (a) all lazy backing fields are initialized to stable empty/None values at construction time without any disk access — `source_context=""`, `code_context=""`, `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`; (b) `_frame_func_obj` is cleared (set to `None`) immediately at construction rather than deferred to the unreachable `_load_source()` call, avoiding pickle fragility with nested/local function objects; (c) all accessors and `__repr__`/`__len__`/`__getitem__` consult `source_loading_enabled` and return the pre-initialized empty values without calling `_load_source()`. This is a FULLY-SPECIFIED state, not just a read-time guard. D17 is distinct from D9 (AST classification needs identity fields only). |
+
+## Data Model
+
+### `FuncCallLocation` (augmented — D14, D17)
+
+```python
+@dataclass
+class FuncCallLocation:
+    file: str
+    line_number: int
+    func_name: str
+    code_firstlineno: int                 # NEW — frame.f_code.co_firstlineno, always populated
+    code_qualname: Optional[str]          # NEW — frame.f_code.co_qualname (3.11+); None pre-3.11
+    source_loading_enabled: bool          # NEW — mirrors save_source_context at capture time
+    # When source_loading_enabled=False, construction must:
+    #   1) initialize every lazy backing field to empty/None without disk access:
+    #        source_context="", code_context="", code_context_labeled="",
+    #        call_line="", num_context_lines=0, func_signature=None, func_docstring=None
+    #   2) clear _frame_func_obj to None immediately (do not wait for _load_source())
+    #      -> prevents pickle fragility with nested/local function objects
+    # Accessors (source_context, code_context, code_context_labeled, call_line,
+    #  num_context_lines, func_signature, func_docstring) AND __repr__/__len__/__getitem__
+    # consult source_loading_enabled and return pre-initialized empties without
+    # calling _load_source().
+```
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                                 # iff bool_context_kind ∈ {"if_test","elif_test"}
+bool_context_kind: Optional[str]                     # 9 kinds + "unknown"
+bool_wrapper_kind: Optional[str]                     # e.g. "bool_cast" when wrapped; else None
+bool_conditional_id: Optional[int]                   # dense; None for non-branch kinds
+
+# Branch attribution (any op)
+conditional_branch_stack: List[Tuple[int, str]]      # [(cond_id, branch_kind), ...] outer→inner
+conditional_branch_depth: int                         # = len(stack)
+
+# PRIMARY per-node arm-child structure (D16)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+    # cond_id → branch_kind → [child labels]
+```
+
+**Preserved (now DERIVED from `cond_branch_children_by_cond`):**
+- `cond_branch_start_children: List[str]` — still the set-of-parents marked by 5d IF-backward flood (UNCHANGED semantics).
+- `cond_branch_then_children: List[str]` — `sorted(set(chain_from_iterable(m["then"] for m in cond_branch_children_by_cond.values() if "then" in m)))`.
+- `cond_branch_elif_children: Dict[int, List[str]]` — aggregate by elif-index across cond_ids.
+- `cond_branch_else_children: List[str]` — analogous.
+
+Also preserved: `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch` (derived `len(conditional_branch_stack) > 0`).
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# Aggregate
+conditional_branch_stacks: List[List[Tuple[int, str]]]     # unique signatures, first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                           # signature → sorted pass numbers
+
+# Per-node cond-id-aware aggregate children (primary — pass-stripped labels)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+```
+
+**Derived views (pass-stripped unions):** `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`.
+
+**Merge rules** (update `_build_layer_logs`):
+- `in_cond_branch`: OR across passes.
+- `conditional_branch_stacks`: unique signatures in first-seen order.
+- `conditional_branch_stack_passes`: accumulate sorted pass numbers per signature.
+- `cond_branch_children_by_cond`: union across passes after stripping `:N` suffix; keep cond_id granularity.
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]            # dense cond_id indexing (D10)
+
+# PRIMARY edge structure (D16)
+conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]
+    # (cond_id, branch_kind) → [(parent, child), ...]
+
+# Rolled-mode pass-divergence (D15)
+conditional_edge_passes: Dict[
+    Tuple[str, str, int, str], List[int]
+]                                                     # (parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted pass numbers
+```
+
+**Preserved (DERIVED from `conditional_arm_edges`):**
+- `conditional_branch_edges: List[Tuple[str, str]]` — IF-edges from 5d (unchanged).
+- `conditional_then_edges: List[Tuple[str, str]]` — `[(p,c) for (cid, bk), edges in conditional_arm_edges.items() if bk=="then" for (p,c) in edges]`.
+- `conditional_elif_edges: List[Tuple[int, int, str, str]]` — `[(cid, int(bk.split("_")[1]), p, c) for (cid, bk), edges if bk.startswith("elif_") for (p,c) in edges]`.
+- `conditional_else_edges: List[Tuple[int, str, str]]` — `[(cid, p, c) for (cid, bk), edges if bk=="else" for (p,c) in edges]`.
+
+`ConditionalEvent`:
+```python
+@dataclass
+class ConditionalEvent:
+    id: int                                                           # dense per-ModelLog
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]
+    test_span: Tuple[int, int]
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int]]                         # "then", "elif_1", ..., "else"
+    branch_test_spans: Dict[str, Tuple[int, int]]                     # "then", "elif_1", ...
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]                                            # labels of bools driving this event
+```
+
+### `constants.py` FIELD_ORDER updates (one commit)
+
+- `LAYER_PASS_LOG_FIELD_ORDER`: add 7 new entries (`bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, `conditional_branch_stack`, `conditional_branch_depth`, `cond_branch_children_by_cond`). Derived fields (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`) stay in FIELD_ORDER — they're materialized for serialization.
+- `MODEL_LOG_FIELD_ORDER`: add 3 new primary entries (`conditional_events`, `conditional_arm_edges`, `conditional_edge_passes`). Derived fields (`conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`) stay.
+- `LAYER_LOG_FIELD_ORDER`: add 4 aggregate entries (`conditional_branch_stacks`, `conditional_branch_stack_passes`, `cond_branch_children_by_cond`, plus the aggregate derived children).
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+    # Returns: (kind, wrapper_kind, conditional_key_or_None, branch_test_kind_or_None)
+def attribute_op(func_call_stack: List[FuncCallLocation]
+                 ) -> List[Tuple[ConditionalKey, str]]: ...
+    # Returns ConditionalKeys, not dense ints. Dense IDs are assigned in Phase 5c.
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+
+ConditionalKey = Tuple[str, int, int, int]   # (file, func_firstlineno, if_stmt_lineno, if_col_offset)
+```
+
+### Postprocess Step 5 restructure (six-phase — revised per D10)
+
+**5a. Build file indexes.**
+For every terminal scalar bool layer, collect filenames from `func_call_stack`. Eagerly build `FileIndex` per file (cache).
+
+**5b. Classify bools (structural keys).**
+For each `is_terminal_bool_layer` scalar bool, **iterating in `ModelLog.layer_list` order for determinism**:
+- Walk frames; call `classify_bool(frame.file, frame.line_number)`; take the most-informative result (innermost non-`unknown` kind).
+- Record on the bool's `LayerPassLog` temporarily:
+  - `bool_context_kind`, `bool_wrapper_kind`, `bool_is_branch`, and a TEMPORARY attribute `_bool_conditional_key` (not in FIELD_ORDER — transient).
+- Collect unique `ConditionalKey`s in **first-seen order** (insertion-ordered dict, not a set).
+
+**5c. Materialize events; assign dense IDs; translate keys → ints. (Sole id-assignment step.)**
+- Build `ModelLog.conditional_events` list: for each unique `ConditionalKey` in the **first-seen order from 5b**, create a `ConditionalEvent` with a dense `id` (0, 1, 2, ...). This guarantees stable `cond_id` assignment across runs on the same model/input.
+- Walk every bool layer with `_bool_conditional_key`: set `bool_conditional_id = events_by_key[_bool_conditional_key].id`; register label in `ConditionalEvent.bool_layers`; delete `_bool_conditional_key`.
+- Also translate `parent_conditional_id` fields inside `ConditionalEvent`s that reference other keys.
+- From this point forward, no `ConditionalKey` escapes `ast_branches.py` — only dense `int` IDs are exposed.
+
+**5d. IF backward flood** (PR #127 behavior, now pre-filtered).
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestor parents with `cond_branch_start_children`; emit `conditional_branch_edges`. Unchanged by D13.
+
+**5e. Forward branch attribution + arm edges.**
+For every op:
+- `stack_keys = attribute_op(func_call_stack)` → list of `(ConditionalKey, kind)`.
+- Translate keys to dense IDs: for each `(key, kind)`, if `key ∈ events_by_key` emit `(events_by_key[key].id, kind)`; otherwise **DROP** the entry. A `ConditionalKey` may be returned by `attribute_op` that was never materialized in 5c — this happens when an op is lexically inside an `if` whose predicate was not driven by a captured tensor bool (the documented false-negative scope: `if self.training:`, `if x.shape[0] > 0:`, `if tensor.item() > 0:`). Dropping unmaterialized keys keeps the attribution consistent with the event set.
+- Assemble `conditional_branch_stack: List[Tuple[int, str]]` from the surviving entries.
+- Set `conditional_branch_depth`, update `in_cond_branch`.
+
+For every forward edge `(parent, child)` (ALL edges — D13):
+- Compute set difference `gained = child.stack - parent.stack` (prefix-order, so elements not in parent's stack in order).
+- Each gained `(cond_id, branch_kind)` triggers:
+  - `ModelLog.conditional_arm_edges[(cond_id, branch_kind)].append((parent.label, child.label))`.
+  - `parent.cond_branch_children_by_cond[cond_id][branch_kind].append(child.label)`.
+- If `parent.stack` has entries not in `child.stack` (branch exit / reconvergence): no edge is recorded; valid per Invariant 6.
+
+**5f. Derived-view materialization + `conditional_edge_passes`.**
+- Compute derived fields (`conditional_then_edges`, `cond_branch_then_children`, etc.) from primary cond-id-aware structures.
+- For rolled-mode awareness, record each arm-edge's pass-stripped form: `conditional_edge_passes[(parent_no_pass, child_no_pass, cond_id, branch_kind)].append(pass_num)`; sort lists at the end.
+
+### Classification algorithm (`classify_bool`)
+
+```python
+def classify_bool(filename: str, line: int) -> BoolClassification:
+    idx = get_file_index(filename)
+    if idx is None:
+        return BoolClassification(kind="unknown", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Walk bool consumers whose span contains `line`, innermost outward.
+    # Each consumer has kind ∈ {if_test, elif_test, assert, bool_cast,
+    #                            comprehension_filter, while, ifexp, match_guard}.
+    consumers = [c for c in idx.bool_consumers if c.span.contains(line)]
+    consumers.sort(key=lambda c: c.depth, reverse=True)   # innermost first
+
+    wrapper = None
+    for consumer in consumers:
+        if consumer.kind == "bool_cast" and wrapper is None:
+            wrapper = "bool_cast"
+            continue   # keep walking outward; bool_cast doesn't decide alone
+        if consumer.kind in {"if_test", "elif_test"}:
+            return BoolClassification(
+                kind=consumer.kind,
+                wrapper_kind=wrapper,
+                conditional_key=consumer.conditional_key,
+                branch_test_kind=consumer.branch_test_kind,
+            )
+        # any other consumer wins outright (assert/while/ifexp/comp/match)
+        return BoolClassification(kind=consumer.kind, wrapper_kind=wrapper,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Reached here: maybe a standalone bool_cast with no outer branch
+    if wrapper == "bool_cast":
+        return BoolClassification(kind="bool_cast", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+    return BoolClassification(kind="unknown", wrapper_kind=None,
+                               conditional_key=None, branch_test_kind=None)
+```
+
+### Attribution algorithm (`attribute_op`)
+
+Per frame (shallow → deep):
+1. Scope resolution per D14:
+   - `(filename, code_firstlineno, code_qualname)` exact match if `code_qualname` is non-None; otherwise
+   - `(filename, code_firstlineno, func_name)` match IFF exactly one scope in the file index matches; otherwise
+   - **FAIL CLOSED**: skip this frame's contribution entirely (no branch-interval query, no heuristic, no smallest-scope guess). Emit a debug counter for diagnostics.
+2. If scope was resolved: query branch-interval tree at `frame.line_number` → list of `(ConditionalKey, branch_kind, nesting_depth)` sorted by nesting depth asc.
+3. Append to the aggregate stack (deduplicate adjacent).
+
+## Visualization
+
+### Label precedence (Graphviz + dagua bridge)
+
+1. **Arm-entry label** (highest) — edge appears in `conditional_arm_edges[(cond_id, "then")]` / `elif_N` / `else`:
+   - Single-arm: `THEN` / `ELIF N` / `ELSE`.
+   - Multi-arm on same edge (D13 case): composite like `THEN(cond_outer) · THEN(cond_inner)` — concise form to be agreed; default: `N arms`.
+   - Rolled mode with pass divergence (D15): `THEN(1,3) / ELSE(2)` or `mixed`.
+2. **IF label** — edge is in `conditional_branch_edges`.
+3. **Arg labels** — move from `edge_dict["label"]` to `edge_dict["headlabel"]` / `xlabel` so they don't compete.
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+- Refactor existing `edge_dict["label"]` writes (lines ~985-996 and ~1049-1090) into a single `_compute_edge_label(parent, child, model_log)` function implementing the precedence rules.
+- Move argument-name labels off `label` → `headlabel` / `xlabel`.
+
+### Dagua bridge (`torchlens/visualization/dagua_bridge.py`)
+
+- Extend `_classify_forward_edge` to return new edge kinds: `"elif_N"`, `"else"`, `"multi_arm"`, `"mixed_pass"`.
+
+### ELK (`torchlens/visualization/elk_layout.py`)
+
+- Single comment: ELK does not render conditional edge labels.
+
+## Capture / Postprocess Lifecycle (full integration — addresses F4, F9 partials)
+
+Every new label-bearing field must be wired end-to-end. Phase 3 delivers all of this BEFORE Phase 4 (Step 5) can populate data.
+
+### Capture-time defaults (Phase 1)
+
+Files: `torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`, `torchlens/postprocess/graph_traversal.py`.
+- Init every new `LayerPassLog` field with default (empty list, `{}`, `False`, `None`).
+- Remove gating of `func_call_stack` population on `save_source_context` (D17). Populate core fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`) unconditionally. Lazy source-text properties remain gated.
+
+### Raw→final rename (Phase 3, `torchlens/postprocess/labeling.py`)
+
+Extend `_rename_raw_labels_in_place` to rewrite labels in:
+- `conditional_arm_edges` (each `(parent, child)` tuple).
+- `conditional_edge_passes` (keys — positions 0, 1).
+- `conditional_events[*].bool_layers`.
+- `cond_branch_children_by_cond` per `LayerPassLog` (every nested list member).
+- Existing fields (`conditional_branch_edges`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`).
+
+### Cleanup / `keep_unsaved_layers=False` (Phase 3, `torchlens/data_classes/cleanup.py`)
+
+Extend filter logic to scrub every new surface when a label is removed:
+- `conditional_arm_edges`: drop tuples where parent OR child is removed; drop empty keys.
+- `conditional_edge_passes`: drop tuple keys where parent or child is removed.
+- `conditional_events[*].bool_layers`: remove labels.
+- `cond_branch_children_by_cond`: drop removed children; drop empty branch_kind keys; drop empty cond_id keys.
+- `LayerLog.conditional_branch_stack_passes`: unchanged (signatures are cond_id tuples; labels aren't in keys).
+- Also scrub derived views (`cond_branch_then_children`, etc.); they'll be recomputed anyway, but the pruning must be consistent.
+
+### Export (`torchlens/data_classes/interface.py::to_pandas`)
+
+Add columns for: `conditional_branch_depth`, `bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, plus a compact string form of `conditional_branch_stack`.
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+1. **`cond_branch_children_by_cond` ↔ `conditional_arm_edges` bidirectional consistency.**
+   For each `(cond_id, branch_kind) → edges` in `conditional_arm_edges`, every `(parent, child)`: `child ∈ parent.cond_branch_children_by_cond[cond_id][branch_kind]` and vice versa.
+2. **Derived views consistency.**
+   `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` per-node and `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges` on `ModelLog` equal the projections of primary structures.
+3. **Children labels exist in `ModelLog`.**
+4. **Bool classification invariants.**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+   `bool_wrapper_kind is not None` ⟹ `bool_context_kind ∈ {"if_test", "elif_test", "bool_cast"}`.
+5. **Conditional event references are valid.**
+   Every `cond_id` in any stack entry, `bool_conditional_id`, `conditional_arm_edges` key, or `cond_branch_children_by_cond` key has matching `ConditionalEvent.id`.
+6. **Stack monotonicity on every parent→child edge (REVISED).**
+   Exactly one of: child.stack extends parent.stack (entry); parent.stack extends child.stack (exit/reconvergence); stacks equal. Non-prefix reorderings are invalid.
+7. **Elif contiguity on `ConditionalEvent` (per-event, not per-node).**
+   `branch_ranges` and `branch_test_spans` keys for elif arms are contiguous from `elif_1`. Per-node `cond_branch_children_by_cond[cid]` may be sparse — that's legal.
+8. **`bool_layers` back-references (NEW).**
+   For every `ConditionalEvent.bool_layers`: each label exists, and each referenced layer's `bool_conditional_id` equals the event's `id`.
+9. **`LayerLog` aggregate consistency (NEW).**
+   `LayerLog.conditional_branch_stacks` equals exactly the set of distinct `LayerPassLog.conditional_branch_stack` values from that layer's passes.
+   `LayerLog.conditional_branch_stack_passes[sig]` equals the sorted list of pass numbers for which that signature appeared.
+10. **`conditional_edge_passes` exactness (NEW).**
+    For every `(parent_no_pass, child_no_pass, cond_id, branch_kind) → [pass_nums]`:
+    - `pass_nums` is sorted ascending and has no duplicates.
+    - For each `pass_num` there exists an unrolled edge `(parent:pass_num, child:pass_num)` in `conditional_arm_edges[(cond_id, branch_kind)]`.
+    - Every unrolled edge in `conditional_arm_edges` is represented somewhere in `conditional_edge_passes`.
+11. **No orphan `_bool_conditional_key` (NEW, dev-mode).**
+    After 5c, no `LayerPassLog` has a `_bool_conditional_key` attribute. Enforced in dev mode to catch incomplete 5c migrations.
+12. **`LayerLog.cond_branch_children_by_cond` aggregate exactness (NEW).**
+    For every `LayerLog`, `cond_branch_children_by_cond` equals the pass-stripped union of `cond_branch_children_by_cond` across its constituent `LayerPassLog` passes. No cond_id or branch_kind present in any pass is missing from the aggregate; no extraneous entries appear.
+13. **Legacy IF-view consistency (NEW).**
+    `conditional_branch_edges` ↔ `cond_branch_start_children` bidirectionally consistent: every `(parent, bool_label)` tuple in `conditional_branch_edges` has `bool_label ∈ parent.cond_branch_start_children`; and every label in any node's `cond_branch_start_children` corresponds to a tuple with that node as parent in `conditional_branch_edges`.
+
+## Tests
+
+### New file `tests/test_conditional_branches.py` + models in `tests/example_models.py` (or dedicated new file if size warrants)
+
+**Baseline / positive:**
+- `SimpleIfElseModel` / `ElifLadderModel` / `NestedIfThenIfModel` / `NestedInElseModel` / `MultilinePredicateModel` — verify THEN/ELIF/ELSE edges, `conditional_events` entries, branch_ranges correctness.
+
+**Branch-entry via non-predicate ancestors (D13):**
+- `BranchUsesOnlyParameterModel` — `if c: y = self.bias + 1`. Assert `self.bias → y` appears in `conditional_arm_edges[(cid, "then")]`.
+- `BranchUsesOnlyConstantModel` — analogous with a constant.
+- **`MultiArmEntryNestedModel` (NEW — Finding 2):** `if A: if B: y = self.bias + 1`. Assert the single `self.bias → y` edge appears in BOTH `conditional_arm_edges[(outer_id, "then")]` AND `conditional_arm_edges[(inner_id, "then")]`, and `self.bias.cond_branch_children_by_cond` has both `outer_id` and `inner_id` mapping to `[y]`. Verify derived `cond_branch_then_children` also lists `y` (uniquely, not twice).
+
+**Wrapped bool (F2 resolution):**
+- `IfBoolCastModel` — `if bool(x.sum() > 0):`. Assert `bool_is_branch=True`, `bool_context_kind="if_test"`, `bool_wrapper_kind="bool_cast"`.
+
+**Multi-pass / rolled (D15):**
+- `LoopedIfAlternatingModel` — `for i: if i%2`. Per-pass stacks differ; aggregate has 2 signatures.
+- `AlternatingRecurrentIfModel` — recurrent, THEN pass 1 / ELSE pass 2.
+- **`RolledMixedArmModel` (strengthened — F7 resolution):** Assert `ModelLog.conditional_edge_passes` has entries with non-trivial pass lists AND each `(parent_no_pass, child_no_pass, cond_id, branch_kind) → pass_nums` is exactly verifiable — sorted ascending, no duplicates, every `pass_num` corresponds to a real unrolled edge in `conditional_arm_edges[(cond_id, branch_kind)]` on that pass. Assert rolled renderer output (graphviz+dagua) contains a composite label. **D13×D15 interaction:** add a companion scenario where the mixed-pass arm edge is ALSO a multi-arm-entry edge (nested conditional taking different inner arms across passes); assert both dimensions survive end-to-end. **Post-cleanup check:** after `keep_unsaved_layers=False`, assert no pruned labels appear in `conditional_edge_passes` keys.
+
+**Reconvergence (F5):**
+- `ReconvergingBranchesModel` — `if c: x=a else: x=b; y=f(x)`. Invariant 6 passes. Assert `y.conditional_branch_stack == []` and both parents' stacks were non-empty.
+
+**Scope resolution (D14):**
+- `NestedHelperSameNameModel` — two local `helper()` functions, same name, different branches. Assert attribution uses `code_firstlineno`; verify `bool_conditional_id` differs between the two helpers' if-statements.
+- **`NestedQualnameModel` (NEW — replaces LambdaBranchModel):** `class Outer: def forward(self): def helper(self): if cond: op() return helper(self)` — nested function named `helper` with a distinct `code_qualname` from a method also named `helper` elsewhere. Assert attribution distinguishes them via `code_qualname` (Python 3.11+).
+- **`SameLineNestedDefModel` (NEW — D14 fail-closed):** Two local defs with the same `func_name` and same `code_firstlineno` (degenerate case, forceable via `exec` or metaprogramming). Assert D14 step 3 triggers: returns empty branch stack for that frame rather than silently picking one; no `conditional_branch_edges` or arm edges are emitted from that site. Also run this under Python 3.9/3.10 CI (where `code_qualname` is None) to verify fail-closed behavior across supported versions.
+- `DecoratedForwardModel` — decorator on forward. Graceful degradation OR correct attribution.
+
+**False positives — non-branch bools:**
+- `AssertTensorCondModel`, `BoolCastOnlyModel`, `TernaryIfExpModel`, `ComprehensionIfModel`, `WhileLoopModel`, `MatchGuardModel`.
+
+**Compound / negation / walrus:**
+- `NotIfModel`, `AndOrIfModel`, `WalrusIfModel`.
+
+**Documented false negatives (no attribution):**
+- `PythonBoolModel`, `ItemScalarizationModel`, `TorchWhereModel`, `ShapePredicateModel`.
+
+**save_source_context gating (F1 resolution — STRENGTHENED):**
+- **`SaveSourceContextOffModel` (strengthened):** `save_source_context=False`. Assert `func_call_stack` is NON-EMPTY on every captured op; each `FuncCallLocation` has non-None `file`, `line_number`, `code_firstlineno`, and `source_loading_enabled=False`. Assert every lazy accessor returns the documented empty state without triggering a load: `loc.source_context == ""`, `loc.code_context == ""`, `loc.code_context_labeled == ""`, `loc.call_line == ""`, `loc.num_context_lines == 0`, `loc.func_signature is None`, `loc.func_docstring is None`, `len(loc) == 0`, and `repr(loc)` contains no source text. Assert `loc._frame_func_obj is None` (cleared at construction per D17). Branch attribution populated correctly. **Pickle round-trip:** also pickle/unpickle a `ModelLog` captured with `save_source_context=False`; unpickled log must round-trip cleanly (exercises the `_frame_func_obj` retention fix).
+- **`SaveSourceContextOffAssertModel`:** `save_source_context=False` + `assert tensor_cond`. No false-positive IF edge.
+
+**Field-lifecycle integration (F4 resolution — STRENGTHENED):**
+- **`KeepUnsavedLayersFalseModel` (strengthened):** `keep_unsaved_layers=False` with conditionals. Assert NO removed label appears anywhere in:
+  - `conditional_arm_edges` (tuples).
+  - `conditional_edge_passes` (tuple keys).
+  - `conditional_events[*].bool_layers`.
+  - `cond_branch_children_by_cond` (any nested list) — check on BOTH `LayerPassLog` AND `LayerLog` aggregates.
+  - `conditional_branch_stack_passes` values on `LayerLog`.
+  - All derived views (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`).
+- `ToPandasConditionalModel` — DataFrame has all conditional columns populated.
+
+**Visualization label precedence (NEW — F8 confirmation):**
+- **`BranchEntryWithArgLabelModel` (NEW):** branch-entry edge that ALSO has an argument label. Assert graphviz renderer output shows branch label in `edge_dict["label"]` and arg label in `edge_dict["headlabel"]` (or `xlabel`) — they do not collide. Assert dagua bridge classifies the edge (`_classify_forward_edge` returns `"then"`, not `"default"`) AND the emitted dagua edge metadata carries BOTH the branch kind and the arg label in distinct fields (specification: branch kind in `edge.type`, arg label in a separate `arg_label` attribute that the dagua bridge adds alongside `edge.label`).
+
+**Smoke:** `@pytest.mark.smoke` on `SimpleIfElseModel`, `ElifLadderModel`.
+
+## Backward Compatibility
+
+- Every existing field retained with identical external semantics.
+- Old fields materialized as derived views from primary cond-id-aware structures. Serialization includes both primary and derived (FIELD_ORDER includes both).
+- `in_cond_branch` remains a direct field; recomputed from `conditional_branch_stack`.
+- `FIELD_ORDER` updates in single commit.
+- Pickle compat: `__setstate__` default-fill for 1 prior minor version. If primary structures are missing on load, reconstruct from legacy derived fields where possible (best-effort for N-1 compat; newer loaders prefer primary).
+
+## Implementation Phases
+
+Each phase gate: tier-1 smoke passes. Tier-2 at phases 4, 6, 9. Tier-3 before PR.
+
+1. **Foundation: fields + capture ungating.**
+   - Add all new fields to `LayerPassLog`, `LayerLog`, `ModelLog`, `FuncCallLocation` + `FIELD_ORDER` updates + defaults.
+   - Ungate `func_call_stack` population in `output_tensors.py`, `source_tensors.py`, `graph_traversal.py` (D17).
+   - Populate `code_firstlineno`, `code_qualname` in stack capture (`utils/introspection.py`).
+   - Gate: existing test suite passes unchanged. New **conditional-branch** fields remain default (empty list/dict, `False`, `None`). New `FuncCallLocation` core identity fields (`code_firstlineno`, `code_qualname`, `source_loading_enabled`) ARE populated per D17; verify via test that `func_call_stack` is non-empty even when `save_source_context=False`, and that lazy source-text properties still return empty/None in that case.
+2. **AST module.**
+   - Write `ast_branches.py` (FileIndex, ConditionalRecord, BoolConsumer index, branch interval trees, classify_bool, attribute_op, cache management).
+   - Unit tests on synthetic source snippets covering all 9 bool-context kinds, flattened elif chains, nested ifs, ternary, match guards, etc.
+   - Gate: `ast_branches` tests pass in isolation.
+3. **Lifecycle wiring (upstream of Step 5 integration).**
+   - Extend `labeling.py::_rename_raw_labels_in_place` for every new field.
+   - Extend `cleanup.py` for every new field.
+   - Extend `interface.py::to_pandas` with new columns.
+   - Integration test: synthetic model with new fields pre-populated manually; `keep_unsaved_layers=False` + `to_pandas()` round-trip.
+   - Gate: lifecycle tests pass.
+4. **Postprocess Step 5 integration (6 phases 5a-5f).**
+   - Restructure `control_flow.py`. 5c is the sole key→id translation.
+   - Wire to `ast_branches.py`.
+   - Remove old post-validation (D12).
+   - Gate: new integration test with `SimpleIfElseModel` passes end-to-end.
+5. **Multi-pass merge + `conditional_edge_passes`.**
+   - Update `_build_layer_logs` for aggregate fields.
+   - Populate `ModelLog.conditional_edge_passes`.
+   - Gate: `AlternatingRecurrentIfModel`, `RolledMixedArmModel` pass.
+6. **Invariants.**
+   - Add 11 checks to `validation/invariants.py`.
+   - Wire into `validate_forward_pass`.
+   - Gate: all tests still pass; invariants catch deliberately-corrupted metadata in unit tests.
+7. **Graphviz rendering.**
+   - Refactor to `_compute_edge_label` precedence function.
+   - Move arg labels to `headlabel`/`xlabel`.
+   - Implement multi-arm and rolled-mixed labels.
+   - Gate: visual-diff regression check on existing aesthetic tests.
+8. **Dagua bridge.**
+   - Extend `_classify_forward_edge` with new edge kinds.
+   - Gate: existing dagua tests still pass; new conditional coverage.
+9. **Integration tests.**
+   - All ~30 conditional tests with assertions.
+   - Gate: all pass; coverage of every listed scenario.
+10. **Documentation.**
+    - Update `AGENTS.md` conditional section.
+    - Update `architecture.md` Step 5 section.
+    - Update `torchlens/user_funcs.py` docstrings: `save_source_context=False` no longer zeros `func_call_stack` — only source-text properties are gated (D17). Any README/API doc references to this behavior get the same update.
+    - User-facing limitations page.
+11. **PR.**
+    - Migration notes with before/after field table.
+    - Compat matrix.
+
+## Deliverables
+
+- 1 new module (~400 lines): `torchlens/postprocess/ast_branches.py`.
+- Modified modules (~11):
+  - `torchlens/data_classes/{layer_pass_log,layer_log,model_log,func_call_location,cleanup,interface}.py`
+  - `torchlens/constants.py`
+  - `torchlens/postprocess/{control_flow,labeling,graph_traversal}.py`
+  - `torchlens/capture/{source_tensors,output_tensors}.py`
+  - `torchlens/utils/introspection.py`
+  - `torchlens/validation/invariants.py`
+  - `torchlens/visualization/{rendering,dagua_bridge,elk_layout}.py`
+- Tests: `tests/test_conditional_branches.py` (~550 lines), ~32 new models.
+- Docs: AGENTS.md, architecture.md, user limitations.
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch | All field additions in one commit. |
+| R2 | Multi-pass regressions on recurrent tests | `AlternatingRecurrentIfModel` / `RolledMixedArmModel` in Phase 5 test gate. |
+| R3 | Source resolution fragile on decorated/wrapped forwards | Use `frame.f_code.co_firstlineno`/`co_qualname` (D14); don't rely on `inspect.getsourcefile(module_class)`. |
+| R4 | `linecache` stale source after edit | Cache by `(filename, mtime)`; invalidate on mismatch; fail-soft to `unknown`. |
+| R5 | Pre-classification misses a syntactic form → silent `unknown` | Unit tests for every kind; dev-mode assertion: line inside `If.test` span but classifier returns `unknown` → log warning. |
+| R6 | Interval tree perf on huge `forward` | Parse once; O(log k + d) query; benchmark `HugeNestedIfModel` in Phase 2. |
+| R7 | Old pickled ModelLogs fail | `__setstate__` default-fill; document window. |
+| R8 | Arg-label relocation to `headlabel` breaks existing aesthetic tests | Visual-diff gate in Phase 7; gate behind a flag if regressions appear. |
+| R9 | D16 primary structure inflates memory on large models | Benchmark; cond-id keys compact; derived views computed on-demand only. |
+| R10 | D17 ungating breaks something depending on empty `func_call_stack` | Phase 1 tests check `func_call_stack` non-empty; audit any code reading it. |
+| R11 | Multi-arm entry edges produce confusing visuals | Dedicated test (`MultiArmEntryNestedModel`) + label precedence rule + user docs. |
+
+## Open Questions for Architect / User
+
+1. ELK: document as unsupported (default). Confirm?
+2. Multi-arm edge label format: `THEN(cond_outer) · THEN(cond_inner)` vs `2 arms` vs a renderer-side decision. Default: readable form with cond name/IDs.
+3. Pickle compat window: 1 prior minor version (default).
+4. v2 scope confirmation: ternary + while + column offsets + ELK parity.
+5. Test model count: ~32. OK?
+6. `code_qualname` fallback on Python 3.9/3.10 (no `co_qualname`): accept identity-fallback to `code_firstlineno` + `func_name`?
+
+---
+
+## CHANGELOG v2 → v3 (addresses `review_round_2.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R2-F1 Conditional ID contract (BLOCKER) | D10 revised + Step 5c is sole key→id translator + `ConditionalKey` explicit type. |
+| R2-F2 Multi-entry edges cond-id-blind (HIGH) | D16 new: `conditional_arm_edges` + `cond_branch_children_by_cond` primary; legacy fields derived. |
+| R2-F3 `code_qualname` not used in matching (MEDIUM) | D14 revised: exact match on `(filename, code_firstlineno, code_qualname)` first; fallbacks explicit. |
+| R2-F4 Cleanup incomplete for D15 (MEDIUM) | Lifecycle/Cleanup section enumerates every new surface; `KeepUnsavedLayersFalseModel` strengthened. |
+| R2 F1 partial (save_source_context capture path) | D17 new: Phase 1 explicitly ungates `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `SaveSourceContextOffModel` strengthened to assert non-empty `func_call_stack`. |
+| R2 F9 partial | Covered by D14 revision and test swap (NestedQualnameModel replacing LambdaBranchModel). |
+| R2 missing invariants (bool_layers back-ref, aggregate stacks, edge_passes exactness) | Invariants 8, 9, 10, 11 added. |
+| R2 phase ordering | Phases reordered: lifecycle wiring is Phase 3, BEFORE Step 5 integration (Phase 4). Phase 1 gate no longer references Phase 5 deliverables. |
+| R2 test gaps | Added `MultiArmEntryNestedModel`, `NestedQualnameModel`, `BranchEntryWithArgLabelModel`; strengthened `SaveSourceContextOffModel`, `KeepUnsavedLayersFalseModel`, `RolledMixedArmModel`. |
+
+## CHANGELOG v3 → v4 (addresses `review_round_3.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R3-F1 5e can attribute via unmaterialized keys (BLOCKER) | Step 5e spec now explicitly DROPS `ConditionalKey`s not in `events_by_key`; rationale and test link to documented false-negative scope. |
+| R3-F2 D17 promises ungated stack but `FuncCallLocation` lazy props eagerly load (HIGH) | D17 revised; `FuncCallLocation` gains `source_loading_enabled: bool`; all lazy props + `__repr__`/`__len__`/`__getitem__` must fail closed when disabled. Phase 1 gate wording updated. |
+| R3-F3 D14 fallback can still silently pick wrong scope on 3.9/3.10 (MEDIUM) | D14 revised v2: step 2 requires unique match; step 3 FAILS CLOSED (no smallest-containing-scope heuristic). New `SameLineNestedDefModel` test exercises the fail-closed path. |
+| R3-F4 Invariants incomplete (MEDIUM) | Added invariants 12 (`LayerLog.cond_branch_children_by_cond` aggregate exactness) and 13 (legacy IF-view consistency). |
+| R3-F5 Phase 1 gate imprecise (MEDIUM) | Gate wording split: conditional-branch fields stay default; `FuncCallLocation` identity fields populated; verify via explicit sub-test. |
+| R3-F6 Nondeterministic `cond_id` assignment (MEDIUM) | 5b/5c spec updated: iterate `ModelLog.layer_list` order, collect keys in first-seen order via insertion-ordered dict (not set). |
+| R3-F7 Docs miss user_funcs.py (LOW) | Phase 10 adds `user_funcs.py` docstring updates + README/API doc corrections. |
+| R3 test gaps (MultiArm/NestedQualname/BranchEntry/SaveSrcOff/KeepUnsaved/RolledMixed) | All six test rows strengthened with concrete assertion lists; `SameLineNestedDefModel` added. |
+
+## CHANGELOG v4 → v5 (addresses `review_round_4.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R4-F1 `source_loading_enabled` incomplete for full `FuncCallLocation` surface (HIGH) | D17 revised v2 + data model expanded to enumerate all 7 lazy accessors (`source_context`, `code_context`, `code_context_labeled`, `call_line`, `num_context_lines`, `func_signature`, `func_docstring`). When disabled, all lazy backing fields are initialized empty at construction (no disk access); `_frame_func_obj` is cleared at construction to prevent pickle fragility with nested/local functions. |
+| R4-F2 `attribute_op` subsection contradicts D14 v2 (MEDIUM) | Algorithm subsection updated: no more "smallest containing scope" heuristic; step 3 fails closed (skips frame) matching D14 v2. |
+| R4-F3 `source_context == []` type contradicts current `str` API (LOW) | `SaveSourceContextOffModel` assertions aligned to `str` types: `source_context == ""` etc. Pickle round-trip also added. |
+| R4 test gap: disabled-source accessor coverage | Strengthened `SaveSourceContextOffModel` now asserts every lazy accessor + `_frame_func_obj is None` + pickle round-trip. |

--- a/.project-context/plans/if-else-attribution/plan_v6.md
+++ b/.project-context/plans/if-else-attribution/plan_v6.md
@@ -1,0 +1,585 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Version:** v6 (post-adversarial-review-5)
+**History:** `plan_v{1,2,3}.md`, `plan_v5.md`, `review_round_{1,2,3,4,5}.md`.
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering (`assert`, `bool()` cast, comprehension filters, `while`, `ifexp`, `match` guards, `unknown`).
+3. Explicit per-pass branch representation on `LayerPassLog`; lossless aggregate representation on `LayerLog` and `ModelLog` (including rolled-edge pass divergence and multi-arm-entry edges).
+4. Render THEN / ELIF / ELSE edge labels in Graphviz (primary) + dagua bridge; ELK documented as unsupported.
+5. Comprehensive tests for positive paths, every documented limitation, multi-pass divergence, multi-arm entry, and lifecycle integration.
+6. Strict backward compatibility — no existing field is renamed or removed; old fields derived from new primary structures.
+
+## Out-of-Scope for v1 (explicit limitations)
+
+**Non-branch bool consumers — classified, not attributed:**
+- Ternary (`x if cond else y`) → `bool_context_kind="ifexp"`
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast NOT nested inside `If.test` → `bool_context_kind="bool_cast"`
+
+`bool(tensor_cond)` nested *inside* an `If.test`/elif test IS a branch (see D3).
+
+**Source-unavailable — graceful degradation (`bool_context_kind="unknown"`, no attribution):**
+- Jupyter / REPL cells, `exec`/`eval`, `.pyc`-only, native `.so` modules
+- `torch.compile`, `torch.jit.script`, `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel`
+- Monkey-patched `forward` where source resolves to the patch
+
+**Documented false negatives — torchlens cannot see:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred to v2 release:**
+- Column-offset disambiguation for multi-op lines
+- `ast.IfExp` full attribution
+- `while` loop body attribution
+- ELK conditional edge rendering
+
+## Decisions (architect-level)
+
+| # | Decision |
+|---|----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` (Python AST has no `Elif` node). |
+| D3 | Pre-classify every terminal scalar bool by enclosing AST context. `bool(x)` nested inside `If.test`/elif test normalizes to `if_test`/`elif_test` + `bool_wrapper_kind="bool_cast"`. Standalone `bool(x)` → `bool_cast`. |
+| D4 | Attribution uses full `func_call_stack` (every frame), not just the user-facing frame. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregates via unique signatures + pass map. |
+| D6 | Keep every existing field; old fields populated from new primary structures as derived views. |
+| D7 | AST logic lives in new module `torchlens/postprocess/ast_branches.py`. |
+| D8 | File cache keyed by `(filename, stat.st_mtime_ns)`. Process-local. |
+| D9 | AST classification runs whenever `(file, line)` is on `func_call_stack` (which is always, after D18 ungates capture). `save_source_context` only gates rich source-text capture. |
+| **D10 (REVISED)** | Two-stage identifier scheme: `ConditionalKey = (file, func_firstlineno, if_stmt_lineno, if_col_offset)` is the AST-internal structural key used in Phases 5a/5b/5e. Phase 5c is the **sole** step that materializes `ModelLog.conditional_events` and assigns dense per-`ModelLog` `conditional_id: int`. Phase 5c rewrites all `bool_conditional_key` → `bool_conditional_id` and all stack entries `(ConditionalKey, kind)` → `(cond_id, kind)` in one pass. No other code outside `ast_branches.py` sees `ConditionalKey`. |
+| D11 | Graphviz gets ELIF/ELSE labels with explicit precedence (see Visualization). Dagua bridge extended. ELK gets a comment. |
+| D12 | Old post-validation ("clear IF markings if no `ast.If`") is REMOVED; pre-classification makes it unnecessary. |
+| D13 | Branch-entry edges detected by diffing `conditional_branch_stack` across EVERY forward edge, not only edges from branch-start nodes. Legitimate: a single edge can gain MULTIPLE stack entries simultaneously (e.g., `self.bias → x` inside nested `if A: if B:` enters both outer and inner THEN). All gained entries are recorded. |
+| **D14 (REVISED v2)** | `FuncCallLocation` augmented with `code_firstlineno: int` (always) + `code_qualname: Optional[str]` (Python 3.11+; None on 3.9/3.10). Scope resolution in `attribute_op`: (1) exact match on `(filename, code_firstlineno, code_qualname)` if qualname non-None; (2) exact match on `(filename, code_firstlineno, func_name)` IFF exactly one scope matches; (3) if step 2 has zero or multiple candidates, **FAIL CLOSED** — return empty branch stack for that frame (no "smallest containing scope" heuristic). This prevents silent wrong attribution on same-line nested defs/lambdas, especially under 3.9/3.10 where `code_qualname` is absent. |
+| D15 | `ModelLog.conditional_edge_passes` maps `(parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted List[int]` of pass numbers. Rolled-mode renderers consult this for mixed-arm labels. |
+| **D16 (NEW)** | **Cond-id-aware primary structures.** Primary arm-edge representation is `ModelLog.conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]` (`(cond_id, branch_kind) → [(parent, child)]`). Primary per-node child list is `LayerPassLog.cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]` (`cond_id → branch_kind → [child_labels]`). Existing `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` become DERIVED VIEWS computed from the primary structures. This lets a single edge correctly record entry into multiple arms simultaneously (D13). |
+| **D17 (REVISED v3)** | **Explicit capture-path ungating + disabled-source state identical to the existing "no source available" contract on `FuncCallLocation`.** Phase 1 unconditionally populates identity fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`, `source_loading_enabled`) on every captured op at `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `source_loading_enabled` mirrors `save_source_context` at capture time. **When `source_loading_enabled=False`:** construction sets `_source_loaded=True` immediately and initializes the same observable state that `_load_source()` produces when source can't be loaded (see `func_call_location.py:149-153,165-169`): `code_context=None`, `source_context="None"` (literal 4-char string — current API), `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`, `_frame_func_obj=None`. Accessors and dunder methods inherit current no-source behavior verbatim — `len==0`, `__getitem__` raises `IndexError`, `__repr__` ends with "code: source unavailable" — with zero disk access. Clearing `_frame_func_obj` at construction eliminates pickle fragility with nested/local function objects (previously only released inside `_load_source()`). This reuses the already-existing no-source contract for complete API/test backward compatibility. D17 is distinct from D9 (AST classification needs identity fields only). |
+
+## Data Model
+
+### `FuncCallLocation` (augmented — D14, D17)
+
+```python
+@dataclass
+class FuncCallLocation:
+    file: str
+    line_number: int
+    func_name: str
+    code_firstlineno: int                 # NEW — frame.f_code.co_firstlineno, always populated
+    code_qualname: Optional[str]          # NEW — frame.f_code.co_qualname (3.11+); None pre-3.11
+    source_loading_enabled: bool          # NEW — mirrors save_source_context at capture time
+    # When source_loading_enabled=False, construction sets _source_loaded=True
+    # immediately with the no-source state already produced by _load_source() when
+    # source can't be loaded (see func_call_location.py:149-153, 165-169):
+    #   code_context=None
+    #   source_context="None"       # literal 4-char string (current API)
+    #   code_context_labeled=""
+    #   call_line=""
+    #   num_context_lines=0
+    #   func_signature=None
+    #   func_docstring=None
+    #   _frame_func_obj=None        # cleared at construction -> safe for pickle
+    # Existing accessor semantics carry over: len(loc)==0,
+    # loc[i] raises IndexError, repr(loc) ends with "code: source unavailable".
+    # No disk access ever; _load_source is effectively never entered.
+```
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                                 # iff bool_context_kind ∈ {"if_test","elif_test"}
+bool_context_kind: Optional[str]                     # 9 kinds + "unknown"
+bool_wrapper_kind: Optional[str]                     # e.g. "bool_cast" when wrapped; else None
+bool_conditional_id: Optional[int]                   # dense; None for non-branch kinds
+
+# Branch attribution (any op)
+conditional_branch_stack: List[Tuple[int, str]]      # [(cond_id, branch_kind), ...] outer→inner
+conditional_branch_depth: int                         # = len(stack)
+
+# PRIMARY per-node arm-child structure (D16)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+    # cond_id → branch_kind → [child labels]
+```
+
+**Preserved (now DERIVED from `cond_branch_children_by_cond`):**
+- `cond_branch_start_children: List[str]` — still the set-of-parents marked by 5d IF-backward flood (UNCHANGED semantics).
+- `cond_branch_then_children: List[str]` — `sorted(set(chain_from_iterable(m["then"] for m in cond_branch_children_by_cond.values() if "then" in m)))`.
+- `cond_branch_elif_children: Dict[int, List[str]]` — aggregate by elif-index across cond_ids.
+- `cond_branch_else_children: List[str]` — analogous.
+
+Also preserved: `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch` (derived `len(conditional_branch_stack) > 0`).
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# Aggregate
+conditional_branch_stacks: List[List[Tuple[int, str]]]     # unique signatures, first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                           # signature → sorted pass numbers
+
+# Per-node cond-id-aware aggregate children (primary — pass-stripped labels)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+```
+
+**Derived views (pass-stripped unions):** `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`.
+
+**Merge rules** (update `_build_layer_logs`):
+- `in_cond_branch`: OR across passes.
+- `conditional_branch_stacks`: unique signatures in first-seen order.
+- `conditional_branch_stack_passes`: accumulate sorted pass numbers per signature.
+- `cond_branch_children_by_cond`: union across passes after stripping `:N` suffix; keep cond_id granularity.
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]            # dense cond_id indexing (D10)
+
+# PRIMARY edge structure (D16)
+conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]
+    # (cond_id, branch_kind) → [(parent, child), ...]
+
+# Rolled-mode pass-divergence (D15)
+conditional_edge_passes: Dict[
+    Tuple[str, str, int, str], List[int]
+]                                                     # (parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted pass numbers
+```
+
+**Preserved (DERIVED from `conditional_arm_edges`):**
+- `conditional_branch_edges: List[Tuple[str, str]]` — IF-edges from 5d (unchanged).
+- `conditional_then_edges: List[Tuple[str, str]]` — `[(p,c) for (cid, bk), edges in conditional_arm_edges.items() if bk=="then" for (p,c) in edges]`.
+- `conditional_elif_edges: List[Tuple[int, int, str, str]]` — `[(cid, int(bk.split("_")[1]), p, c) for (cid, bk), edges if bk.startswith("elif_") for (p,c) in edges]`.
+- `conditional_else_edges: List[Tuple[int, str, str]]` — `[(cid, p, c) for (cid, bk), edges if bk=="else" for (p,c) in edges]`.
+
+`ConditionalEvent`:
+```python
+@dataclass
+class ConditionalEvent:
+    id: int                                                           # dense per-ModelLog
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]
+    test_span: Tuple[int, int]
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int]]                         # "then", "elif_1", ..., "else"
+    branch_test_spans: Dict[str, Tuple[int, int]]                     # "then", "elif_1", ...
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]                                            # labels of bools driving this event
+```
+
+### `constants.py` FIELD_ORDER updates (one commit)
+
+- `LAYER_PASS_LOG_FIELD_ORDER`: add 7 new entries (`bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, `conditional_branch_stack`, `conditional_branch_depth`, `cond_branch_children_by_cond`). Derived fields (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`) stay in FIELD_ORDER — they're materialized for serialization.
+- `MODEL_LOG_FIELD_ORDER`: add 3 new primary entries (`conditional_events`, `conditional_arm_edges`, `conditional_edge_passes`). Derived fields (`conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`) stay.
+- `LAYER_LOG_FIELD_ORDER`: add 4 aggregate entries (`conditional_branch_stacks`, `conditional_branch_stack_passes`, `cond_branch_children_by_cond`, plus the aggregate derived children).
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+    # Returns: (kind, wrapper_kind, conditional_key_or_None, branch_test_kind_or_None)
+def attribute_op(func_call_stack: List[FuncCallLocation]
+                 ) -> List[Tuple[ConditionalKey, str]]: ...
+    # Returns ConditionalKeys, not dense ints. Dense IDs are assigned in Phase 5c.
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+
+ConditionalKey = Tuple[str, int, int, int]   # (file, func_firstlineno, if_stmt_lineno, if_col_offset)
+```
+
+### Postprocess Step 5 restructure (six-phase — revised per D10)
+
+**5a. Build file indexes.**
+For every terminal scalar bool layer, collect filenames from `func_call_stack`. Eagerly build `FileIndex` per file (cache).
+
+**5b. Classify bools (structural keys).**
+For each `is_terminal_bool_layer` scalar bool, **iterating in `ModelLog.layer_list` order for determinism**:
+- Walk frames; call `classify_bool(frame.file, frame.line_number)`; take the most-informative result (innermost non-`unknown` kind).
+- Record on the bool's `LayerPassLog` temporarily:
+  - `bool_context_kind`, `bool_wrapper_kind`, `bool_is_branch`, and a TEMPORARY attribute `_bool_conditional_key` (not in FIELD_ORDER — transient).
+- Collect unique `ConditionalKey`s in **first-seen order** (insertion-ordered dict, not a set).
+
+**5c. Materialize events; assign dense IDs; translate keys → ints. (Sole id-assignment step.)**
+- Build `ModelLog.conditional_events` list: for each unique `ConditionalKey` in the **first-seen order from 5b**, create a `ConditionalEvent` with a dense `id` (0, 1, 2, ...). This guarantees stable `cond_id` assignment across runs on the same model/input.
+- Walk every bool layer with `_bool_conditional_key`: set `bool_conditional_id = events_by_key[_bool_conditional_key].id`; register label in `ConditionalEvent.bool_layers`; delete `_bool_conditional_key`.
+- Also translate `parent_conditional_id` fields inside `ConditionalEvent`s that reference other keys.
+- From this point forward, no `ConditionalKey` escapes `ast_branches.py` — only dense `int` IDs are exposed.
+
+**5d. IF backward flood** (PR #127 behavior, now pre-filtered).
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestor parents with `cond_branch_start_children`; emit `conditional_branch_edges`. Unchanged by D13.
+
+**5e. Forward branch attribution + arm edges.**
+For every op:
+- `stack_keys = attribute_op(func_call_stack)` → list of `(ConditionalKey, kind)`.
+- Translate keys to dense IDs: for each `(key, kind)`, if `key ∈ events_by_key` emit `(events_by_key[key].id, kind)`; otherwise **DROP** the entry. A `ConditionalKey` may be returned by `attribute_op` that was never materialized in 5c — this happens when an op is lexically inside an `if` whose predicate was not driven by a captured tensor bool (the documented false-negative scope: `if self.training:`, `if x.shape[0] > 0:`, `if tensor.item() > 0:`). Dropping unmaterialized keys keeps the attribution consistent with the event set.
+- Assemble `conditional_branch_stack: List[Tuple[int, str]]` from the surviving entries.
+- Set `conditional_branch_depth`, update `in_cond_branch`.
+
+For every forward edge `(parent, child)` (ALL edges — D13):
+- Compute set difference `gained = child.stack - parent.stack` (prefix-order, so elements not in parent's stack in order).
+- Each gained `(cond_id, branch_kind)` triggers:
+  - `ModelLog.conditional_arm_edges[(cond_id, branch_kind)].append((parent.label, child.label))`.
+  - `parent.cond_branch_children_by_cond[cond_id][branch_kind].append(child.label)`.
+- If `parent.stack` has entries not in `child.stack` (branch exit / reconvergence): no edge is recorded; valid per Invariant 6.
+
+**5f. Derived-view materialization + `conditional_edge_passes`.**
+- Compute derived fields (`conditional_then_edges`, `cond_branch_then_children`, etc.) from primary cond-id-aware structures.
+- For rolled-mode awareness, record each arm-edge's pass-stripped form: `conditional_edge_passes[(parent_no_pass, child_no_pass, cond_id, branch_kind)].append(pass_num)`; sort lists at the end.
+
+### Classification algorithm (`classify_bool`)
+
+```python
+def classify_bool(filename: str, line: int) -> BoolClassification:
+    idx = get_file_index(filename)
+    if idx is None:
+        return BoolClassification(kind="unknown", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Walk bool consumers whose span contains `line`, innermost outward.
+    # Each consumer has kind ∈ {if_test, elif_test, assert, bool_cast,
+    #                            comprehension_filter, while, ifexp, match_guard}.
+    consumers = [c for c in idx.bool_consumers if c.span.contains(line)]
+    consumers.sort(key=lambda c: c.depth, reverse=True)   # innermost first
+
+    wrapper = None
+    for consumer in consumers:
+        if consumer.kind == "bool_cast" and wrapper is None:
+            wrapper = "bool_cast"
+            continue   # keep walking outward; bool_cast doesn't decide alone
+        if consumer.kind in {"if_test", "elif_test"}:
+            return BoolClassification(
+                kind=consumer.kind,
+                wrapper_kind=wrapper,
+                conditional_key=consumer.conditional_key,
+                branch_test_kind=consumer.branch_test_kind,
+            )
+        # any other consumer wins outright (assert/while/ifexp/comp/match)
+        return BoolClassification(kind=consumer.kind, wrapper_kind=wrapper,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Reached here: maybe a standalone bool_cast with no outer branch
+    if wrapper == "bool_cast":
+        return BoolClassification(kind="bool_cast", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+    return BoolClassification(kind="unknown", wrapper_kind=None,
+                               conditional_key=None, branch_test_kind=None)
+```
+
+### Attribution algorithm (`attribute_op`)
+
+Per frame (shallow → deep):
+1. Scope resolution per D14:
+   - `(filename, code_firstlineno, code_qualname)` exact match if `code_qualname` is non-None; otherwise
+   - `(filename, code_firstlineno, func_name)` match IFF exactly one scope in the file index matches; otherwise
+   - **FAIL CLOSED**: skip this frame's contribution entirely (no branch-interval query, no heuristic, no smallest-scope guess). Emit a debug counter for diagnostics.
+2. If scope was resolved: query branch-interval tree at `frame.line_number` → list of `(ConditionalKey, branch_kind, nesting_depth)` sorted by nesting depth asc.
+3. Append to the aggregate stack (deduplicate adjacent).
+
+## Visualization
+
+### Label precedence (Graphviz + dagua bridge)
+
+1. **Arm-entry label** (highest) — edge appears in `conditional_arm_edges[(cond_id, "then")]` / `elif_N` / `else`:
+   - Single-arm: `THEN` / `ELIF N` / `ELSE`.
+   - Multi-arm on same edge (D13 case): composite like `THEN(cond_outer) · THEN(cond_inner)` — concise form to be agreed; default: `N arms`.
+   - Rolled mode with pass divergence (D15): `THEN(1,3) / ELSE(2)` or `mixed`.
+2. **IF label** — edge is in `conditional_branch_edges`.
+3. **Arg labels** — move from `edge_dict["label"]` to `edge_dict["headlabel"]` / `xlabel` so they don't compete.
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+- Refactor existing `edge_dict["label"]` writes (lines ~985-996 and ~1049-1090) into a single `_compute_edge_label(parent, child, model_log)` function implementing the precedence rules.
+- Move argument-name labels off `label` → `headlabel` / `xlabel`.
+
+### Dagua bridge (`torchlens/visualization/dagua_bridge.py`)
+
+- Extend `_classify_forward_edge` to return new edge kinds: `"elif_N"`, `"else"`, `"multi_arm"`, `"mixed_pass"`.
+
+### ELK (`torchlens/visualization/elk_layout.py`)
+
+- Single comment: ELK does not render conditional edge labels.
+
+## Capture / Postprocess Lifecycle (full integration — addresses F4, F9 partials)
+
+Every new label-bearing field must be wired end-to-end. Phase 3 delivers all of this BEFORE Phase 4 (Step 5) can populate data.
+
+### Capture-time defaults (Phase 1)
+
+Files: `torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`, `torchlens/postprocess/graph_traversal.py`.
+- Init every new `LayerPassLog` field with default (empty list, `{}`, `False`, `None`).
+- Remove gating of `func_call_stack` population on `save_source_context` (D17). Populate core fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`) unconditionally. Lazy source-text properties remain gated.
+
+### Raw→final rename (Phase 3, `torchlens/postprocess/labeling.py`)
+
+Extend `_rename_raw_labels_in_place` to rewrite labels in:
+- `conditional_arm_edges` (each `(parent, child)` tuple).
+- `conditional_edge_passes` (keys — positions 0, 1).
+- `conditional_events[*].bool_layers`.
+- `cond_branch_children_by_cond` per `LayerPassLog` (every nested list member).
+- Existing fields (`conditional_branch_edges`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`).
+
+### Cleanup / `keep_unsaved_layers=False` (Phase 3, `torchlens/data_classes/cleanup.py`)
+
+Extend filter logic to scrub every new surface when a label is removed:
+- `conditional_arm_edges`: drop tuples where parent OR child is removed; drop empty keys.
+- `conditional_edge_passes`: drop tuple keys where parent or child is removed.
+- `conditional_events[*].bool_layers`: remove labels.
+- `cond_branch_children_by_cond`: drop removed children; drop empty branch_kind keys; drop empty cond_id keys.
+- `LayerLog.conditional_branch_stack_passes`: unchanged (signatures are cond_id tuples; labels aren't in keys).
+- Also scrub derived views (`cond_branch_then_children`, etc.); they'll be recomputed anyway, but the pruning must be consistent.
+
+### Export (`torchlens/data_classes/interface.py::to_pandas`)
+
+Add columns for: `conditional_branch_depth`, `bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, plus a compact string form of `conditional_branch_stack`.
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+1. **`cond_branch_children_by_cond` ↔ `conditional_arm_edges` bidirectional consistency.**
+   For each `(cond_id, branch_kind) → edges` in `conditional_arm_edges`, every `(parent, child)`: `child ∈ parent.cond_branch_children_by_cond[cond_id][branch_kind]` and vice versa.
+2. **Derived views consistency.**
+   `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` per-node and `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges` on `ModelLog` equal the projections of primary structures.
+3. **Children labels exist in `ModelLog`.**
+4. **Bool classification invariants.**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+   `bool_wrapper_kind is not None` ⟹ `bool_context_kind ∈ {"if_test", "elif_test", "bool_cast"}`.
+5. **Conditional event references are valid.**
+   Every `cond_id` in any stack entry, `bool_conditional_id`, `conditional_arm_edges` key, or `cond_branch_children_by_cond` key has matching `ConditionalEvent.id`.
+6. **Stack monotonicity on every parent→child edge (REVISED).**
+   Exactly one of: child.stack extends parent.stack (entry); parent.stack extends child.stack (exit/reconvergence); stacks equal. Non-prefix reorderings are invalid.
+7. **Elif contiguity on `ConditionalEvent` (per-event, not per-node).**
+   `branch_ranges` and `branch_test_spans` keys for elif arms are contiguous from `elif_1`. Per-node `cond_branch_children_by_cond[cid]` may be sparse — that's legal.
+8. **`bool_layers` back-references (NEW).**
+   For every `ConditionalEvent.bool_layers`: each label exists, and each referenced layer's `bool_conditional_id` equals the event's `id`.
+9. **`LayerLog` aggregate consistency (NEW).**
+   `LayerLog.conditional_branch_stacks` equals exactly the set of distinct `LayerPassLog.conditional_branch_stack` values from that layer's passes.
+   `LayerLog.conditional_branch_stack_passes[sig]` equals the sorted list of pass numbers for which that signature appeared.
+10. **`conditional_edge_passes` exactness (NEW).**
+    For every `(parent_no_pass, child_no_pass, cond_id, branch_kind) → [pass_nums]`:
+    - `pass_nums` is sorted ascending and has no duplicates.
+    - For each `pass_num` there exists an unrolled edge `(parent:pass_num, child:pass_num)` in `conditional_arm_edges[(cond_id, branch_kind)]`.
+    - Every unrolled edge in `conditional_arm_edges` is represented somewhere in `conditional_edge_passes`.
+11. **No orphan `_bool_conditional_key` (NEW, dev-mode).**
+    After 5c, no `LayerPassLog` has a `_bool_conditional_key` attribute. Enforced in dev mode to catch incomplete 5c migrations.
+12. **`LayerLog.cond_branch_children_by_cond` aggregate exactness (NEW).**
+    For every `LayerLog`, `cond_branch_children_by_cond` equals the pass-stripped union of `cond_branch_children_by_cond` across its constituent `LayerPassLog` passes. No cond_id or branch_kind present in any pass is missing from the aggregate; no extraneous entries appear.
+13. **Legacy IF-view consistency (NEW).**
+    `conditional_branch_edges` ↔ `cond_branch_start_children` bidirectionally consistent: every `(parent, bool_label)` tuple in `conditional_branch_edges` has `bool_label ∈ parent.cond_branch_start_children`; and every label in any node's `cond_branch_start_children` corresponds to a tuple with that node as parent in `conditional_branch_edges`.
+
+## Tests
+
+### New file `tests/test_conditional_branches.py` + models in `tests/example_models.py` (or dedicated new file if size warrants)
+
+**Baseline / positive:**
+- `SimpleIfElseModel` / `ElifLadderModel` / `NestedIfThenIfModel` / `NestedInElseModel` / `MultilinePredicateModel` — verify THEN/ELIF/ELSE edges, `conditional_events` entries, branch_ranges correctness.
+
+**Branch-entry via non-predicate ancestors (D13):**
+- `BranchUsesOnlyParameterModel` — `if c: y = self.bias + 1`. Assert `self.bias → y` appears in `conditional_arm_edges[(cid, "then")]`.
+- `BranchUsesOnlyConstantModel` — analogous with a constant.
+- **`MultiArmEntryNestedModel` (NEW — Finding 2):** `if A: if B: y = self.bias + 1`. Assert the single `self.bias → y` edge appears in BOTH `conditional_arm_edges[(outer_id, "then")]` AND `conditional_arm_edges[(inner_id, "then")]`, and `self.bias.cond_branch_children_by_cond` has both `outer_id` and `inner_id` mapping to `[y]`. Verify derived `cond_branch_then_children` also lists `y` (uniquely, not twice).
+
+**Wrapped bool (F2 resolution):**
+- `IfBoolCastModel` — `if bool(x.sum() > 0):`. Assert `bool_is_branch=True`, `bool_context_kind="if_test"`, `bool_wrapper_kind="bool_cast"`.
+
+**Multi-pass / rolled (D15):**
+- `LoopedIfAlternatingModel` — `for i: if i%2`. Per-pass stacks differ; aggregate has 2 signatures.
+- `AlternatingRecurrentIfModel` — recurrent, THEN pass 1 / ELSE pass 2.
+- **`RolledMixedArmModel` (strengthened — F7 resolution):** Assert `ModelLog.conditional_edge_passes` has entries with non-trivial pass lists AND each `(parent_no_pass, child_no_pass, cond_id, branch_kind) → pass_nums` is exactly verifiable — sorted ascending, no duplicates, every `pass_num` corresponds to a real unrolled edge in `conditional_arm_edges[(cond_id, branch_kind)]` on that pass. Assert rolled renderer output (graphviz+dagua) contains a composite label. **D13×D15 interaction:** add a companion scenario where the mixed-pass arm edge is ALSO a multi-arm-entry edge (nested conditional taking different inner arms across passes); assert both dimensions survive end-to-end. **Post-cleanup check:** after `keep_unsaved_layers=False`, assert no pruned labels appear in `conditional_edge_passes` keys.
+
+**Reconvergence (F5):**
+- `ReconvergingBranchesModel` — `if c: x=a else: x=b; y=f(x)`. Invariant 6 passes. Assert `y.conditional_branch_stack == []` and both parents' stacks were non-empty.
+
+**Scope resolution (D14):**
+- `NestedHelperSameNameModel` — two local `helper()` functions, same name, different branches. Assert attribution uses `code_firstlineno`; verify `bool_conditional_id` differs between the two helpers' if-statements.
+- **`NestedQualnameModel` (NEW — replaces LambdaBranchModel):** `class Outer: def forward(self): def helper(self): if cond: op() return helper(self)` — nested function named `helper` with a distinct `code_qualname` from a method also named `helper` elsewhere. Assert attribution distinguishes them via `code_qualname` (Python 3.11+).
+- **`SameLineNestedDefModel` (NEW — D14 fail-closed):** Two local defs with the same `func_name` and same `code_firstlineno` (degenerate case, forceable via `exec` or metaprogramming). Assert D14 step 3 triggers: returns empty branch stack for that frame rather than silently picking one; no `conditional_branch_edges` or arm edges are emitted from that site. Also run this under Python 3.9/3.10 CI (where `code_qualname` is None) to verify fail-closed behavior across supported versions.
+- `DecoratedForwardModel` — decorator on forward. Graceful degradation OR correct attribution.
+
+**False positives — non-branch bools:**
+- `AssertTensorCondModel`, `BoolCastOnlyModel`, `TernaryIfExpModel`, `ComprehensionIfModel`, `WhileLoopModel`, `MatchGuardModel`.
+
+**Compound / negation / walrus:**
+- `NotIfModel`, `AndOrIfModel`, `WalrusIfModel`.
+
+**Documented false negatives (no attribution):**
+- `PythonBoolModel`, `ItemScalarizationModel`, `TorchWhereModel`, `ShapePredicateModel`.
+
+**save_source_context gating (F1 resolution — STRENGTHENED):**
+- **`SaveSourceContextOffModel` (strengthened):** `save_source_context=False`. Assert `func_call_stack` is NON-EMPTY on every captured op; each `FuncCallLocation` has non-None `file`, `line_number`, `code_firstlineno`, and `source_loading_enabled=False`. Assert every accessor returns the existing no-source state: `loc.code_context is None`, `loc.source_context == "None"` (literal 4-char string per current API at `func_call_location.py:150`), `loc.code_context_labeled == ""`, `loc.call_line == ""`, `loc.num_context_lines == 0`, `loc.func_signature is None`, `loc.func_docstring is None`. Assert `len(loc) == 0`, `loc[0]` raises `IndexError`, and `repr(loc)` ends with `"code: source unavailable"`. Assert `loc._frame_func_obj is None` (cleared at construction per D17). Assert no disk access occurred (e.g., by patching `linecache.getlines` with a sentinel; or by monitoring `_source_loaded=True` straight after construction). Branch attribution populated correctly. **Pickle round-trip:** pickle/unpickle a `ModelLog` captured with `save_source_context=False`; unpickled log round-trips cleanly (exercises the `_frame_func_obj` retention fix).
+- **`SaveSourceContextOffAssertModel`:** `save_source_context=False` + `assert tensor_cond`. No false-positive IF edge.
+
+**Field-lifecycle integration (F4 resolution — STRENGTHENED):**
+- **`KeepUnsavedLayersFalseModel` (strengthened):** `keep_unsaved_layers=False` with conditionals. Assert NO removed label appears anywhere in:
+  - `conditional_arm_edges` (tuples).
+  - `conditional_edge_passes` (tuple keys).
+  - `conditional_events[*].bool_layers`.
+  - `cond_branch_children_by_cond` (any nested list) — check on BOTH `LayerPassLog` AND `LayerLog` aggregates.
+  - `conditional_branch_stack_passes` values on `LayerLog`.
+  - All derived views (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`).
+- `ToPandasConditionalModel` — DataFrame has all conditional columns populated.
+
+**Visualization label precedence (NEW — F8 confirmation):**
+- **`BranchEntryWithArgLabelModel` (NEW):** branch-entry edge that ALSO has an argument label. Assert graphviz renderer output shows branch label in `edge_dict["label"]` and arg label in `edge_dict["headlabel"]` (or `xlabel`) — they do not collide. Assert dagua bridge classifies the edge (`_classify_forward_edge` returns `"then"`, not `"default"`) AND the emitted dagua edge metadata carries BOTH the branch kind and the arg label in distinct fields (specification: branch kind in `edge.type`, arg label in a separate `arg_label` attribute that the dagua bridge adds alongside `edge.label`).
+
+**Smoke:** `@pytest.mark.smoke` on `SimpleIfElseModel`, `ElifLadderModel`.
+
+## Backward Compatibility
+
+- Every existing field retained with identical external semantics.
+- Old fields materialized as derived views from primary cond-id-aware structures. Serialization includes both primary and derived (FIELD_ORDER includes both).
+- `in_cond_branch` remains a direct field; recomputed from `conditional_branch_stack`.
+- `FIELD_ORDER` updates in single commit.
+- Pickle compat: `__setstate__` default-fill for 1 prior minor version. If primary structures are missing on load, reconstruct from legacy derived fields where possible (best-effort for N-1 compat; newer loaders prefer primary).
+
+## Implementation Phases
+
+Each phase gate: tier-1 smoke passes. Tier-2 at phases 4, 6, 9. Tier-3 before PR.
+
+1. **Foundation: fields + capture ungating.**
+   - Add all new fields to `LayerPassLog`, `LayerLog`, `ModelLog`, `FuncCallLocation` + `FIELD_ORDER` updates + defaults.
+   - Ungate `func_call_stack` population in `output_tensors.py`, `source_tensors.py`, `graph_traversal.py` (D17).
+   - Populate `code_firstlineno`, `code_qualname` in stack capture (`utils/introspection.py`).
+   - Gate: existing test suite passes unchanged. New **conditional-branch** fields remain default (empty list/dict, `False`, `None`). New `FuncCallLocation` core identity fields (`code_firstlineno`, `code_qualname`, `source_loading_enabled`) ARE populated per D17; verify via test that `func_call_stack` is non-empty even when `save_source_context=False`, and that lazy source-text properties still return empty/None in that case.
+2. **AST module.**
+   - Write `ast_branches.py` (FileIndex, ConditionalRecord, BoolConsumer index, branch interval trees, classify_bool, attribute_op, cache management).
+   - Unit tests on synthetic source snippets covering all 9 bool-context kinds, flattened elif chains, nested ifs, ternary, match guards, etc.
+   - Gate: `ast_branches` tests pass in isolation.
+3. **Lifecycle wiring (upstream of Step 5 integration).**
+   - Extend `labeling.py::_rename_raw_labels_in_place` for every new field.
+   - Extend `cleanup.py` for every new field.
+   - Extend `interface.py::to_pandas` with new columns.
+   - Integration test: synthetic model with new fields pre-populated manually; `keep_unsaved_layers=False` + `to_pandas()` round-trip.
+   - Gate: lifecycle tests pass.
+4. **Postprocess Step 5 integration (6 phases 5a-5f).**
+   - Restructure `control_flow.py`. 5c is the sole key→id translation.
+   - Wire to `ast_branches.py`.
+   - Remove old post-validation (D12).
+   - Gate: new integration test with `SimpleIfElseModel` passes end-to-end.
+5. **Multi-pass merge + `conditional_edge_passes`.**
+   - Update `_build_layer_logs` for aggregate fields.
+   - Populate `ModelLog.conditional_edge_passes`.
+   - Gate: `AlternatingRecurrentIfModel`, `RolledMixedArmModel` pass.
+6. **Invariants.**
+   - Add 11 checks to `validation/invariants.py`.
+   - Wire into `validate_forward_pass`.
+   - Gate: all tests still pass; invariants catch deliberately-corrupted metadata in unit tests.
+7. **Graphviz rendering.**
+   - Refactor to `_compute_edge_label` precedence function.
+   - Move arg labels to `headlabel`/`xlabel`.
+   - Implement multi-arm and rolled-mixed labels.
+   - Gate: visual-diff regression check on existing aesthetic tests.
+8. **Dagua bridge.**
+   - Extend `_classify_forward_edge` with new edge kinds.
+   - Gate: existing dagua tests still pass; new conditional coverage.
+9. **Integration tests.**
+   - All ~30 conditional tests with assertions.
+   - Gate: all pass; coverage of every listed scenario.
+10. **Documentation.**
+    - Update `AGENTS.md` conditional section.
+    - Update `architecture.md` Step 5 section.
+    - Update `torchlens/user_funcs.py` docstrings: `save_source_context=False` no longer zeros `func_call_stack` — only source-text properties are gated (D17). Any README/API doc references to this behavior get the same update.
+    - User-facing limitations page.
+11. **PR.**
+    - Migration notes with before/after field table.
+    - Compat matrix.
+
+## Deliverables
+
+- 1 new module (~400 lines): `torchlens/postprocess/ast_branches.py`.
+- Modified modules (~11):
+  - `torchlens/data_classes/{layer_pass_log,layer_log,model_log,func_call_location,cleanup,interface}.py`
+  - `torchlens/constants.py`
+  - `torchlens/postprocess/{control_flow,labeling,graph_traversal}.py`
+  - `torchlens/capture/{source_tensors,output_tensors}.py`
+  - `torchlens/utils/introspection.py`
+  - `torchlens/validation/invariants.py`
+  - `torchlens/visualization/{rendering,dagua_bridge,elk_layout}.py`
+- Tests: `tests/test_conditional_branches.py` (~550 lines), ~32 new models.
+- Docs: AGENTS.md, architecture.md, user limitations.
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch | All field additions in one commit. |
+| R2 | Multi-pass regressions on recurrent tests | `AlternatingRecurrentIfModel` / `RolledMixedArmModel` in Phase 5 test gate. |
+| R3 | Source resolution fragile on decorated/wrapped forwards | Use `frame.f_code.co_firstlineno`/`co_qualname` (D14); don't rely on `inspect.getsourcefile(module_class)`. |
+| R4 | `linecache` stale source after edit | Cache by `(filename, mtime)`; invalidate on mismatch; fail-soft to `unknown`. |
+| R5 | Pre-classification misses a syntactic form → silent `unknown` | Unit tests for every kind; dev-mode assertion: line inside `If.test` span but classifier returns `unknown` → log warning. |
+| R6 | Interval tree perf on huge `forward` | Parse once; O(log k + d) query; benchmark `HugeNestedIfModel` in Phase 2. |
+| R7 | Old pickled ModelLogs fail | `__setstate__` default-fill; document window. |
+| R8 | Arg-label relocation to `headlabel` breaks existing aesthetic tests | Visual-diff gate in Phase 7; gate behind a flag if regressions appear. |
+| R9 | D16 primary structure inflates memory on large models | Benchmark; cond-id keys compact; derived views computed on-demand only. |
+| R10 | D17 ungating breaks something depending on empty `func_call_stack` | Phase 1 tests check `func_call_stack` non-empty; audit any code reading it. |
+| R11 | Multi-arm entry edges produce confusing visuals | Dedicated test (`MultiArmEntryNestedModel`) + label precedence rule + user docs. |
+
+## Open Questions for Architect / User
+
+1. ELK: document as unsupported (default). Confirm?
+2. Multi-arm edge label format: `THEN(cond_outer) · THEN(cond_inner)` vs `2 arms` vs a renderer-side decision. Default: readable form with cond name/IDs.
+3. Pickle compat window: 1 prior minor version (default).
+4. v2 scope confirmation: ternary + while + column offsets + ELK parity.
+5. Test model count: ~32. OK?
+6. `code_qualname` fallback on Python 3.9/3.10 (no `co_qualname`): accept identity-fallback to `code_firstlineno` + `func_name`?
+
+---
+
+## CHANGELOG v2 → v3 (addresses `review_round_2.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R2-F1 Conditional ID contract (BLOCKER) | D10 revised + Step 5c is sole key→id translator + `ConditionalKey` explicit type. |
+| R2-F2 Multi-entry edges cond-id-blind (HIGH) | D16 new: `conditional_arm_edges` + `cond_branch_children_by_cond` primary; legacy fields derived. |
+| R2-F3 `code_qualname` not used in matching (MEDIUM) | D14 revised: exact match on `(filename, code_firstlineno, code_qualname)` first; fallbacks explicit. |
+| R2-F4 Cleanup incomplete for D15 (MEDIUM) | Lifecycle/Cleanup section enumerates every new surface; `KeepUnsavedLayersFalseModel` strengthened. |
+| R2 F1 partial (save_source_context capture path) | D17 new: Phase 1 explicitly ungates `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `SaveSourceContextOffModel` strengthened to assert non-empty `func_call_stack`. |
+| R2 F9 partial | Covered by D14 revision and test swap (NestedQualnameModel replacing LambdaBranchModel). |
+| R2 missing invariants (bool_layers back-ref, aggregate stacks, edge_passes exactness) | Invariants 8, 9, 10, 11 added. |
+| R2 phase ordering | Phases reordered: lifecycle wiring is Phase 3, BEFORE Step 5 integration (Phase 4). Phase 1 gate no longer references Phase 5 deliverables. |
+| R2 test gaps | Added `MultiArmEntryNestedModel`, `NestedQualnameModel`, `BranchEntryWithArgLabelModel`; strengthened `SaveSourceContextOffModel`, `KeepUnsavedLayersFalseModel`, `RolledMixedArmModel`. |
+
+## CHANGELOG v3 → v4 (addresses `review_round_3.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R3-F1 5e can attribute via unmaterialized keys (BLOCKER) | Step 5e spec now explicitly DROPS `ConditionalKey`s not in `events_by_key`; rationale and test link to documented false-negative scope. |
+| R3-F2 D17 promises ungated stack but `FuncCallLocation` lazy props eagerly load (HIGH) | D17 revised; `FuncCallLocation` gains `source_loading_enabled: bool`; all lazy props + `__repr__`/`__len__`/`__getitem__` must fail closed when disabled. Phase 1 gate wording updated. |
+| R3-F3 D14 fallback can still silently pick wrong scope on 3.9/3.10 (MEDIUM) | D14 revised v2: step 2 requires unique match; step 3 FAILS CLOSED (no smallest-containing-scope heuristic). New `SameLineNestedDefModel` test exercises the fail-closed path. |
+| R3-F4 Invariants incomplete (MEDIUM) | Added invariants 12 (`LayerLog.cond_branch_children_by_cond` aggregate exactness) and 13 (legacy IF-view consistency). |
+| R3-F5 Phase 1 gate imprecise (MEDIUM) | Gate wording split: conditional-branch fields stay default; `FuncCallLocation` identity fields populated; verify via explicit sub-test. |
+| R3-F6 Nondeterministic `cond_id` assignment (MEDIUM) | 5b/5c spec updated: iterate `ModelLog.layer_list` order, collect keys in first-seen order via insertion-ordered dict (not set). |
+| R3-F7 Docs miss user_funcs.py (LOW) | Phase 10 adds `user_funcs.py` docstring updates + README/API doc corrections. |
+| R3 test gaps (MultiArm/NestedQualname/BranchEntry/SaveSrcOff/KeepUnsaved/RolledMixed) | All six test rows strengthened with concrete assertion lists; `SameLineNestedDefModel` added. |
+
+## CHANGELOG v4 → v5 (addresses `review_round_4.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R4-F1 `source_loading_enabled` incomplete for full `FuncCallLocation` surface (HIGH) | D17 revised v2 + data model expanded to enumerate all 7 lazy accessors (`source_context`, `code_context`, `code_context_labeled`, `call_line`, `num_context_lines`, `func_signature`, `func_docstring`). When disabled, all lazy backing fields are initialized empty at construction (no disk access); `_frame_func_obj` is cleared at construction to prevent pickle fragility with nested/local functions. |
+| R4-F2 `attribute_op` subsection contradicts D14 v2 (MEDIUM) | Algorithm subsection updated: no more "smallest containing scope" heuristic; step 3 fails closed (skips frame) matching D14 v2. |
+| R4-F3 `source_context == []` type contradicts current `str` API (LOW) | `SaveSourceContextOffModel` assertions aligned to `str` types: `source_context == ""` etc. Pickle round-trip also added. |
+| R4 test gap: disabled-source accessor coverage | Strengthened `SaveSourceContextOffModel` now asserts every lazy accessor + `_frame_func_obj is None` + pickle round-trip. |
+
+## CHANGELOG v5 → v6 (addresses `review_round_5.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R5-F1 disabled-source contract contradicted current `code_context` API (MEDIUM) | D17 revised v3 + data-model comment + `SaveSourceContextOffModel` all re-aligned to the current "no source available" contract: `code_context=None`, `source_context="None"` (literal string), `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`, `_frame_func_obj=None`; `len==0`; `__getitem__` raises `IndexError`; `__repr__` ends with "code: source unavailable". No disk access when disabled. |

--- a/.project-context/plans/if-else-attribution/plan_v7.md
+++ b/.project-context/plans/if-else-attribution/plan_v7.md
@@ -1,0 +1,618 @@
+# Sprint Plan: Full `if` / `elif` / `else` Branch Attribution for TorchLens
+
+**Date:** 2026-04-22
+**Branch:** `sprint/2026-04`
+**Version:** v7 (ternary folded in; dagua + ELK deferred per user)
+**History:** `plan_v{1,2,3,5,6}.md`, `review_round_{1,2,3,4,5,6}.md`.
+
+## Goals
+
+1. Correctly attribute every captured op to its enclosing Python `if` / `elif` / `else` branch in eager `forward()` methods.
+2. Robust false-positive filtering (`assert`, `bool()` cast, comprehension filters, `while`, `ifexp`, `match` guards, `unknown`).
+3. Explicit per-pass branch representation on `LayerPassLog`; lossless aggregate representation on `LayerLog` and `ModelLog` (including rolled-edge pass divergence and multi-arm-entry edges).
+4. Render THEN / ELIF / ELSE edge labels in Graphviz. (Dagua bridge + ELK deferred to a future sprint per user direction.)
+5. Comprehensive tests for positive paths, every documented limitation, multi-pass divergence, multi-arm entry, and lifecycle integration.
+6. Strict backward compatibility — no existing field is renamed or removed; old fields derived from new primary structures.
+
+## Out-of-Scope for v1 (explicit limitations)
+
+**In scope — fully attributed:**
+- `if` / `elif` / `else` chains (flattened into one `ConditionalEvent`)
+- **Ternary (`x if cond else y`)** (D18) — `bool_context_kind="ifexp"`, `bool_is_branch=True`; `ConditionalEvent.kind="ifexp"` with arms `{then, else}` (no elif). Column-offset disambiguation required because both arms share a source line.
+
+**Non-branch bool consumers — classified, not attributed:**
+- `while cond:` → `bool_context_kind="while"`
+- Comprehension filters → `bool_context_kind="comprehension_filter"`
+- `match case ... if guard:` → `bool_context_kind="match_guard"`
+- `assert tensor_cond` → `bool_context_kind="assert"`
+- `bool(tensor)` cast NOT nested inside `If.test`/elif/IfExp test → `bool_context_kind="bool_cast"`
+
+`bool(tensor_cond)` nested *inside* an `If.test`/elif/IfExp test IS a branch (see D3).
+
+**Source-unavailable — graceful degradation (`bool_context_kind="unknown"`, no attribution):**
+- Jupyter / REPL cells, `exec`/`eval`, `.pyc`-only, native `.so` modules
+- `torch.compile`, `torch.jit.script`, `torch.jit.trace` wrapped models
+- `nn.DataParallel` / `DistributedDataParallel`
+- Monkey-patched `forward` where source resolves to the patch
+
+**Documented false negatives — torchlens cannot see:**
+- Pure Python predicates: `if self.training:`, `if python_bool:`
+- `if tensor.item() > 0:` — scalarization bypasses `Tensor.__bool__`
+- Shape/metadata predicates: `if x.shape[0] > 0:`
+- Functional conditionals: `torch.where`, `torch.cond`, masked blending
+
+**Deferred (tracked in `.project-context/todos.md`):**
+- `while` loop body attribution — iteration semantics, needs distinct data model.
+- Dagua bridge conditional-edge integration (`torchlens/visualization/dagua_bridge.py`).
+- ELK conditional edge rendering (`torchlens/visualization/elk_layout.py` — legacy).
+
+Data structures populate unconditionally in v1; only renderer-side integration for dagua and ELK is deferred.
+
+## Decisions (architect-level)
+
+| # | Decision |
+|---|----------|
+| D1 | AST + per-op frame inspection. NOT `sys.settrace`, NOT bytecode. |
+| D2 | Flatten `if/elif/.../else` into ONE conditional record with branch arms `{then, elif_1, elif_2, ..., else}` (Python AST has no `Elif` node). |
+| **D3 (REVISED)** | Pre-classify every terminal scalar bool by enclosing AST context. `bool(x)` nested inside `If.test`/elif test / `IfExp.test` normalizes to `if_test`/`elif_test`/`ifexp` + `bool_wrapper_kind="bool_cast"`. Standalone `bool(x)` (not in any branch test) → `bool_cast`. **Branch-participating kinds (`bool_is_branch=True`):** `if_test`, `elif_test`, `ifexp`. All three produce arm-entry edges. |
+| D4 | Attribution uses full `func_call_stack` (every frame), not just the user-facing frame. |
+| D5 | `LayerPassLog.conditional_branch_stack` is the per-pass source of truth. `LayerLog` aggregates via unique signatures + pass map. |
+| D6 | Keep every existing field; old fields populated from new primary structures as derived views. |
+| D7 | AST logic lives in new module `torchlens/postprocess/ast_branches.py`. |
+| D8 | File cache keyed by `(filename, stat.st_mtime_ns)`. Process-local. |
+| D9 | AST classification runs whenever `(file, line)` is on `func_call_stack` (which is always, after D18 ungates capture). `save_source_context` only gates rich source-text capture. |
+| **D10 (REVISED)** | Two-stage identifier scheme: `ConditionalKey = (file, func_firstlineno, if_stmt_lineno, if_col_offset)` is the AST-internal structural key used in Phases 5a/5b/5e. Phase 5c is the **sole** step that materializes `ModelLog.conditional_events` and assigns dense per-`ModelLog` `conditional_id: int`. Phase 5c rewrites all `bool_conditional_key` → `bool_conditional_id` and all stack entries `(ConditionalKey, kind)` → `(cond_id, kind)` in one pass. No other code outside `ast_branches.py` sees `ConditionalKey`. |
+| D11 | Graphviz gets ELIF/ELSE labels with explicit precedence (see Visualization). Dagua bridge extended. ELK gets a comment. |
+| D12 | Old post-validation ("clear IF markings if no `ast.If`") is REMOVED; pre-classification makes it unnecessary. |
+| D13 | Branch-entry edges detected by diffing `conditional_branch_stack` across EVERY forward edge, not only edges from branch-start nodes. Legitimate: a single edge can gain MULTIPLE stack entries simultaneously (e.g., `self.bias → x` inside nested `if A: if B:` enters both outer and inner THEN). All gained entries are recorded. |
+| **D14 (REVISED v2)** | `FuncCallLocation` augmented with `code_firstlineno: int` (always) + `code_qualname: Optional[str]` (Python 3.11+; None on 3.9/3.10). Scope resolution in `attribute_op`: (1) exact match on `(filename, code_firstlineno, code_qualname)` if qualname non-None; (2) exact match on `(filename, code_firstlineno, func_name)` IFF exactly one scope matches; (3) if step 2 has zero or multiple candidates, **FAIL CLOSED** — return empty branch stack for that frame (no "smallest containing scope" heuristic). This prevents silent wrong attribution on same-line nested defs/lambdas, especially under 3.9/3.10 where `code_qualname` is absent. |
+| D15 | `ModelLog.conditional_edge_passes` maps `(parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted List[int]` of pass numbers. Rolled-mode renderers consult this for mixed-arm labels. |
+| **D16 (NEW)** | **Cond-id-aware primary structures.** Primary arm-edge representation is `ModelLog.conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]` (`(cond_id, branch_kind) → [(parent, child)]`). Primary per-node child list is `LayerPassLog.cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]` (`cond_id → branch_kind → [child_labels]`). Existing `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` become DERIVED VIEWS computed from the primary structures. This lets a single edge correctly record entry into multiple arms simultaneously (D13). |
+| **D18 (NEW)** | **`col_offset` capture + ternary first-class attribution.** `FuncCallLocation` gains `col_offset: Optional[int]` (captured via `frame.f_code.co_positions()` + `frame.f_lasti` on Python 3.11+; `None` on 3.9/3.10). AST indexing treats `ast.IfExp` as a first-class conditional: classifies its test as `bool_context_kind="ifexp"` with `bool_is_branch=True`, materializes a `ConditionalEvent` with `kind="ifexp"` and arms `{then, else}`. Branch ranges stored as `(start_line, start_col, end_line, end_col)` for BOTH `if_chain` and `ifexp` events; `attribute_op` queries the branch interval tree with the `(line, col)` pair instead of `line` alone. For if-statement arms on different lines, col is redundant but consistent; for ternary arms that share a source line, col is load-bearing. On Python 3.9/3.10 (no `co_positions`), `col_offset=None`; `attribute_op` falls back to line-only matching and **fails closed** when multiple candidate arms match by line alone (e.g., ternary on older Python). |
+| **D17 (REVISED v3)** | **Explicit capture-path ungating + disabled-source state identical to the existing "no source available" contract on `FuncCallLocation`.** Phase 1 unconditionally populates identity fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`, `source_loading_enabled`) on every captured op at `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `source_loading_enabled` mirrors `save_source_context` at capture time. **When `source_loading_enabled=False`:** construction sets `_source_loaded=True` immediately and initializes the same observable state that `_load_source()` produces when source can't be loaded (see `func_call_location.py:149-153,165-169`): `code_context=None`, `source_context="None"` (literal 4-char string — current API), `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`, `_frame_func_obj=None`. Accessors and dunder methods inherit current no-source behavior verbatim — `len==0`, `__getitem__` raises `IndexError`, `__repr__` ends with "code: source unavailable" — with zero disk access. Clearing `_frame_func_obj` at construction eliminates pickle fragility with nested/local function objects (previously only released inside `_load_source()`). This reuses the already-existing no-source contract for complete API/test backward compatibility. D17 is distinct from D9 (AST classification needs identity fields only). |
+
+## Data Model
+
+### `FuncCallLocation` (augmented — D14, D17)
+
+```python
+@dataclass
+class FuncCallLocation:
+    file: str
+    line_number: int
+    func_name: str
+    code_firstlineno: int                 # NEW — frame.f_code.co_firstlineno, always populated
+    code_qualname: Optional[str]          # NEW — frame.f_code.co_qualname (3.11+); None pre-3.11
+    col_offset: Optional[int]             # NEW (D18) — current instruction col_offset
+                                          # (Python 3.11+); None pre-3.11
+    source_loading_enabled: bool          # NEW — mirrors save_source_context at capture time
+    # When source_loading_enabled=False, construction sets _source_loaded=True
+    # immediately with the no-source state already produced by _load_source() when
+    # source can't be loaded (see func_call_location.py:149-153, 165-169):
+    #   code_context=None
+    #   source_context="None"       # literal 4-char string (current API)
+    #   code_context_labeled=""
+    #   call_line=""
+    #   num_context_lines=0
+    #   func_signature=None
+    #   func_docstring=None
+    #   _frame_func_obj=None        # cleared at construction -> safe for pickle
+    # Existing accessor semantics carry over: len(loc)==0,
+    # loc[i] raises IndexError, repr(loc) ends with "code: source unavailable".
+    # No disk access ever; _load_source is effectively never entered.
+```
+
+### `LayerPassLog` — new fields
+
+```python
+# Bool classification (meaningful when is_terminal_bool_layer=True and is_scalar_bool=True)
+bool_is_branch: bool                                 # iff bool_context_kind ∈ {"if_test","elif_test"}
+bool_context_kind: Optional[str]                     # 9 kinds + "unknown"
+bool_wrapper_kind: Optional[str]                     # e.g. "bool_cast" when wrapped; else None
+bool_conditional_id: Optional[int]                   # dense; None for non-branch kinds
+
+# Branch attribution (any op)
+conditional_branch_stack: List[Tuple[int, str]]      # [(cond_id, branch_kind), ...] outer→inner
+conditional_branch_depth: int                         # = len(stack)
+
+# PRIMARY per-node arm-child structure (D16)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+    # cond_id → branch_kind → [child labels]
+```
+
+**Preserved (now DERIVED from `cond_branch_children_by_cond`):**
+- `cond_branch_start_children: List[str]` — still the set-of-parents marked by 5d IF-backward flood (UNCHANGED semantics).
+- `cond_branch_then_children: List[str]` — `sorted(set(chain_from_iterable(m["then"] for m in cond_branch_children_by_cond.values() if "then" in m)))`.
+- `cond_branch_elif_children: Dict[int, List[str]]` — aggregate by elif-index across cond_ids.
+- `cond_branch_else_children: List[str]` — analogous.
+
+Also preserved: `is_terminal_bool_layer`, `is_scalar_bool`, `scalar_bool_value`, `in_cond_branch` (derived `len(conditional_branch_stack) > 0`).
+
+### `LayerLog` — multi-pass aggregation
+
+```python
+# Aggregate
+conditional_branch_stacks: List[List[Tuple[int, str]]]     # unique signatures, first-seen order
+conditional_branch_stack_passes: Dict[
+    Tuple[Tuple[int, str], ...], List[int]
+]                                                           # signature → sorted pass numbers
+
+# Per-node cond-id-aware aggregate children (primary — pass-stripped labels)
+cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]
+```
+
+**Derived views (pass-stripped unions):** `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`.
+
+**Merge rules** (update `_build_layer_logs`):
+- `in_cond_branch`: OR across passes.
+- `conditional_branch_stacks`: unique signatures in first-seen order.
+- `conditional_branch_stack_passes`: accumulate sorted pass numbers per signature.
+- `cond_branch_children_by_cond`: union across passes after stripping `:N` suffix; keep cond_id granularity.
+
+### `ModelLog` — new fields
+
+```python
+conditional_events: List[ConditionalEvent]            # dense cond_id indexing (D10)
+
+# PRIMARY edge structure (D16)
+conditional_arm_edges: Dict[Tuple[int, str], List[Tuple[str, str]]]
+    # (cond_id, branch_kind) → [(parent, child), ...]
+
+# Rolled-mode pass-divergence (D15)
+conditional_edge_passes: Dict[
+    Tuple[str, str, int, str], List[int]
+]                                                     # (parent_no_pass, child_no_pass, cond_id, branch_kind) → sorted pass numbers
+```
+
+**Preserved (DERIVED from `conditional_arm_edges`):**
+- `conditional_branch_edges: List[Tuple[str, str]]` — IF-edges from 5d (unchanged).
+- `conditional_then_edges: List[Tuple[str, str]]` — `[(p,c) for (cid, bk), edges in conditional_arm_edges.items() if bk=="then" for (p,c) in edges]`.
+- `conditional_elif_edges: List[Tuple[int, int, str, str]]` — `[(cid, int(bk.split("_")[1]), p, c) for (cid, bk), edges if bk.startswith("elif_") for (p,c) in edges]`.
+- `conditional_else_edges: List[Tuple[int, str, str]]` — `[(cid, p, c) for (cid, bk), edges if bk=="else" for (p,c) in edges]`.
+
+`ConditionalEvent`:
+```python
+@dataclass
+class ConditionalEvent:
+    id: int                                                           # dense per-ModelLog
+    kind: Literal["if_chain", "ifexp"]                                # D18 — discriminator
+    source_file: str
+    function_qualname: str
+    function_span: Tuple[int, int]
+    if_stmt_span: Tuple[int, int]                                     # for ifexp: the IfExp node span
+    test_span: Tuple[int, int, int, int]                              # (start_line, start_col, end_line, end_col)
+    nesting_depth: int
+    branch_ranges: Dict[str, Tuple[int, int, int, int]]               # arm -> (start_line, start_col, end_line, end_col)
+                                                                      # if_chain arms: "then", "elif_1", ..., "else"
+                                                                      # ifexp arms:    "then", "else" (no elif)
+    branch_test_spans: Dict[str, Tuple[int, int, int, int]]           # if_chain: "then", "elif_1", ...
+                                                                      # ifexp:    "then" (the ternary test itself)
+    parent_conditional_id: Optional[int]
+    parent_branch_kind: Optional[str]
+    bool_layers: List[str]                                            # labels of bools driving this event
+```
+
+### `constants.py` FIELD_ORDER updates (one commit)
+
+- `LAYER_PASS_LOG_FIELD_ORDER`: add 7 new entries (`bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, `conditional_branch_stack`, `conditional_branch_depth`, `cond_branch_children_by_cond`). Derived fields (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`) stay in FIELD_ORDER — they're materialized for serialization.
+- `MODEL_LOG_FIELD_ORDER`: add 3 new primary entries (`conditional_events`, `conditional_arm_edges`, `conditional_edge_passes`). Derived fields (`conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`) stay.
+- `LAYER_LOG_FIELD_ORDER`: add 4 aggregate entries (`conditional_branch_stacks`, `conditional_branch_stack_passes`, `cond_branch_children_by_cond`, plus the aggregate derived children).
+
+## Algorithm
+
+### New module: `torchlens/postprocess/ast_branches.py`
+
+Public API:
+```python
+def get_file_index(filename: str) -> Optional["FileIndex"]: ...
+def classify_bool(filename: str, line: int) -> BoolClassification: ...
+    # Returns: (kind, wrapper_kind, conditional_key_or_None, branch_test_kind_or_None)
+def attribute_op(func_call_stack: List[FuncCallLocation]
+                 ) -> List[Tuple[ConditionalKey, str]]: ...
+    # Returns ConditionalKeys, not dense ints. Dense IDs are assigned in Phase 5c.
+def invalidate_cache(filename: Optional[str] = None) -> None: ...
+
+ConditionalKey = Tuple[str, int, int, int]   # (file, func_firstlineno, if_stmt_lineno, if_col_offset)
+```
+
+### Postprocess Step 5 restructure (six-phase — revised per D10)
+
+**5a. Build file indexes.**
+For every terminal scalar bool layer, collect filenames from `func_call_stack`. Eagerly build `FileIndex` per file (cache).
+
+**5b. Classify bools (structural keys).**
+For each `is_terminal_bool_layer` scalar bool, **iterating in `ModelLog.layer_list` order for determinism**:
+- Walk frames; call `classify_bool(frame.file, frame.line_number)`; take the most-informative result (innermost non-`unknown` kind).
+- Record on the bool's `LayerPassLog` temporarily:
+  - `bool_context_kind`, `bool_wrapper_kind`, `bool_is_branch`, and a TEMPORARY attribute `_bool_conditional_key` (not in FIELD_ORDER — transient).
+- Collect unique `ConditionalKey`s in **first-seen order** (insertion-ordered dict, not a set).
+
+**5c. Materialize events; assign dense IDs; translate keys → ints. (Sole id-assignment step.)**
+- Build `ModelLog.conditional_events` list: for each unique `ConditionalKey` in the **first-seen order from 5b**, create a `ConditionalEvent` with a dense `id` (0, 1, 2, ...). This guarantees stable `cond_id` assignment across runs on the same model/input.
+- Walk every bool layer with `_bool_conditional_key`: set `bool_conditional_id = events_by_key[_bool_conditional_key].id`; register label in `ConditionalEvent.bool_layers`; delete `_bool_conditional_key`.
+- Also translate `parent_conditional_id` fields inside `ConditionalEvent`s that reference other keys.
+- From this point forward, no `ConditionalKey` escapes `ast_branches.py` — only dense `int` IDs are exposed.
+
+**5d. IF backward flood** (PR #127 behavior, now pre-filtered).
+Starting from bools with `bool_is_branch=True` only, backward-flood through `parent_layers`; mark output-ancestor parents with `cond_branch_start_children`; emit `conditional_branch_edges`. Unchanged by D13.
+
+**5e. Forward branch attribution + arm edges.**
+For every op:
+- `stack_keys = attribute_op(func_call_stack)` → list of `(ConditionalKey, kind)`.
+- Translate keys to dense IDs: for each `(key, kind)`, if `key ∈ events_by_key` emit `(events_by_key[key].id, kind)`; otherwise **DROP** the entry. A `ConditionalKey` may be returned by `attribute_op` that was never materialized in 5c — this happens when an op is lexically inside an `if` whose predicate was not driven by a captured tensor bool (the documented false-negative scope: `if self.training:`, `if x.shape[0] > 0:`, `if tensor.item() > 0:`). Dropping unmaterialized keys keeps the attribution consistent with the event set.
+- Assemble `conditional_branch_stack: List[Tuple[int, str]]` from the surviving entries.
+- Set `conditional_branch_depth`, update `in_cond_branch`.
+
+For every forward edge `(parent, child)` (ALL edges — D13):
+- Compute set difference `gained = child.stack - parent.stack` (prefix-order, so elements not in parent's stack in order).
+- Each gained `(cond_id, branch_kind)` triggers:
+  - `ModelLog.conditional_arm_edges[(cond_id, branch_kind)].append((parent.label, child.label))`.
+  - `parent.cond_branch_children_by_cond[cond_id][branch_kind].append(child.label)`.
+- If `parent.stack` has entries not in `child.stack` (branch exit / reconvergence): no edge is recorded; valid per Invariant 6.
+
+**5f. Derived-view materialization + `conditional_edge_passes`.**
+- Compute derived fields (`conditional_then_edges`, `cond_branch_then_children`, etc.) from primary cond-id-aware structures.
+- For rolled-mode awareness, record each arm-edge's pass-stripped form: `conditional_edge_passes[(parent_no_pass, child_no_pass, cond_id, branch_kind)].append(pass_num)`; sort lists at the end.
+
+### Classification algorithm (`classify_bool`)
+
+```python
+def classify_bool(filename: str, line: int) -> BoolClassification:
+    idx = get_file_index(filename)
+    if idx is None:
+        return BoolClassification(kind="unknown", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Walk bool consumers whose span contains `line`, innermost outward.
+    # Each consumer has kind ∈ {if_test, elif_test, assert, bool_cast,
+    #                            comprehension_filter, while, ifexp, match_guard}.
+    consumers = [c for c in idx.bool_consumers if c.span.contains(line)]
+    consumers.sort(key=lambda c: c.depth, reverse=True)   # innermost first
+
+    wrapper = None
+    for consumer in consumers:
+        if consumer.kind == "bool_cast" and wrapper is None:
+            wrapper = "bool_cast"
+            continue   # keep walking outward; bool_cast doesn't decide alone
+        if consumer.kind in {"if_test", "elif_test", "ifexp"}:
+            # D3 revised + D18: all three are branch-participating.
+            return BoolClassification(
+                kind=consumer.kind,
+                wrapper_kind=wrapper,
+                conditional_key=consumer.conditional_key,
+                branch_test_kind=consumer.branch_test_kind,
+            )
+        # any other consumer wins outright (assert/while/ifexp/comp/match)
+        return BoolClassification(kind=consumer.kind, wrapper_kind=wrapper,
+                                   conditional_key=None, branch_test_kind=None)
+
+    # Reached here: maybe a standalone bool_cast with no outer branch
+    if wrapper == "bool_cast":
+        return BoolClassification(kind="bool_cast", wrapper_kind=None,
+                                   conditional_key=None, branch_test_kind=None)
+    return BoolClassification(kind="unknown", wrapper_kind=None,
+                               conditional_key=None, branch_test_kind=None)
+```
+
+### Attribution algorithm (`attribute_op`)
+
+Per frame (shallow → deep):
+1. Scope resolution per D14:
+   - `(filename, code_firstlineno, code_qualname)` exact match if `code_qualname` is non-None; otherwise
+   - `(filename, code_firstlineno, func_name)` match IFF exactly one scope in the file index matches; otherwise
+   - **FAIL CLOSED**: skip this frame's contribution entirely (no branch-interval query, no heuristic, no smallest-scope guess). Emit a debug counter for diagnostics.
+2. If scope was resolved: query the scope's branch interval tree with `(frame.line_number, frame.col_offset)` (D18). Branch ranges are `(start_line, start_col, end_line, end_col)` tuples; a query point `(L, C)` matches a range iff `(start_line, start_col) ≤ (L, C) ≤ (end_line, end_col)` under lexicographic comparison. Return list of `(ConditionalKey, branch_kind, nesting_depth)` sorted by nesting depth asc.
+3. **Col-offset degraded mode:** when `frame.col_offset is None` (Python 3.9/3.10) AND the line-only query returns MULTIPLE candidate arms within a SINGLE `ConditionalEvent` (typical only for ternary), **fail closed** for that conditional and drop all of its candidate entries from this frame's result. Line-only queries that return unambiguous single-arm matches (typical for if-statement bodies on distinct lines) proceed normally.
+4. Append results to the aggregate stack (deduplicate adjacent).
+
+## Visualization
+
+### Label precedence (Graphviz — dagua bridge deferred)
+
+1. **Arm-entry label** (highest) — edge appears in `conditional_arm_edges[(cond_id, "then")]` / `elif_N` / `else`:
+   - Single-arm: `THEN` / `ELIF N` / `ELSE`.
+   - Multi-arm on same edge (D13 case): composite like `THEN(cond_outer) · THEN(cond_inner)` — concise form to be agreed; default: `N arms`.
+   - Rolled mode with pass divergence (D15): `THEN(1,3) / ELSE(2)` or `mixed`.
+2. **IF label** — edge is in `conditional_branch_edges`.
+3. **Arg labels** — move from `edge_dict["label"]` to `edge_dict["headlabel"]` / `xlabel` so they don't compete.
+
+### Graphviz (`torchlens/visualization/rendering.py`)
+
+- Refactor existing `edge_dict["label"]` writes (lines ~985-996 and ~1049-1090) into a single `_compute_edge_label(parent, child, model_log)` function implementing the precedence rules.
+- Move argument-name labels off `label` → `headlabel` / `xlabel`.
+
+### Dagua bridge (deferred)
+
+Per user direction, dagua bridge work (`torchlens/visualization/dagua_bridge.py`) is deferred to a future sprint. The existing bridge continues to use its current `_classify_forward_edge` (returns `"then"` for pre-PR #127 style THEN edges); new conditional structures will not be wired through dagua in v1. Documented in `.project-context/todos.md`.
+
+### ELK (deferred)
+
+Per user direction, ELK rendering (`torchlens/visualization/elk_layout.py`) is deferred. No changes in v1 (not even the documentation comment). Documented in `.project-context/todos.md`.
+
+## Capture / Postprocess Lifecycle (full integration — addresses F4, F9 partials)
+
+Every new label-bearing field must be wired end-to-end. Phase 3 delivers all of this BEFORE Phase 4 (Step 5) can populate data.
+
+### Capture-time defaults (Phase 1)
+
+Files: `torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`, `torchlens/postprocess/graph_traversal.py`.
+- Init every new `LayerPassLog` field with default (empty list, `{}`, `False`, `None`).
+- Remove gating of `func_call_stack` population on `save_source_context` (D17). Populate core fields (`file`, `line_number`, `func_name`, `code_firstlineno`, `code_qualname`) unconditionally. Lazy source-text properties remain gated.
+
+### Raw→final rename (Phase 3, `torchlens/postprocess/labeling.py`)
+
+Extend `_rename_raw_labels_in_place` to rewrite labels in:
+- `conditional_arm_edges` (each `(parent, child)` tuple).
+- `conditional_edge_passes` (keys — positions 0, 1).
+- `conditional_events[*].bool_layers`.
+- `cond_branch_children_by_cond` per `LayerPassLog` (every nested list member).
+- Existing fields (`conditional_branch_edges`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`).
+
+### Cleanup / `keep_unsaved_layers=False` (Phase 3, `torchlens/data_classes/cleanup.py`)
+
+Extend filter logic to scrub every new surface when a label is removed:
+- `conditional_arm_edges`: drop tuples where parent OR child is removed; drop empty keys.
+- `conditional_edge_passes`: drop tuple keys where parent or child is removed.
+- `conditional_events[*].bool_layers`: remove labels.
+- `cond_branch_children_by_cond`: drop removed children; drop empty branch_kind keys; drop empty cond_id keys.
+- `LayerLog.conditional_branch_stack_passes`: unchanged (signatures are cond_id tuples; labels aren't in keys).
+- Also scrub derived views (`cond_branch_then_children`, etc.); they'll be recomputed anyway, but the pruning must be consistent.
+
+### Export (`torchlens/data_classes/interface.py::to_pandas`)
+
+Add columns for: `conditional_branch_depth`, `bool_is_branch`, `bool_context_kind`, `bool_wrapper_kind`, `bool_conditional_id`, plus a compact string form of `conditional_branch_stack`.
+
+## Validation / Invariants (`torchlens/validation/invariants.py`)
+
+1. **`cond_branch_children_by_cond` ↔ `conditional_arm_edges` bidirectional consistency.**
+   For each `(cond_id, branch_kind) → edges` in `conditional_arm_edges`, every `(parent, child)`: `child ∈ parent.cond_branch_children_by_cond[cond_id][branch_kind]` and vice versa.
+2. **Derived views consistency.**
+   `cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children` per-node and `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges` on `ModelLog` equal the projections of primary structures.
+3. **Children labels exist in `ModelLog`.**
+4. **Bool classification invariants.**
+   `bool_is_branch=True` ⟺ `bool_context_kind ∈ {"if_test", "elif_test"}`.
+   `bool_is_branch=True` ⟹ `bool_conditional_id is not None`.
+   `bool_context_kind is not None` ⟹ layer has `is_terminal_bool_layer=True`.
+   `bool_wrapper_kind is not None` ⟹ `bool_context_kind ∈ {"if_test", "elif_test", "bool_cast"}`.
+5. **Conditional event references are valid.**
+   Every `cond_id` in any stack entry, `bool_conditional_id`, `conditional_arm_edges` key, or `cond_branch_children_by_cond` key has matching `ConditionalEvent.id`.
+6. **Stack monotonicity on every parent→child edge (REVISED).**
+   Exactly one of: child.stack extends parent.stack (entry); parent.stack extends child.stack (exit/reconvergence); stacks equal. Non-prefix reorderings are invalid.
+7. **Elif contiguity on `ConditionalEvent` (per-event, not per-node).**
+   `branch_ranges` and `branch_test_spans` keys for elif arms are contiguous from `elif_1`. Per-node `cond_branch_children_by_cond[cid]` may be sparse — that's legal.
+8. **`bool_layers` back-references (NEW).**
+   For every `ConditionalEvent.bool_layers`: each label exists, and each referenced layer's `bool_conditional_id` equals the event's `id`.
+9. **`LayerLog` aggregate consistency (NEW).**
+   `LayerLog.conditional_branch_stacks` equals exactly the set of distinct `LayerPassLog.conditional_branch_stack` values from that layer's passes.
+   `LayerLog.conditional_branch_stack_passes[sig]` equals the sorted list of pass numbers for which that signature appeared.
+10. **`conditional_edge_passes` exactness (NEW).**
+    For every `(parent_no_pass, child_no_pass, cond_id, branch_kind) → [pass_nums]`:
+    - `pass_nums` is sorted ascending and has no duplicates.
+    - For each `pass_num` there exists an unrolled edge `(parent:pass_num, child:pass_num)` in `conditional_arm_edges[(cond_id, branch_kind)]`.
+    - Every unrolled edge in `conditional_arm_edges` is represented somewhere in `conditional_edge_passes`.
+11. **No orphan `_bool_conditional_key` (NEW, dev-mode).**
+    After 5c, no `LayerPassLog` has a `_bool_conditional_key` attribute. Enforced in dev mode to catch incomplete 5c migrations.
+12. **`LayerLog.cond_branch_children_by_cond` aggregate exactness (NEW).**
+    For every `LayerLog`, `cond_branch_children_by_cond` equals the pass-stripped union of `cond_branch_children_by_cond` across its constituent `LayerPassLog` passes. No cond_id or branch_kind present in any pass is missing from the aggregate; no extraneous entries appear.
+13. **Legacy IF-view consistency (NEW).**
+    `conditional_branch_edges` ↔ `cond_branch_start_children` bidirectionally consistent: every `(parent, bool_label)` tuple in `conditional_branch_edges` has `bool_label ∈ parent.cond_branch_start_children`; and every label in any node's `cond_branch_start_children` corresponds to a tuple with that node as parent in `conditional_branch_edges`.
+
+## Tests
+
+### New file `tests/test_conditional_branches.py` + models in `tests/example_models.py` (or dedicated new file if size warrants)
+
+**Baseline / positive:**
+- `SimpleIfElseModel` / `ElifLadderModel` / `NestedIfThenIfModel` / `NestedInElseModel` / `MultilinePredicateModel` — verify THEN/ELIF/ELSE edges, `conditional_events` entries, branch_ranges correctness.
+
+**Branch-entry via non-predicate ancestors (D13):**
+- `BranchUsesOnlyParameterModel` — `if c: y = self.bias + 1`. Assert `self.bias → y` appears in `conditional_arm_edges[(cid, "then")]`.
+- `BranchUsesOnlyConstantModel` — analogous with a constant.
+- **`MultiArmEntryNestedModel` (NEW — Finding 2):** `if A: if B: y = self.bias + 1`. Assert the single `self.bias → y` edge appears in BOTH `conditional_arm_edges[(outer_id, "then")]` AND `conditional_arm_edges[(inner_id, "then")]`, and `self.bias.cond_branch_children_by_cond` has both `outer_id` and `inner_id` mapping to `[y]`. Verify derived `cond_branch_then_children` also lists `y` (uniquely, not twice).
+
+**Wrapped bool (F2 resolution):**
+- `IfBoolCastModel` — `if bool(x.sum() > 0):`. Assert `bool_is_branch=True`, `bool_context_kind="if_test"`, `bool_wrapper_kind="bool_cast"`.
+
+**Multi-pass / rolled (D15):**
+- `LoopedIfAlternatingModel` — `for i: if i%2`. Per-pass stacks differ; aggregate has 2 signatures.
+- `AlternatingRecurrentIfModel` — recurrent, THEN pass 1 / ELSE pass 2.
+- **`RolledMixedArmModel` (strengthened — F7 resolution):** Assert `ModelLog.conditional_edge_passes` has entries with non-trivial pass lists AND each `(parent_no_pass, child_no_pass, cond_id, branch_kind) → pass_nums` is exactly verifiable — sorted ascending, no duplicates, every `pass_num` corresponds to a real unrolled edge in `conditional_arm_edges[(cond_id, branch_kind)]` on that pass. Assert rolled renderer output (graphviz+dagua) contains a composite label. **D13×D15 interaction:** add a companion scenario where the mixed-pass arm edge is ALSO a multi-arm-entry edge (nested conditional taking different inner arms across passes); assert both dimensions survive end-to-end. **Post-cleanup check:** after `keep_unsaved_layers=False`, assert no pruned labels appear in `conditional_edge_passes` keys.
+
+**Reconvergence (F5):**
+- `ReconvergingBranchesModel` — `if c: x=a else: x=b; y=f(x)`. Invariant 6 passes. Assert `y.conditional_branch_stack == []` and both parents' stacks were non-empty.
+
+**Scope resolution (D14):**
+- `NestedHelperSameNameModel` — two local `helper()` functions, same name, different branches. Assert attribution uses `code_firstlineno`; verify `bool_conditional_id` differs between the two helpers' if-statements.
+- **`NestedQualnameModel` (NEW — replaces LambdaBranchModel):** `class Outer: def forward(self): def helper(self): if cond: op() return helper(self)` — nested function named `helper` with a distinct `code_qualname` from a method also named `helper` elsewhere. Assert attribution distinguishes them via `code_qualname` (Python 3.11+).
+- **`SameLineNestedDefModel` (NEW — D14 fail-closed):** Two local defs with the same `func_name` and same `code_firstlineno` (degenerate case, forceable via `exec` or metaprogramming). Assert D14 step 3 triggers: returns empty branch stack for that frame rather than silently picking one; no `conditional_branch_edges` or arm edges are emitted from that site. Also run this under Python 3.9/3.10 CI (where `code_qualname` is None) to verify fail-closed behavior across supported versions.
+- `DecoratedForwardModel` — decorator on forward. Graceful degradation OR correct attribution.
+
+**False positives — non-branch bools:**
+- `AssertTensorCondModel`, `BoolCastOnlyModel`, `TernaryIfExpModel`, `ComprehensionIfModel`, `WhileLoopModel`, `MatchGuardModel`.
+
+**Compound / negation / walrus:**
+- `NotIfModel`, `AndOrIfModel`, `WalrusIfModel`.
+
+**Ternary (D18 — fully attributed):**
+- `BasicTernaryModel` — `y = a(x) if cond else b(x)`. Assert `ConditionalEvent.kind=="ifexp"`; arms `{then, else}`; ops for `a(x)` attributed to `then`, ops for `b(x)` attributed to `else`.
+- `NestedTernaryModel` — `y = (a if c1 else b) if c2 else d`. Assert 2 `ConditionalEvent`s with `kind=="ifexp"`; correct nesting via `parent_conditional_id` / `parent_branch_kind`.
+- `TernaryInsideIfModel` — `if cond: y = a if c2 else b`. Assert mixed stack: outer `if_chain` THEN + inner `ifexp` then/else.
+- `TernaryWithBoolCastModel` — `y = a if bool(t) else b`. Assert `bool_context_kind="ifexp"`, `bool_wrapper_kind="bool_cast"`, ifexp still attributed.
+- `TernaryPy310FailClosedModel` — (gated on Python version) same-line ternary with no `col_offset` available; assert D18 degraded-mode fail-closed: both arms unattributed, no confident wrong label.
+- `TernaryMultiOpOneLineModel` — `y = (a * b + c) if cond else (d / e - f)`. Assert each op attributed to the correct arm via col_offset.
+
+**Documented false negatives (no attribution):**
+- `PythonBoolModel`, `ItemScalarizationModel`, `TorchWhereModel`, `ShapePredicateModel`.
+
+**save_source_context gating (F1 resolution — STRENGTHENED):**
+- **`SaveSourceContextOffModel` (strengthened):** `save_source_context=False`. Assert `func_call_stack` is NON-EMPTY on every captured op; each `FuncCallLocation` has non-None `file`, `line_number`, `code_firstlineno`, and `source_loading_enabled=False`. Assert every accessor returns the existing no-source state: `loc.code_context is None`, `loc.source_context == "None"` (literal 4-char string per current API at `func_call_location.py:150`), `loc.code_context_labeled == ""`, `loc.call_line == ""`, `loc.num_context_lines == 0`, `loc.func_signature is None`, `loc.func_docstring is None`. Assert `len(loc) == 0`, `loc[0]` raises `IndexError`, and `repr(loc)` ends with `"code: source unavailable"`. Assert `loc._frame_func_obj is None` (cleared at construction per D17). Assert no disk access occurred (e.g., by patching `linecache.getlines` with a sentinel; or by monitoring `_source_loaded=True` straight after construction). Branch attribution populated correctly. **Pickle round-trip:** pickle/unpickle a `ModelLog` captured with `save_source_context=False`; unpickled log round-trips cleanly (exercises the `_frame_func_obj` retention fix).
+- **`SaveSourceContextOffAssertModel`:** `save_source_context=False` + `assert tensor_cond`. No false-positive IF edge.
+
+**Field-lifecycle integration (F4 resolution — STRENGTHENED):**
+- **`KeepUnsavedLayersFalseModel` (strengthened):** `keep_unsaved_layers=False` with conditionals. Assert NO removed label appears anywhere in:
+  - `conditional_arm_edges` (tuples).
+  - `conditional_edge_passes` (tuple keys).
+  - `conditional_events[*].bool_layers`.
+  - `cond_branch_children_by_cond` (any nested list) — check on BOTH `LayerPassLog` AND `LayerLog` aggregates.
+  - `conditional_branch_stack_passes` values on `LayerLog`.
+  - All derived views (`cond_branch_then_children`, `cond_branch_elif_children`, `cond_branch_else_children`, `cond_branch_start_children`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges`).
+- `ToPandasConditionalModel` — DataFrame has all conditional columns populated.
+
+**Visualization label precedence (NEW — F8 confirmation):**
+- **`BranchEntryWithArgLabelModel` (NEW):** branch-entry edge that ALSO has an argument label. Assert graphviz renderer output shows branch label in `edge_dict["label"]` and arg label in `edge_dict["headlabel"]` (or `xlabel`) — they do not collide. (Dagua bridge behavior for this case is out of scope; deferred sprint.)
+
+**Smoke:** `@pytest.mark.smoke` on `SimpleIfElseModel`, `ElifLadderModel`.
+
+## Backward Compatibility
+
+- Every existing field retained with identical external semantics.
+- Old fields materialized as derived views from primary cond-id-aware structures. Serialization includes both primary and derived (FIELD_ORDER includes both).
+- `in_cond_branch` remains a direct field; recomputed from `conditional_branch_stack`.
+- `FIELD_ORDER` updates in single commit.
+- Pickle compat: `__setstate__` default-fill for 1 prior minor version. If primary structures are missing on load, reconstruct from legacy derived fields where possible (best-effort for N-1 compat; newer loaders prefer primary).
+
+## Implementation Phases
+
+Each phase gate: tier-1 smoke passes. Tier-2 at phases 4, 6, 9. Tier-3 before PR.
+
+1. **Foundation: fields + capture ungating.**
+   - Add all new fields to `LayerPassLog`, `LayerLog`, `ModelLog`, `FuncCallLocation` + `FIELD_ORDER` updates + defaults.
+   - Ungate `func_call_stack` population in `output_tensors.py`, `source_tensors.py`, `graph_traversal.py` (D17).
+   - Populate `code_firstlineno`, `code_qualname` in stack capture (`utils/introspection.py`).
+   - Gate: existing test suite passes unchanged. New **conditional-branch** fields remain default (empty list/dict, `False`, `None`). New `FuncCallLocation` core identity fields (`code_firstlineno`, `code_qualname`, `source_loading_enabled`) ARE populated per D17; verify via test that `func_call_stack` is non-empty even when `save_source_context=False`, and that lazy source-text properties still return empty/None in that case.
+2. **AST module.**
+   - Write `ast_branches.py` (FileIndex, ConditionalRecord, BoolConsumer index, branch interval trees, classify_bool, attribute_op, cache management).
+   - Unit tests on synthetic source snippets covering all 9 bool-context kinds, flattened elif chains, nested ifs, ternary, match guards, etc.
+   - Gate: `ast_branches` tests pass in isolation.
+3. **Lifecycle wiring (upstream of Step 5 integration).**
+   - Extend `labeling.py::_rename_raw_labels_in_place` for every new field.
+   - Extend `cleanup.py` for every new field.
+   - Extend `interface.py::to_pandas` with new columns.
+   - Integration test: synthetic model with new fields pre-populated manually; `keep_unsaved_layers=False` + `to_pandas()` round-trip.
+   - Gate: lifecycle tests pass.
+4. **Postprocess Step 5 integration (6 phases 5a-5f).**
+   - Restructure `control_flow.py`. 5c is the sole key→id translation.
+   - Wire to `ast_branches.py`.
+   - Remove old post-validation (D12).
+   - Gate: new integration test with `SimpleIfElseModel` passes end-to-end.
+5. **Multi-pass merge + `conditional_edge_passes`.**
+   - Update `_build_layer_logs` for aggregate fields.
+   - Populate `ModelLog.conditional_edge_passes`.
+   - Gate: `AlternatingRecurrentIfModel`, `RolledMixedArmModel` pass.
+6. **Invariants.**
+   - Add 11 checks to `validation/invariants.py`.
+   - Wire into `validate_forward_pass`.
+   - Gate: all tests still pass; invariants catch deliberately-corrupted metadata in unit tests.
+7. **Graphviz rendering.**
+   - Refactor to `_compute_edge_label` precedence function.
+   - Move arg labels to `headlabel`/`xlabel`.
+   - Implement multi-arm and rolled-mixed labels, plus ternary THEN/ELSE.
+   - Gate: visual-diff regression check on existing aesthetic tests.
+8. **(Deferred: Dagua bridge + ELK — per user, not in this sprint.)**
+9. **Integration tests.**
+   - All ~30 conditional tests with assertions.
+   - Gate: all pass; coverage of every listed scenario.
+10. **Documentation.**
+    - Update `AGENTS.md` conditional section.
+    - Update `architecture.md` Step 5 section.
+    - Update `torchlens/user_funcs.py` docstrings: `save_source_context=False` no longer zeros `func_call_stack` — only source-text properties are gated (D17). Any README/API doc references to this behavior get the same update.
+    - User-facing limitations page.
+11. **PR.**
+    - Migration notes with before/after field table.
+    - Compat matrix.
+
+## Deliverables
+
+- 1 new module (~400 lines): `torchlens/postprocess/ast_branches.py`.
+- Modified modules (~10 — dagua_bridge.py and elk_layout.py deferred):
+  - `torchlens/data_classes/{layer_pass_log,layer_log,model_log,func_call_location,cleanup,interface}.py`
+  - `torchlens/constants.py`
+  - `torchlens/postprocess/{control_flow,labeling,graph_traversal}.py`
+  - `torchlens/capture/{source_tensors,output_tensors}.py`
+  - `torchlens/utils/introspection.py`
+  - `torchlens/validation/invariants.py`
+  - `torchlens/visualization/rendering.py` (Graphviz only; dagua + ELK deferred per user)
+- Tests: `tests/test_conditional_branches.py` (~550 lines), ~32 new models.
+- Docs: AGENTS.md, architecture.md, user limitations.
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| R1 | `FIELD_ORDER` mismatch | All field additions in one commit. |
+| R2 | Multi-pass regressions on recurrent tests | `AlternatingRecurrentIfModel` / `RolledMixedArmModel` in Phase 5 test gate. |
+| R3 | Source resolution fragile on decorated/wrapped forwards | Use `frame.f_code.co_firstlineno`/`co_qualname` (D14); don't rely on `inspect.getsourcefile(module_class)`. |
+| R4 | `linecache` stale source after edit | Cache by `(filename, mtime)`; invalidate on mismatch; fail-soft to `unknown`. |
+| R5 | Pre-classification misses a syntactic form → silent `unknown` | Unit tests for every kind; dev-mode assertion: line inside `If.test` span but classifier returns `unknown` → log warning. |
+| R6 | Interval tree perf on huge `forward` | Parse once; O(log k + d) query; benchmark `HugeNestedIfModel` in Phase 2. |
+| R7 | Old pickled ModelLogs fail | `__setstate__` default-fill; document window. |
+| R8 | Arg-label relocation to `headlabel` breaks existing aesthetic tests | Visual-diff gate in Phase 7; gate behind a flag if regressions appear. |
+| R9 | D16 primary structure inflates memory on large models | Benchmark; cond-id keys compact; derived views computed on-demand only. |
+| R10 | D17 ungating breaks something depending on empty `func_call_stack` | Phase 1 tests check `func_call_stack` non-empty; audit any code reading it. |
+| R11 | Multi-arm entry edges produce confusing visuals | Dedicated test (`MultiArmEntryNestedModel`) + label precedence rule + user docs. |
+
+## Open Questions for Architect / User
+
+1. ELK: document as unsupported (default). Confirm?
+2. Multi-arm edge label format: `THEN(cond_outer) · THEN(cond_inner)` vs `2 arms` vs a renderer-side decision. Default: readable form with cond name/IDs.
+3. Pickle compat window: 1 prior minor version (default).
+4. v2 scope confirmation: ternary + while + column offsets + ELK parity.
+5. Test model count: ~32. OK?
+6. `code_qualname` fallback on Python 3.9/3.10 (no `co_qualname`): accept identity-fallback to `code_firstlineno` + `func_name`?
+
+---
+
+## CHANGELOG v2 → v3 (addresses `review_round_2.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R2-F1 Conditional ID contract (BLOCKER) | D10 revised + Step 5c is sole key→id translator + `ConditionalKey` explicit type. |
+| R2-F2 Multi-entry edges cond-id-blind (HIGH) | D16 new: `conditional_arm_edges` + `cond_branch_children_by_cond` primary; legacy fields derived. |
+| R2-F3 `code_qualname` not used in matching (MEDIUM) | D14 revised: exact match on `(filename, code_firstlineno, code_qualname)` first; fallbacks explicit. |
+| R2-F4 Cleanup incomplete for D15 (MEDIUM) | Lifecycle/Cleanup section enumerates every new surface; `KeepUnsavedLayersFalseModel` strengthened. |
+| R2 F1 partial (save_source_context capture path) | D17 new: Phase 1 explicitly ungates `output_tensors.py:311`, `source_tensors.py:169`, `graph_traversal.py:67`. `SaveSourceContextOffModel` strengthened to assert non-empty `func_call_stack`. |
+| R2 F9 partial | Covered by D14 revision and test swap (NestedQualnameModel replacing LambdaBranchModel). |
+| R2 missing invariants (bool_layers back-ref, aggregate stacks, edge_passes exactness) | Invariants 8, 9, 10, 11 added. |
+| R2 phase ordering | Phases reordered: lifecycle wiring is Phase 3, BEFORE Step 5 integration (Phase 4). Phase 1 gate no longer references Phase 5 deliverables. |
+| R2 test gaps | Added `MultiArmEntryNestedModel`, `NestedQualnameModel`, `BranchEntryWithArgLabelModel`; strengthened `SaveSourceContextOffModel`, `KeepUnsavedLayersFalseModel`, `RolledMixedArmModel`. |
+
+## CHANGELOG v3 → v4 (addresses `review_round_3.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R3-F1 5e can attribute via unmaterialized keys (BLOCKER) | Step 5e spec now explicitly DROPS `ConditionalKey`s not in `events_by_key`; rationale and test link to documented false-negative scope. |
+| R3-F2 D17 promises ungated stack but `FuncCallLocation` lazy props eagerly load (HIGH) | D17 revised; `FuncCallLocation` gains `source_loading_enabled: bool`; all lazy props + `__repr__`/`__len__`/`__getitem__` must fail closed when disabled. Phase 1 gate wording updated. |
+| R3-F3 D14 fallback can still silently pick wrong scope on 3.9/3.10 (MEDIUM) | D14 revised v2: step 2 requires unique match; step 3 FAILS CLOSED (no smallest-containing-scope heuristic). New `SameLineNestedDefModel` test exercises the fail-closed path. |
+| R3-F4 Invariants incomplete (MEDIUM) | Added invariants 12 (`LayerLog.cond_branch_children_by_cond` aggregate exactness) and 13 (legacy IF-view consistency). |
+| R3-F5 Phase 1 gate imprecise (MEDIUM) | Gate wording split: conditional-branch fields stay default; `FuncCallLocation` identity fields populated; verify via explicit sub-test. |
+| R3-F6 Nondeterministic `cond_id` assignment (MEDIUM) | 5b/5c spec updated: iterate `ModelLog.layer_list` order, collect keys in first-seen order via insertion-ordered dict (not set). |
+| R3-F7 Docs miss user_funcs.py (LOW) | Phase 10 adds `user_funcs.py` docstring updates + README/API doc corrections. |
+| R3 test gaps (MultiArm/NestedQualname/BranchEntry/SaveSrcOff/KeepUnsaved/RolledMixed) | All six test rows strengthened with concrete assertion lists; `SameLineNestedDefModel` added. |
+
+## CHANGELOG v4 → v5 (addresses `review_round_4.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R4-F1 `source_loading_enabled` incomplete for full `FuncCallLocation` surface (HIGH) | D17 revised v2 + data model expanded to enumerate all 7 lazy accessors (`source_context`, `code_context`, `code_context_labeled`, `call_line`, `num_context_lines`, `func_signature`, `func_docstring`). When disabled, all lazy backing fields are initialized empty at construction (no disk access); `_frame_func_obj` is cleared at construction to prevent pickle fragility with nested/local functions. |
+| R4-F2 `attribute_op` subsection contradicts D14 v2 (MEDIUM) | Algorithm subsection updated: no more "smallest containing scope" heuristic; step 3 fails closed (skips frame) matching D14 v2. |
+| R4-F3 `source_context == []` type contradicts current `str` API (LOW) | `SaveSourceContextOffModel` assertions aligned to `str` types: `source_context == ""` etc. Pickle round-trip also added. |
+| R4 test gap: disabled-source accessor coverage | Strengthened `SaveSourceContextOffModel` now asserts every lazy accessor + `_frame_func_obj is None` + pickle round-trip. |
+
+## CHANGELOG v5 → v6 (addresses `review_round_5.md`)
+
+| Finding | Disposition |
+|---------|-------------|
+| R5-F1 disabled-source contract contradicted current `code_context` API (MEDIUM) | D17 revised v3 + data-model comment + `SaveSourceContextOffModel` all re-aligned to the current "no source available" contract: `code_context=None`, `source_context="None"` (literal string), `code_context_labeled=""`, `call_line=""`, `num_context_lines=0`, `func_signature=None`, `func_docstring=None`, `_frame_func_obj=None`; `len==0`; `__getitem__` raises `IndexError`; `__repr__` ends with "code: source unavailable". No disk access when disabled. |
+
+## CHANGELOG v6 → v7 (user-directed scope changes)
+
+| Change | Rationale |
+|--------|-----------|
+| Ternary (`ast.IfExp`) promoted to fully-attributed (D18, D3 revised) | User: "do v2 now"; ternary is close enough to if/else and benefits from unified attribution model. Column-offset capture enables same-line arm disambiguation. |
+| Column offsets added to `FuncCallLocation` (D18) | Required for ternary arm attribution (both arms share a source line). Python 3.11+ via `co_positions()`; 3.9/3.10 fail-closed for same-line ambiguity. |
+| `ConditionalEvent.kind` discriminator (`"if_chain"` / `"ifexp"`) | Differentiates ternary from if-chains without forking the data model. |
+| `branch_ranges` and `test_span` widened to 4-tuples `(start_line, start_col, end_line, end_col)` | Required for col-aware lookup. Consistent for both `if_chain` and `ifexp`. |
+| While-loop attribution formally deferred (new sprint) | Iteration semantics differ from branch attribution; warrants own plan. Tracked in `.project-context/todos.md`. |
+| Dagua bridge work removed from scope | User directive. `visualization/dagua_bridge.py` untouched in v1. |
+| ELK rendering removed from scope | User directive. `visualization/elk_layout.py` untouched in v1 (not even a comment). |
+| Test matrix gains 6 ternary models | `BasicTernaryModel`, `NestedTernaryModel`, `TernaryInsideIfModel`, `TernaryWithBoolCastModel`, `TernaryPy310FailClosedModel`, `TernaryMultiOpOneLineModel`. |
+| `BranchEntryWithArgLabelModel` simplified to Graphviz-only | Dagua assertion removed. |

--- a/.project-context/plans/if-else-attribution/review_round_1.md
+++ b/.project-context/plans/if-else-attribution/review_round_1.md
@@ -1,0 +1,102 @@
+# Adversarial Review: `if` / `elif` / `else` Attribution Sprint Plan
+
+Scope reviewed:
+- Full plan in `.project-context/plans/if-else-attribution/plan.md`
+- Research grounding in `.project-context/research/ast-design.md`, `adversarial.md`, `prior-art.md`
+- Current implementation surfaces in `torchlens/postprocess/control_flow.py`, data classes, constants, visualization, labeling, cleanup, and validation
+
+## Finding 1: `save_source_context=False` is internally inconsistent with D3/D9/D12
+- Severity: blocker
+- What's wrong: D3 and D12 say Step 5 should pre-classify bools and remove the old "mark first, clear later" behavior, but D9 keeps AST attribution gated on `save_source_context=True`, and the test matrix's `SaveSourceContextOffModel` still expects legacy IF-edge behavior with no branch attribution. Those three positions do not compose.
+- Why it matters: current Step 5 floods backward from **all** terminal bools and only does AST validation when `save_source_context` is on (`torchlens/postprocess/control_flow.py:51-77`, `164-193`). If the new classifier is also gated off, 5d has no way to distinguish real `if`/`elif` tests from `assert`, `bool()`, `while`, or comprehension filters. Either false positives come back, or IF edges disappear entirely.
+- Suggested fix: change D9 to say: "AST classification needed for Step 5 runs whenever `func_call_stack` has `(file, line)`; `save_source_context` only gates rich source snippets and user-facing source display." Then update Step 5b/5d and the `SaveSourceContextOffModel` row to match that rule.
+- Test: add a `save_source_context=False` case with `assert tensor_cond` and verify no `conditional_branch_edges` are emitted.
+
+## Finding 2: `if bool(tensor_cond):` is a real branch that the classifier would suppress
+- Severity: high
+- What's wrong: Step 5b says to choose the innermost non-`unknown` bool consumer, and D3 treats `bool_cast` as non-branch. For `if bool(tensor_cond):`, the innermost consumer is the `bool(...)` call, not the enclosing `If.test`, so the plan classifies a genuine branch as non-branch.
+- Why it matters: this is not the same case as `flag = bool(tensor)` with no branch. The runtime bool conversion still drives an `if`, but the proposed rule would set `bool_is_branch=False` and drop attribution. The problem follows directly from the plan's `classify_bool()` rule plus the explicit bool-consumer index in `ast_branches.py`.
+- Suggested fix: change D3/Step 5b so that a `bool(...)` consumer nested inside an `If.test` or flattened `elif` test is normalized to branch participation. If you still want to preserve the cast information, record it separately, e.g. `bool_context_kind="if_test"` plus `bool_wrapper_kind="bool_cast"`.
+- Test: add `IfBoolCastModel` with `if bool(x.sum() > 0): ...` and assert `bool_is_branch=True`.
+
+## Finding 3: Step 5e only looking at branch-start nodes misses valid branch-entry edges
+- Severity: blocker
+- What's wrong: Step 5e says "For each branch-start node's children, diff parent vs child stack to determine which branch was entered." That preserves the current assumption that branch entry must appear on an edge out of a branch-start node.
+- Why it matters: that is false when the first op inside a branch depends only on a parameter, buffer, or constant rather than on the predicate's dataflow ancestors. Current THEN detection already has this limitation because it only inspects `start_node.child_layers` (`torchlens/postprocess/control_flow.py:146-163`). Example:
+
+```python
+if x.sum() > 0:
+    y = self.bias + 1
+else:
+    y = self.bias - 1
+```
+
+The branch-local ops should get THEN/ELSE attribution, but there may be no edge from the branch-start node to those ops, so no labeled entry edge is ever emitted.
+- Suggested fix: change Step 5e to diff stacks on **all** forward edges `(parent, child)`, not just edges whose parent is a branch-start node. Keep `conditional_branch_edges` as the legacy IF-edge structure, but derive THEN/ELIF/ELSE entry edges from the first gained stack item on any edge.
+- Test: add `BranchUsesOnlyParameterModel` and assert that an arm label is emitted on the parameter-to-op edge.
+
+## Finding 4: The plan misses Step 11/cleanup/export integration for the new fields
+- Severity: high
+- What's wrong: the plan adds new raw-label-bearing fields (`cond_branch_else_children`, `cond_branch_elif_children`, `conditional_elif_edges`, `conditional_else_edges`, `conditional_events.bool_layers`) but does not explicitly update the rename, cleanup, and export surfaces that currently hardcode the old conditional fields only.
+- Why it matters: current rename logic only knows about `cond_branch_start_children`, `cond_branch_then_children`, `conditional_branch_edges`, and `conditional_then_edges` (`torchlens/postprocess/labeling.py:214-228`, `551-562`). Cleanup only filters the two existing edge lists (`torchlens/data_classes/cleanup.py:157-166`, `212-217`). Capture-time field initialization only sets the current conditional fields (`torchlens/capture/source_tensors.py:230-248`, `torchlens/capture/output_tensors.py:171-175`). `to_pandas()` does not even expose today's conditional fields (`torchlens/data_classes/interface.py:406-507`).
+- Suggested fix: change Phase 1 and Deliverables to explicitly include `torchlens/postprocess/labeling.py`, `torchlens/data_classes/cleanup.py`, `torchlens/capture/source_tensors.py`, `torchlens/capture/output_tensors.py`, and `torchlens/data_classes/interface.py`. Add a rule: every new label-bearing field must be wired through rename, cleanup, and export before Phase 1 is considered green.
+- Test: run a keep/trim scenario (`keep_unsaved_layers=False`) and assert no new conditional field contains a removed raw label after Step 12.
+
+## Finding 5: Invariant 6 rejects legitimate reconvergence
+- Severity: high
+- What's wrong: invariant 6 says "For a parent→child edge, the child's stack contains the parent's stack as a prefix (or enters a new branch)." That only allows equality or suffix growth.
+- Why it matters: legal control-flow exits do the opposite. In `ReconvergingBranchesModel`, the edge from a branch-local op to a post-merge op should drop the innermost `(cond_id, branch_kind)` suffix. The plan's own test matrix includes `ReconvergingBranchesModel`, so invariant 6 would false-positive on a case the plan claims to support.
+- Suggested fix: rewrite invariant 6 to allow suffix pops as well as suffix pushes. Concrete replacement: "For any parent→child edge, one stack must be a prefix of the other; gains represent branch entry, drops represent branch exit/reconvergence."
+- Test: explicitly assert that reconverging edges pass invariants while a non-prefix reordering fails.
+
+## Finding 6: Invariant 7 is attached to the wrong data structure
+- Severity: medium
+- What's wrong: invariant 7 requires `cond_branch_elif_children` keys to be contiguous from 1 for a given `cond_id`. That is reasonable for the normalized `ConditionalEvent`, but not for every per-node adjacency dict.
+- Why it matters: a particular parent node may legitimately have only an `elif_2` entry because it has no direct edge into `elif_1`, or because `elif_1` contains no captured op reachable from that parent. The same issue gets worse after the LayerLog union step, where per-parent sparse coverage is expected.
+- Suggested fix: move the contiguity check from per-node `cond_branch_elif_children` to `ConditionalEvent.branch_ranges` / `branch_test_spans`. For per-node child maps, only enforce that keys are positive ints and children exist.
+- Test: add a model where only the second `elif` arm has a direct edge from a given parent, and ensure invariants still pass.
+
+## Finding 7: Rolled-mode branch labels lose pass-level truth
+- Severity: high
+- What's wrong: the LayerLog merge in the plan unions `cond_branch_*_children` after stripping pass suffixes, but it does not introduce any edge-level pass map for branch arms.
+- Why it matters: the same rolled parent→child edge can be THEN on pass 1 and ELSE on pass 2. Current rolled Graphviz and dagua rendering already consume only aggregate child lists plus generic pass labels (`torchlens/visualization/rendering.py:985-996`, `1162-1188`; `torchlens/visualization/dagua_bridge.py:342-354`, `478-490`). With the proposed union semantics, the renderer has no truthful way to label that edge.
+- Suggested fix: add an explicit rolled-edge data structure, e.g. `conditional_edge_passes[(parent_no_pass, child_no_pass, cond_id, branch_kind)] -> [pass_nums]`, and update the Visualization section to define how conflicting branch kinds are rendered (`THEN 1 / ELSE 2`, `mixed`, etc.).
+- Test: add a recurrent model where the same no-pass edge is THEN on one pass and ELSE on another, and assert the rolled renderer does not collapse it to a single-arm label.
+
+## Finding 8: Visualization label precedence is underspecified and currently collides
+- Severity: medium
+- What's wrong: D11 says to extend the existing IF/THEN label block for ELIF/ELSE, but the current Graphviz code already uses a single `edge_dict["label"]` and overwrites IF with THEN (`torchlens/visualization/rendering.py:984-996`). Argument labels then append into the same label field (`1049-1090`). Dagua likewise picks exactly one edge type (`torchlens/visualization/dagua_bridge.py:342-354`).
+- Why it matters: once ELIF/ELSE are added, the renderer still needs a precedence rule. Is a THEN edge also an IF edge? What wins when the same edge also needs an argument label? What happens in rolled mode when pass annotations are present? The plan does not answer any of those.
+- Suggested fix: change the Visualization section to define explicit composition rules. Concrete recommendation:
+  - `IF` is only used for condition-chain edges (`conditional_branch_edges`)
+  - arm-entry edges use `THEN` / `ELIF n` / `ELSE` and suppress `IF`
+  - argument labels move to `headlabel`/`xlabel` so they do not compete with branch labels
+  - dagua_bridge must use the same precedence order
+- Test: add a model where a branch-entry edge is also argument-labeled and verify the rendered label is deterministic.
+
+## Finding 9: Per-frame attribution does not have enough runtime identity to resolve scopes robustly
+- Severity: high
+- What's wrong: D4 and the `attribute_op(func_call_stack)` design rely on per-frame scope resolution, but current `FuncCallLocation` only stores `file`, `line_number`, and `func_name` (`torchlens/data_classes/func_call_location.py:50-69`). Stack capture only records `co_filename`, `co_name`, and `f_lineno`, with a best-effort name lookup for the function object (`torchlens/utils/introspection.py:404-464`).
+- Why it matters: line-only scope resolution is under-specified for nested helpers with repeated names, lambdas, decorated wrappers, and local functions defined on the same line. The plan's `FileIndex` talks about `function_qualname`, lambdas, and smallest-containing-function lookup, but the runtime evidence currently retained by TorchLens is not enough to do that reliably.
+- Suggested fix: amend the Foundation section and `ast_branches.py` API to require `FuncCallLocation` to store `code_firstlineno` (minimum) and preferably a qualname/code-object identity. Then resolve scopes by `(filename, code_firstlineno, func_name)` before falling back to line-only heuristics.
+- Test: add `NestedHelperSameNameModel` and `LambdaBranchModel` so the implementation cannot silently pass with line-only scope matching.
+
+## Summary: verdict = RED
+- The AST-first direction is still viable.
+- The plan is not implementable as-is without correctness regressions.
+- The biggest issues are the D3/D9/D12 contradiction, the branch-entry edge restriction in 5e, and the lack of a truthful rolled-edge story.
+
+## Blockers
+- `save_source_context=False` semantics contradict D3/D9/D12 and leave Step 5 with no correct bool-selection rule.
+- Step 5e only labels edges out of branch-start nodes, so valid branch entries can be missed entirely.
+
+## Highs
+- `if bool(tensor_cond):` would be misclassified as non-branch.
+- New fields are not wired through rename/cleanup/export surfaces.
+- Invariant 6 would reject legitimate reconvergence.
+- Rolled-mode visualization has no pass-level arm metadata, so unioned child lists can lie.
+- Per-frame runtime metadata is too weak for robust scope attribution in nested helper/lambda/decorator cases.
+
+## Mediums/Lows
+- Invariant 7 applies contiguity to the wrong structure.
+- Visualization label precedence/composition is not specified, and the current renderer already overwrites IF with THEN.

--- a/.project-context/plans/if-else-attribution/review_round_2.md
+++ b/.project-context/plans/if-else-attribution/review_round_2.md
@@ -1,0 +1,89 @@
+# Adversarial Review Round 2: `if` / `elif` / `else` Attribution Sprint Plan v2
+
+Scope reviewed:
+- Current plan: `.project-context/plans/if-else-attribution/plan.md`
+- Prior plan: `.project-context/plans/if-else-attribution/plan_v1.md`
+- Prior review: `.project-context/plans/if-else-attribution/review_round_1.md`
+- Grounding: `.project-context/research/{ast-design,adversarial,prior-art}.md`
+- Current code paths named in the plan and round-1 review
+
+## Resolution
+
+| Finding | Status | Why |
+|---|---|---|
+| F1 | PARTIALLY RESOLVED | D9 correctly changes the intended semantics so AST classification no longer depends on `save_source_context` (`plan.md:61`, `84`, `413-417`). But the plan still assumes `(file, line)` is "always" present while the current capture path still zeros `func_call_stack` when `save_source_context=False` in [output_tensors.py](/home/jtaylor/projects/torchlens/torchlens/capture/output_tensors.py:311), [source_tensors.py](/home/jtaylor/projects/torchlens/torchlens/capture/source_tensors.py:169), and [graph_traversal.py](/home/jtaylor/projects/torchlens/torchlens/postprocess/graph_traversal.py:67). The v2 phases/deliverables never explicitly schedule those ungates. |
+| F2 | RESOLVED | D3 now treats `bool(x)` inside `If.test` / `elif` as branch-participating and records `bool_wrapper_kind="bool_cast"` (`plan.md:55`, `194-202`). The new `IfBoolCastModel` row exercises the fix (`plan.md:364-367`). |
+| F3 | RESOLVED | D13 changes 5e from "branch-start children only" to diffing stacks on every forward edge (`plan.md:65`, `228-240`). The new `BranchUsesOnlyParameterModel` / `BranchUsesOnlyConstantModel` rows directly cover the original gap (`plan.md:358-362`). |
+| F4 | PARTIALLY RESOLVED | v2 adds the missing lifecycle section and includes `labeling.py`, `cleanup.py`, and `interface.py` in phases/deliverables (`plan.md:288-310`, `441`, `459-463`). But the cleanup spec still only mentions pruning "new edge lists" and omits `conditional_edge_passes`, `conditional_events[*].bool_layers`, and surviving parents' new child lists/maps; current cleanup already only knows about `conditional_branch_edges` / `conditional_then_edges` ([cleanup.py](/home/jtaylor/projects/torchlens/torchlens/data_classes/cleanup.py:157), [cleanup.py](/home/jtaylor/projects/torchlens/torchlens/data_classes/cleanup.py:212)). |
+| F5 | RESOLVED | Invariant 6 is rewritten to allow either stack to be a prefix of the other, explicitly permitting reconvergence (`plan.md:330-335`). `ReconvergingBranchesModel` now asserts that case (`plan.md:376-379`). |
+| F6 | RESOLVED | Invariant 7 has been moved off the per-node `cond_branch_elif_children` map and onto `ConditionalEvent.branch_ranges` (`plan.md:336-337`). That addresses the sparse-per-parent case raised in round 1. |
+| F7 | RESOLVED | D15 adds explicit pass-level rolled-edge metadata and the visualization section now defines composite rolled labels (`plan.md:67`, `139-142`, `250-261`). That resolves the original absence of a truthful rolled-edge data source. |
+| F8 | RESOLVED | v2 now specifies label precedence, says arm-entry labels suppress `IF`, and moves arg labels off the main `label` field (`plan.md:248-275`). That directly addresses the overwrite/collision problem in current [rendering.py](/home/jtaylor/projects/torchlens/torchlens/visualization/rendering.py:985) and [dagua_bridge.py](/home/jtaylor/projects/torchlens/torchlens/visualization/dagua_bridge.py:342). |
+| F9 | PARTIALLY RESOLVED | D14 adds `code_firstlineno` and `code_qualname` and keys `FileIndex` by `(code_firstlineno, qualname)` (`plan.md:66`, `71-84`, `187-193`). But `attribute_op()` still says resolution is by `(filename, code_firstlineno, func_name)` rather than `code_qualname` (`plan.md:204-207`), so the new identity field is not actually in the primary runtime match key. |
+
+## New
+
+## Finding 1: D10 and Step 5 disagree on when `conditional_id` becomes a dense int
+- Severity: blocker
+- What's wrong: D10 says `conditional_id` is a dense per-`ModelLog` integer and that the structural AST key is internal only (`plan.md:62`). But 5b has `classify_bool()` already returning `maybe_cond_id` and immediately writing `bool_conditional_id` plus appending into `ModelLog.conditional_events[cond_id].bool_layers` (`plan.md:202`, `216-223`), even though 5c is the step that materializes `conditional_events`.
+- Why it matters: as written, the identifier can’t be both a dense external int and an AST-internal structural key at the same moment. The spec also asks `attribute_op()` to return `List[Tuple[int, str]]` before the dense-id materialization exists (`plan.md:183`, `204-209`). An implementation worker would have to invent an unstated temporary-key rewrite pass.
+- Fix: introduce an explicit temporary `ConditionalKey` type in `ast_branches.py`, let 5a/5b/5e operate on keys, and make 5c the sole "key -> dense int" translation step that rewrites `bool_conditional_id`, `conditional_branch_stack`, and all emitted edge records in one pass. Alternative: move event materialization and dense-id assignment before 5b.
+- Test: add a model with one `if a and b:` plus one nested `elif` so that multiple bool layers and nested stack entries must all map to the same final dense IDs.
+
+## Finding 2: D13 allows multi-entry edges, but the new edge structures are still cond-id-blind
+- Severity: high
+- What's wrong: 5e now says a single forward edge can gain every stack item present in `child_stack` but not `parent_stack` (`plan.md:231-238`). That makes one edge legitimately enter multiple branches at once, e.g. outer `then` and inner `then` for a parameter-fed op inside a nested `if`. But the preserved THEN structures are still only `(parent, child)` and `List[str]` with no `cond_id` (`plan.md:108-111`, `163-165`), and the new per-parent `elif` / `else` child maps are also not keyed by `cond_id` (`plan.md:103-105`).
+- Why it matters: the first new case D13 unlocks is also the first case the data model cannot represent losslessly. On one `parent -> child` edge you can have two simultaneous THEN entries, or two different conditionals each with `elif_1`, and the current primary structures collapse them. The visualization API also still returns a single branch label per edge (`plan.md:252-257`, `269`, `275`), so even a correct implementation has nowhere truthful to put the second entry.
+- Fix: add a cond-id-aware primary arm-entry structure for all branch kinds, e.g. `conditional_arm_edges[(cond_id, branch_kind)] -> List[(parent, child)]` and a parent-side `cond_branch_children_by_cond: Dict[int, Dict[str, List[str]]]`. Keep `conditional_then_edges` and `cond_branch_then_children` as backward-compatible derived unions only.
+- Test: add a nested-`if` model where `self.bias -> add` enters outer THEN and inner THEN on the same pass, and assert both cond IDs survive in the primary structure.
+
+## Finding 3: D14 captures `code_qualname`, but the algorithm never actually matches on it
+- Severity: medium
+- What's wrong: the plan says the file index is keyed by `(code_firstlineno, qualname)` (`plan.md:187-193`) and D14 explicitly adds `code_qualname` to `FuncCallLocation` (`plan.md:66`, `71-84`). But `attribute_op()` still resolves scopes by `(filename, code_firstlineno, func_name)` (`plan.md:204-207`).
+- Why it matters: the new field that was added to fix same-name nested helpers and lambda/decorator ambiguity is not in the actual primary lookup key. In practice that means the v2 fix still relies mostly on `co_firstlineno`, with `code_qualname` present but inert. That is weaker than the decision text promises.
+- Fix: make the exact-match path use `(filename, code_firstlineno, code_qualname)` and only fall back to `func_name` / line-based heuristics when `code_qualname` is unavailable.
+- Test: keep `NestedHelperSameNameModel`, but replace `LambdaBranchModel` with a case that actually exercises D14’s matching logic under a real branch-attribution path. The current `lambda x: op(x) if cond else op2(x)` example is `IfExp`, which the plan explicitly classifies but does not attribute (`plan.md:20`, `45`, `393`).
+
+## Fresh
+
+## Finding 4: The D15 cleanup and validation story is still incomplete
+- Severity: medium
+- What's wrong: the lifecycle section says cleanup should prune "new edge lists" (`plan.md:304-305`), and the keep-unsaved-layers test only mentions those edge lists (`plan.md:419-423`). Nothing there covers `conditional_edge_passes`, `conditional_events[*].bool_layers`, or the new aggregate pass maps on `LayerLog`. The current cleanup code only filters `conditional_branch_edges` and `conditional_then_edges` ([cleanup.py](/home/jtaylor/projects/torchlens/torchlens/data_classes/cleanup.py:157), [cleanup.py](/home/jtaylor/projects/torchlens/torchlens/data_classes/cleanup.py:212)).
+- Why it matters: once D15 exists, stale rolled-edge keys are user-visible wrong metadata, not just dead internal state. The same applies to stale `bool_layers` references inside `ConditionalEvent`: they let a pruned bool layer continue to "drive" a surviving event.
+- Fix: extend the cleanup spec to scrub `conditional_edge_passes`, `conditional_events[*].bool_layers`, and every surviving parent-side conditional child list/map. Add reverse-link invariants for `bool_layers` and exactness invariants for the pass maps.
+- Test: strengthen `KeepUnsavedLayersFalseModel` so it asserts that no removed label appears anywhere in `conditional_edge_passes`, `conditional_events.bool_layers`, `cond_branch_*_children`, or `conditional_branch_stack_passes`.
+
+## Tests
+
+- `BranchUsesOnlyParameterModel`: good. It directly exercises the D13 fix the round-1 review requested.
+- `IfBoolCastModel`: good. It directly exercises D3’s wrapped-bool normalization and the new `bool_wrapper_kind`.
+- `RolledMixedArmModel`: partial. It checks renderer output, but not whether `conditional_edge_passes` is itself correct, stable, or pruned after layer removal.
+- `NestedHelperSameNameModel`: partial. It exercises `code_firstlineno`; it does not prove that `code_qualname` is used in matching.
+- `LambdaBranchModel`: not a real coverage row for D14. As specified, it uses `IfExp`, which the plan marks as classified-but-not-attributed (`plan.md:19-25`, `43-46`, `393`).
+- `SaveSourceContextOffModel`: partial. It should assert that `func_call_stack` is non-empty and carries `(file, line, code_firstlineno)` under `save_source_context=False`, otherwise it misses the live gating bug in [output_tensors.py](/home/jtaylor/projects/torchlens/torchlens/capture/output_tensors.py:311).
+- `KeepUnsavedLayersFalseModel`: partial. It currently covers only "new edge lists"; it should cover `conditional_edge_passes`, `conditional_events.bool_layers`, and surviving parents’ conditional child lists/maps.
+- Missing entirely: one test where a branch-entry edge is also argument-labeled, to prove the D11 precedence rule and the `headlabel` / `xlabel` move actually solve the current [rendering.py](/home/jtaylor/projects/torchlens/torchlens/visualization/rendering.py:1087) overwrite path.
+- Missing entirely: one nested parameter-only model where a single edge gains two branch-stack items at once, which is the first correctness cliff introduced by D13.
+
+## Phases
+
+- The phase ordering is not sound as written. `plan.md:310` says Phase 1 cannot be declared green until rename and cleanup are verified, but rename/cleanup are not scheduled until Phase 5 (`plan.md:441-442`). That gate is impossible to satisfy literally.
+- D9’s "always capture `(file, line)`" semantics must be a Phase 1 deliverable, and the file list needs to explicitly include `torchlens/postprocess/graph_traversal.py`; the live save-source gate there ([graph_traversal.py](/home/jtaylor/projects/torchlens/torchlens/postprocess/graph_traversal.py:67)) otherwise survives past the foundation phase.
+- The dense-id design from Finding 1 has to be resolved before Phase 3. Otherwise Step 5 is blocked on an identifier contract that is still contradictory.
+- Recommended order: Phase 1 should include `FuncCallLocation` augmentation, ungated stack capture plumbing, and the temporary-vs-dense conditional-key design; only then is the AST module / Step 5 work in Phases 2-3 well-specified.
+
+## Invariants
+
+- The 8 invariants are not yet complete for the new state.
+- Missing invariant: every label in `ConditionalEvent.bool_layers` exists and each referenced bool layer points back to the same `bool_conditional_id`.
+- Missing invariant: `LayerLog.conditional_branch_stacks` and `conditional_branch_stack_passes` must equal the exact set/map induced by the underlying `LayerPassLog.conditional_branch_stack` values. D5 adds those aggregates, but none of invariants 1-8 checks them.
+- Missing invariant: `conditional_edge_passes` should be exact, not just plausible. It should enforce unique sorted pass numbers and prove that each `(parent_no_pass, child_no_pass, cond_id, branch_kind, pass_num)` corresponds to a real unrolled edge classified that way on that pass.
+- Missing invariant: if D13 continues to allow an edge to gain more than one stack item, there must be a cond-id-aware primary representation that proves no information was lost. Right now the invariant set cannot detect that loss because the primary structures are already collapsed.
+
+## Summary: verdict = RED
+
+- v2 fixes most of the round-1 conceptual objections.
+- It still contains one specification-level blocker: the conditional-ID contract is internally inconsistent.
+- The largest new hole introduced by v2 is D13’s multi-entry edge case, which the current edge data model and visualization contract cannot represent losslessly.
+
+Count: 1 blocker / 1 high / 2 mediums / 0 lows

--- a/.project-context/plans/if-else-attribution/review_round_3.md
+++ b/.project-context/plans/if-else-attribution/review_round_3.md
@@ -1,0 +1,80 @@
+## Resolution
+
+| Finding | Status | Why |
+|---|---|---|
+| R2-F1 Conditional ID contract | RESOLVED | D10 + 5b/5c/5e now consistently use `ConditionalKey` before 5c and dense `cond_id` after 5c. The v2 contradiction between early `bool_conditional_id` writes and late event materialization is gone. |
+| R2-F2 Multi-entry edges cond-id-blind | RESOLVED | D16 adds cond-id-aware primaries: `ModelLog.conditional_arm_edges` and `LayerPassLog.cond_branch_children_by_cond`. That directly fixes the v2 lossiness for one edge entering multiple arms. |
+| R2-F3 `code_qualname` not used in matching | RESOLVED | D14 now makes the exact-match path `(filename, code_firstlineno, code_qualname)` first, with explicit fallback order after that. |
+| R2-F4 Cleanup incomplete for D15 | RESOLVED | Phase 3 now explicitly wires rename/cleanup through `conditional_edge_passes`, `conditional_events[*].bool_layers`, and `cond_branch_children_by_cond`, which are missing in current code at `torchlens/postprocess/labeling.py:216-228`, `torchlens/postprocess/labeling.py:551-562`, and `torchlens/data_classes/cleanup.py:157-166`, `torchlens/data_classes/cleanup.py:212-217`. |
+| R1 partial: save-source capture-path ungating | PARTIAL | D17 correctly schedules ungating at the three live gates in `torchlens/capture/source_tensors.py:169-171`, `torchlens/capture/output_tensors.py:67-69` and `311-312`, and `torchlens/postprocess/graph_traversal.py:67-68`. But v3 also claims `source_context` stays empty under `save_source_context=False`, and it never specifies the required `FuncCallLocation` gating despite current unconditional loading in `torchlens/data_classes/func_call_location.py:107-169`. |
+| R1 partial: lifecycle wiring for new fields | RESOLVED | Capture defaults, Phase 3 rename, Phase 3 cleanup, and `to_pandas()` are all now called out explicitly. That closes the earlier “new field exists but is not renamed/cleaned/exported” planning gap. |
+| R1 partial: runtime identity too weak for robust scope resolution | PARTIAL | D14 is materially better than v2, but the broader concern is only partially resolved because TorchLens supports Python 3.9/3.10 (`pyproject.toml:11`, `pyproject.toml:20-23`), where `code_qualname` is absent and the plan falls back to heuristics. |
+
+## New-in-v3
+
+### Finding 1
+- Severity: blocker
+- Description: 5e can discover enclosing conditionals that 5c never materialized.
+- Why it matters: D10/5c creates `conditional_events` only from bool-driven `ConditionalKey`s collected in 5b, but 5e re-runs `attribute_op(func_call_stack)` for every op and then translates each returned key through `events_by_key`. That does not compose with the plan’s own documented false negatives (`if self.training:`, `if x.shape[0] > 0:`, `if tensor.item() > 0:`): those ops are lexically inside an `if`, so 5e can still see a branch interval even though no branch-driving bool was captured. As written, that is either a lookup miss or silent over-attribution. Current Step 5 is still rooted in observed terminal bools only (`torchlens/postprocess/control_flow.py:30-76`).
+- Concrete fix: make 5e explicitly drop any `ConditionalKey` not present in `events_by_key`, or define `attribute_op()` to return only keys already materialized from 5b. Do not leave this as an implicit implementation choice.
+- Optional test: strengthen `PythonBoolModel` and `ShapePredicateModel` to assert `conditional_branch_stack == []` on branch-local ops and no failure during 5e translation.
+
+### Finding 2
+- Severity: high
+- Description: D17 is not implementable as written without changing `FuncCallLocation` semantics.
+- Why it matters: v3 says core call-site identity is always captured but lazy source text remains gated by `save_source_context`. Current `FuncCallLocation` cannot do that. Once a stack entry exists, `_load_source()` will eagerly load `code_context`, `source_context`, `func_signature`, and `func_docstring` on first access regardless of `save_source_context` (`torchlens/data_classes/func_call_location.py:107-169`), and `__repr__`, `__len__`, and `__getitem__` all trigger that path (`torchlens/data_classes/func_call_location.py:238-263`). The public docstring also still says call stacks are recorded only when `save_source_context=True` (`torchlens/user_funcs.py:231-233`).
+- Concrete fix: add an explicit “source loading enabled” flag to `FuncCallLocation`, have `_load_source()` fail closed when disabled, and update repr/accessor behavior plus docs accordingly.
+- Optional test: in `SaveSourceContextOffModel`, assert `repr(loc)` says source unavailable and `len(loc) == 0`, not just that the stack is non-empty.
+
+### Finding 3
+- Severity: medium
+- Description: D14’s fallback can still select the wrong scope on supported runtimes.
+- Why it matters: exact matching is good on Python 3.11+, but TorchLens supports 3.9/3.10 (`pyproject.toml:11`, `pyproject.toml:20-23`) where `code_qualname` may be unavailable. The plan then falls back to `(filename, code_firstlineno, func_name)` and finally “smallest containing scope”. That is still wrong for same-line nested defs/lambdas and for wrapper/decorator frames where the exact scope is not the user branch scope.
+- Concrete fix: state a fail-closed rule when the exact match misses on 3.9/3.10 or when multiple candidate scopes remain. Do not silently choose the smallest containing scope in ambiguous cases.
+- Optional test: add a 3.9/3.10-targeted same-line nested-helper case, or explicitly mark that class of ambiguity unsupported.
+
+### Finding 4
+- Severity: medium
+- Description: Invariants 8-11 are helpful but still not sufficient for the new state.
+- Why it matters: they cover `bool_layers`, stack aggregate exactness, `conditional_edge_passes`, and orphan temporary keys. They do not explicitly prove that `LayerLog.cond_branch_children_by_cond` equals the pass-stripped union of its passes, and they do not prove legacy IF-view exactness (`conditional_branch_edges` ↔ `cond_branch_start_children`). Those are exactly the kinds of aggregate/view drifts the current multi-pass code is prone to; today `_build_layer_logs` merges only three fields and otherwise keeps first-pass data (`torchlens/postprocess/finalization.py:536-580`, `torchlens/data_classes/layer_log.py:135-142`).
+- Concrete fix: add one invariant for `LayerLog.cond_branch_children_by_cond` exactness and one invariant for `conditional_branch_edges`/`cond_branch_start_children` bidirectional consistency.
+- Optional test: deliberately corrupt those aggregates in a validation unit test and assert the invariant failure message is specific.
+
+### Finding 5
+- Severity: medium
+- Description: the new Phase 1 gate is not literally achievable as written.
+- Why it matters: Phase 1 includes D17 ungating plus `FuncCallLocation` augmentation, so not all “new fields” can remain empty. The new conditional-attribution fields can remain at defaults, but the new call-site identity fields cannot. As written, the gate is imprecise enough that an implementation worker has to reinterpret it.
+- Concrete fix: rewrite the gate to say “new conditional-branch fields remain default/empty; ungated `func_call_stack` and `FuncCallLocation` core identity fields are populated.”
+
+## Fresh
+
+### Finding 6
+- Severity: medium
+- Description: `conditional_id` ordering is underspecified and likely nondeterministic.
+- Why it matters: 5b says to collect a set of unique `ConditionalKey`s, then 5c assigns dense IDs. If that is implemented literally with a set, event order and IDs will drift across runs and Python implementations. That is a bad contract for tests, serialization, and any user-facing display keyed by `cond_id`.
+- Concrete fix: define a deterministic order for 5c, either first-seen order from 5b or a structural sort by `(source_file, func_firstlineno, if_stmt_lineno, if_col_offset)`.
+
+### Finding 7
+- Severity: low
+- Description: the documentation phase does not include the user-facing `save_source_context` contract that v3 changes.
+- Why it matters: D17 changes semantics visible to users, but Phase 10 lists only `AGENTS.md`, `architecture.md`, and a limitations page. The current API doc still says the Python call stack is recorded only when `save_source_context=True` (`torchlens/user_funcs.py:231-233`).
+- Concrete fix: add `torchlens/user_funcs.py` docstrings and README/API docs to the documentation checklist.
+
+## Tests
+
+| Test | Assessment | Why |
+|---|---|---|
+| `MultiArmEntryNestedModel` | Adequate for the core D16 case | It proves the exact lossless case round 2 cared about: one edge enters two THEN arms at once, both cond IDs survive in the primary structures, and the derived THEN view dedupes correctly. It does not cover `elif`/`else` multi-entry or renderer composition. |
+| `NestedQualnameModel` | Partial | It proves the happy-path 3.11 `code_qualname` exact match. It does not exercise the ambiguous fallback path that still matters on supported 3.9/3.10, and it does not force a fail-closed outcome when exact matching misses. |
+| `BranchEntryWithArgLabelModel` | Partial | It is good for Graphviz, where `label` vs `headlabel`/`xlabel` is the real collision in `torchlens/visualization/rendering.py:985-1090`. It is not enough for dagua as written, because the current bridge only carries one edge `label` plus `type` (`torchlens/visualization/dagua_bridge.py:478-490`); a dagua-specific expected representation needs to be defined. |
+| strengthened `SaveSourceContextOffModel` | Partial | It will catch the live capture-path gates and the new core identity fields. It still does not prove the promised “lazy source properties remain gated” behavior unless the test explicitly checks `repr`, `len`, and `source_context`/`code_context` access semantics under `save_source_context=False`. |
+| strengthened `KeepUnsavedLayersFalseModel` | Partial | It now covers the major raw-label surfaces round 2 called out. It still should assert that aggregate `LayerLog` conditional state stays clean too, especially `cond_branch_children_by_cond` and any pass maps/view fields derived after pruning. |
+| strengthened `RolledMixedArmModel` | Partial | It checks that mixed-pass metadata exists and that the renderer emits some composite label. It does not prove exactness of the `(parent_no_pass, child_no_pass, cond_id, branch_kind) -> pass_nums` mapping, and it does not combine mixed-pass behavior with the D13/D16 multi-entry-on-one-edge case. |
+
+## Summary
+
+Verdict = RED
+
+The main round-2 blockers are mostly fixed, but v3 still has one specification-level blocker: 5e can attribute ops to AST conditionals that 5c never materialized from observed bools. The largest new implementation hole is D17: the plan promises ungated call stacks without ungated source loading, but the current `FuncCallLocation` design cannot express that split.
+
+Counts: 1 blocker / 1 high / 4 mediums / 1 low

--- a/.project-context/plans/if-else-attribution/review_round_4.md
+++ b/.project-context/plans/if-else-attribution/review_round_4.md
@@ -1,0 +1,53 @@
+## Resolution
+
+| Item | Status | Evidence |
+|---|---|---|
+| F1 (`5e` can attribute via unmaterialized keys) | RESOLVED | v4 makes the drop rule explicit in Step `5e`: translate only keys present in `events_by_key`, otherwise drop, with rationale tied to the documented false-negative scope. See D10 + Step `5e` in `.project-context/plans/if-else-attribution/plan.md:59-60,217-220`. Tests also now enumerate the false-negative models explicitly at `.project-context/plans/if-else-attribution/plan.md:411-412`. |
+| F2 (D17 ungated stack vs eager lazy props) | PARTIAL | The core fix is present: D17 adds `source_loading_enabled` and requires fail-closed behavior for lazy props plus `__repr__` / `__len__` / `__getitem__` in `.project-context/plans/if-else-attribution/plan.md:67,71-84`, with Phase 1 gate wording corrected at `.project-context/plans/if-else-attribution/plan.md:445-449`. But v4 still does not cover all current lazy surfaces or the retained `_frame_func_obj` serialization/pickle risk; see New-in-v4 Finding 1. |
+| F3 (D14 fallback can still silently pick wrong scope) | PARTIAL | The decision text is correct now: D14 v2 requires unique step-2 match and otherwise fail-closed, with a dedicated ambiguity test at `.project-context/plans/if-else-attribution/plan.md:64,399-403`. But the later `attribute_op` subsection still reintroduces the forbidden “smallest containing scope” heuristic at `.project-context/plans/if-else-attribution/plan.md:276-280`; see New-in-v4 Finding 2. |
+| F4 (invariants incomplete) | RESOLVED | v4 adds exactly the missing invariants Round 3 asked for: aggregate exactness for `LayerLog.cond_branch_children_by_cond` and bidirectional legacy IF-view consistency. See `.project-context/plans/if-else-attribution/plan.md:371-374`. |
+| F5 (Phase 1 gate imprecise) | RESOLVED | The Phase 1 gate now distinguishes conditional-branch defaults from populated `FuncCallLocation` identity fields, and it explicitly calls out the lazy gated behavior under `save_source_context=False`. See `.project-context/plans/if-else-attribution/plan.md:445-449`. |
+| F6 (`cond_id` ordering underspecified / nondeterministic) | RESOLVED | v4 now defines deterministic ordering in both collection and materialization: iterate bools in `ModelLog.layer_list` order, collect keys in first-seen insertion order, then assign dense IDs in that order. See `.project-context/plans/if-else-attribution/plan.md:202-210`. The underlying `layer_list` order is a real codebase contract, not implied hand-waving: `torchlens/data_classes/model_log.py:177`, `torchlens/postprocess/labeling.py:360-377`, `torchlens/validation/invariants.py:915-945`. |
+| F7 (docs missed `user_funcs.py`) | RESOLVED | Phase 10 now explicitly includes `torchlens/user_funcs.py` docstrings and README/API references for the changed `save_source_context` contract. See `.project-context/plans/if-else-attribution/plan.md:484-488`. |
+| R3 partial: save-source capture-path ungating | PARTIAL | The ungating points are now explicitly named and the Phase 1 gate is coherent: `.project-context/plans/if-else-attribution/plan.md:67,314-316,445-449`. Remaining issue is not capture-path coverage anymore; it is the incomplete disabled-source contract on `FuncCallLocation` itself. |
+| R3 partial: lifecycle wiring for new fields | RESOLVED | Rename, cleanup, and export wiring are now enumerated concretely, including the new cond-id-aware structures and pass maps, at `.project-context/plans/if-else-attribution/plan.md:318-339`, with matching cleanup-strengthening tests at `.project-context/plans/if-else-attribution/plan.md:418-426`. |
+| R3 partial: runtime identity too weak for scope resolution | PARTIAL | D14 materially improves the identity tuple and adds fail-closed ambiguity handling at `.project-context/plans/if-else-attribution/plan.md:64,399-403`, but the contradictory fallback text at `.project-context/plans/if-else-attribution/plan.md:276-280` means the plan is still internally inconsistent on this exact point. |
+
+## New-in-v4 findings
+
+### Finding 1
+- Severity: high
+- Description: `source_loading_enabled` still does not cover the full disabled-source contract, and the plan now risks breaking pickle/serialization under `save_source_context=False`.
+- Why it matters: v4 fixes the core Round 3 issue conceptually, but it only names four lazy properties plus `__repr__` / `__len__` / `__getitem__` in D17 and the `FuncCallLocation` data-model note (`.project-context/plans/if-else-attribution/plan.md:67,71-84`). The current class has three additional lazy accessors that also call `_load_source()` today: `code_context_labeled`, `call_line`, and `num_context_lines` (`torchlens/data_classes/func_call_location.py:194-218`). More importantly, the current object releases `_frame_func_obj` only inside `_load_source()` (`torchlens/data_classes/func_call_location.py:156-169`), and the repo already records this as a known gotcha (`torchlens/data_classes/AGENTS.md:35-36`). Under the v4 disabled-source design, `_load_source()` is intentionally never reached, so the function object can stay attached indefinitely. That conflicts with the plan’s own pickle-compat story at `.project-context/plans/if-else-attribution/plan.md:439`, and nested/local function objects are exactly the kind of thing that make default pickling fragile.
+- Additional note: there is no `__iter__` on `FuncCallLocation`, so that specific accessor path is not relevant. `copy.deepcopy()` is not the loading risk either; it copies object state directly. The unresolved problem is the retained `_frame_func_obj` state and the still-uncovered lazy properties.
+- Concrete fix: make the disabled path a fully-specified state, not just a read-time guard. The plan should require that when `source_loading_enabled=False`, all lazy backing fields are initialized to stable empty/None values without disk access, and `_frame_func_obj` is cleared immediately or excluded from pickle via explicit state handling. The same section should enumerate `code_context_labeled`, `call_line`, and `num_context_lines` alongside the other lazy properties.
+
+### Finding 2
+- Severity: medium
+- Description: D14 is still internally contradictory inside v4.
+- Why it matters: the top-level decision and the dedicated ambiguity test both say step 3 must fail closed when step 2 is non-unique or missing (`.project-context/plans/if-else-attribution/plan.md:64,399-403`). But the later `attribute_op` subsection still says the fallback order ends with “smallest function scope containing `line_number`” (`.project-context/plans/if-else-attribution/plan.md:276-280`). That is exactly the heuristic Round 3 rejected. An implementation worker can reasonably follow either section.
+- Assessment of the fail-closed policy itself: the policy is otherwise defensible. I do not see a new spec-level case where multiple step-2 matches are common and must be disambiguated rather than failed closed; the realistic ambiguous cases here are pathological same-line duplicated defs/lambdas/metaprogramming, and v4 already scopes those toward graceful degradation.
+- Concrete fix: replace `.project-context/plans/if-else-attribution/plan.md:276-280` with the D14 v2 wording verbatim so the algorithm subsection and decision table match.
+
+## Fresh findings
+
+### Finding 3
+- Severity: low
+- Description: the strengthened disabled-source test now encodes a type contract that conflicts with the current public API.
+- Why it matters: `SaveSourceContextOffModel` now expects `loc.source_context == []` in `.project-context/plans/if-else-attribution/plan.md:415`, but `source_context` is currently a `str` field/property (`torchlens/data_classes/func_call_location.py:63,185-191`) and existing tests already assert that contract (`tests/test_metadata.py:896`). This is not a blocker, but it is the kind of ambiguity that invites avoidable churn during implementation.
+- Concrete fix: decide whether disabled `source_context` should remain an empty string / sentinel string for backward compatibility, or whether the API is intentionally changing. Then align D17, the test text, and the `FuncCallLocation` type hints/docstrings to one answer.
+
+## Tests
+
+- The v4 test strengthening is materially better and mostly closes the Round 3 coverage gaps. In particular, `SameLineNestedDefModel`, the strengthened `RolledMixedArmModel`, `KeepUnsavedLayersFalseModel`, and `BranchEntryWithArgLabelModel` now cover the intended behaviors they were added for. See `.project-context/plans/if-else-attribution/plan.md:394,402,418-429`.
+- The deterministic `cond_id` path is adequately covered at the spec level now because ordering is defined in 5b/5c, and the codebase already has a stable `layer_list` execution-order contract (`torchlens/data_classes/model_log.py:177`, `torchlens/postprocess/labeling.py:360-377`, `torchlens/validation/invariants.py:915-945`).
+- The main remaining test gap is the disabled-source contract. v4 still needs explicit assertions for `code_context`, `code_context_labeled`, `call_line`, and `num_context_lines` under `save_source_context=False`, plus a pickle round-trip on a log captured with `save_source_context=False` so the `_frame_func_obj` retention problem cannot slip through.
+- I do not see a remaining Round 3-style gap in the 5e drop rule tests. The documented false-negative cases are now explicitly listed, and the drop behavior is specified rather than left implicit.
+
+## Summary: verdict = RED
+
+v4 is close, and most Round 3 items are either resolved or reduced to cleanup-level inconsistencies. But one genuine HIGH remains: the `source_loading_enabled` design is still incomplete for the real `FuncCallLocation` object model, especially around retained `_frame_func_obj` state and pickle/serialization behavior under `save_source_context=False`. There is also one medium internal contradiction in D14, but that alone would not have blocked convergence.
+
+If Finding 1 is fixed and Finding 2 is textually reconciled, this should likely move to YELLOW immediately.
+
+Counts: 1 high / 1 medium / 1 low

--- a/.project-context/plans/if-else-attribution/review_round_5.md
+++ b/.project-context/plans/if-else-attribution/review_round_5.md
@@ -1,0 +1,21 @@
+## Resolution
+
+| Item | Status | Evidence |
+|---|---|---|
+| R4-F1 `source_loading_enabled` incomplete for full `FuncCallLocation` surface | PARTIAL | v5 does fix the specific round-4 gaps: D17 now enumerates all seven lazy accessors, requires preinitialized disabled-source values, and clears `_frame_func_obj` at construction to avoid the previously identified pickle risk; the strengthened `SaveSourceContextOffModel` also adds full-accessor and pickle-round-trip coverage. See `.project-context/plans/if-else-attribution/plan.md:67,71-92,421-423`. But the newly specified disabled-source contract now says `code_context == ""`, which conflicts with the current `Optional[List[str]]` API and current `__getitem__`/`__len__` behavior in `torchlens/data_classes/func_call_location.py:176-181,253-263` plus existing tests at `tests/test_metadata.py:891-897,971-1000`. That new mismatch means the full-surface contract is still not internally coherent. |
+| R4-F2 `attribute_op` subsection contradicts D14 v2 | RESOLVED | The operative algorithm now matches D14 v2 exactly: scope resolution falls back to `(filename, code_firstlineno, func_name)` only on a unique match, and otherwise fails closed with no "smallest containing scope" heuristic. See `.project-context/plans/if-else-attribution/plan.md:64,281-289,573`. |
+| R4-F3 `source_context == []` type contradicts current `str` API | RESOLVED | v5 aligns the disabled-source contract and the strengthened test with the current `str`-typed `source_context` surface by specifying `source_context == ""` rather than `[]`. See `.project-context/plans/if-else-attribution/plan.md:67,84-85,421-423,574` and `torchlens/data_classes/func_call_location.py:185-191`. |
+
+## New-in-v5 findings
+
+### Finding 1
+- Severity: medium
+- Description: the new disabled-source accessor spec now contradicts the current `code_context` API and still leaves `__getitem__` behavior underspecified.
+- Why it matters: D17 and the strengthened disabled-source test now require `loc.code_context == ""` under `save_source_context=False` (`.project-context/plans/if-else-attribution/plan.md:67,84-85,421-423`). That does not match the current public surface, where `code_context` is `Optional[List[str]]`, existing tests assert `list | None`, `__getitem__` returns source lines / slices, and disabled source today is represented via `code_context is None` with `IndexError` from `__getitem__` (`torchlens/data_classes/func_call_location.py:62,81,176-181,253-263`; `tests/test_metadata.py:891-897,954-1000`). As written, an implementation worker can either preserve the current API or follow the new plan text, but not both. The same section also says `__getitem__` should "return the pre-initialized empty values" without defining whether integer indexing should raise, return `""`, or whether slicing should return `[]` or `""`.
+- Concrete fix: make one explicit compatibility choice and use it consistently in D17, the data-model block, and `SaveSourceContextOffModel`. The conservative choice is: keep `source_context=""`, keep `code_context=None` when source loading is disabled, keep `__len__ == 0`, and specify that disabled `__getitem__` preserves the current `IndexError` behavior. If the API is intentionally changing instead, then the plan needs to say so explicitly and update the type contract, dunder semantics, and compatibility notes together.
+
+## Summary: verdict = YELLOW
+
+v5 cleanly resolves the round-4 contradiction in `attribute_op` and the `source_context` type mismatch, and it also closes the `_frame_func_obj` pickle-risk gap that made round 4 red. The remaining issue is narrower but still real: the new disabled-source state is not yet specified in a way that is compatible with the current `code_context`/`__getitem__` contract. That is a clear-cut spec fix, not a rethink, so this is no longer RED, but it is not GREEN either.
+
+Counts: 0 blocker / 0 high / 1 medium / 0 low

--- a/.project-context/plans/if-else-attribution/review_round_6.md
+++ b/.project-context/plans/if-else-attribution/review_round_6.md
@@ -1,0 +1,15 @@
+## Resolution
+
+| Item | Status | Evidence |
+|---|---|---|
+| R5-F1 disabled-source contract for `code_context` / `__getitem__` | RESOLVED | v6 now aligns all three normative sections with the current `FuncCallLocation` no-source contract. D17 specifies `code_context=None`, `source_context="None"` (literal string), and verbatim dunder behavior: `len==0`, `__getitem__` raises `IndexError`, `__repr__` ends with `"code: source unavailable"`; see `.project-context/plans/if-else-attribution/plan.md:67`. The `FuncCallLocation` data-model comment repeats the same disabled-source state, including `code_context=None` and `loc[i]` raising `IndexError`; see `.project-context/plans/if-else-attribution/plan.md:71-94`. The strengthened `SaveSourceContextOffModel` row matches that contract exactly, asserting `loc.code_context is None`, `loc.source_context == "None"`, and `loc[0]` raises `IndexError`; see `.project-context/plans/if-else-attribution/plan.md:426`. This matches the live implementation at `torchlens/data_classes/func_call_location.py:149-150,176-178,253-257`. No contradiction remains across D17, the data-model block, and the test row. |
+
+## New-in-v6
+
+No new findings.
+
+## Summary: verdict = GREEN
+
+v6 resolves the round-5 medium cleanly and is implementable as written. The disabled-source contract is now internally consistent and matches the current `FuncCallLocation` API and dunder semantics.
+
+Counts: 0 blocker / 0 high / 0 medium / 0 low

--- a/.project-context/plans/io-sprint/final_review_claude.md
+++ b/.project-context/plans/io-sprint/final_review_claude.md
@@ -1,0 +1,53 @@
+# Final Review (Claude): `main..codex/io-sprint`
+
+**Verdict:** REQUEST_CHANGES (aligned with Codex)
+
+## Tests & Gates
+- `ruff check .`: clean
+- `mypy torchlens/`: clean (59 source files)
+- `pytest tests/ -m "not slow"`: 1054 passed, 21 skipped, 0 failed, ~18 min
+- `pytest tests/ -m smoke`: 28 passed
+
+End-to-end smoke: `log_forward_pass -> torchlens.save -> torchlens.load` round-trips on a toy Conv2d model, activations bit-exact, to_pandas returns a 61-col frame.
+
+## Confirmed independently
+
+- **CRITICAL path traversal (Codex #1)**: reproduced. Tampered `manifest.json` with `relative_path = "../outside.safetensors"` + matching sha256 is happily accepted by `tl.load()`. Read outside the bundle root succeeds. This is a real security bug.
+- **HIGH two-pass streaming (Codex #2)**: reproduced. `log_forward_pass(m, x, layers_to_save=['conv2d_1_1', 'conv2d_2_3'], save_activations_to=bundle, keep_activations_in_memory=False)` produces an empty `blobs/` directory, empty manifest tensors list, `keep_activations_in_memory=False` is silently ignored, and `activation_ref` is never set. Users get a corrupt bundle on disk and a ModelLog that claims it streamed when it didn't.
+
+## My additional findings
+
+1. **MEDIUM** — `torchlens/_io/bundle.py:266` emits `UserWarning: Bundle contains unreferenced extra files in blobs/` when a legitimate blob file is present but its manifest entry was edited away. The warning fires on the path-traversal exploit above, *before* the load succeeds. The warning should be escalated to `TorchLensIOError` when the unreferenced file's name collides with a persisted-but-redirected entry, or at least tightened from `UserWarning` (ignorable) to `warnings.warn(..., UserWarning)` with `stacklevel` set so users see it. Current behavior lets a tampered bundle load with only a print-to-stderr warning.
+
+2. **MEDIUM** — `README.md:205` "Saving and Loading" section never explicitly tells the user that portable bundles use `pickle.load` internally, nor that `tl.load()` must only be used on trusted input. Good practice and the adversarial review both require this disclosure.
+
+3. **LOW** — Plan Fork F specifies 13 version-policy rows; `tests/test_io_bundle.py` exercises all of them via monkeypatching. But the test file in a couple of cases asserts `TorchLensIOError` without checking the message content names the mismatched version string. For user-facing quality, these messages are exactly where actionability matters. Not a blocker.
+
+4. **LOW** — `torchlens/_io/rehydrate.py` has no top-of-file warning that the S6 `rehydrate_nested` function silently no-ops on `lazy=True, materialize_nested=True` (the default) because there are no remaining nested BlobRefs. This is correct behavior but will confuse a user who calls it expecting "do something." A 1-line docstring clarifying "only does work when `materialize_nested=False` was set at load time" would prevent that.
+
+5. **LOW** — `LazyActivationRef.materialize()` at `torchlens/_io/lazy.py:67` opens the file three times: once via `pathlib.exists()`, once via `sha256_of_file()`, once via `safetensors.torch.load_file()`. Not a correctness issue, but for huge tensors (multi-GB) this means 3x IOPS. Consider reading once into memory then verifying checksum + tensor.
+
+## Confirmed contracts (matches plan)
+
+- Fork A PORTABLE_STATE_SPEC: verified lint test is in S1 (`tests/test_io_scrub_policy.py`) and passes on every live instance attr across 7 classes.
+- Fork B lazy=False default: confirmed in public API signature.
+- Fork C six pandas surfaces + forward_args_summary/forward_kwargs_summary on ModulePassLog: confirmed.
+- Fork D step 19 always runs + step 20 conditional: confirmed in `postprocess/__init__.py:199-206, 263-265`. **BUT** only exercised in the single-pass `layers_to_save="all"` path — fails in two-pass (Codex #2 above).
+- Fork E strict=True default: confirmed in `torchlens.save` signature.
+- Fork F 13-row version policy: confirmed implemented in `manifest.py::enforce_version_policy`.
+- Fork G TorchLensIOError wrapping: confirmed, all bundle-layer errors funnel through.
+- Fork H two-layer drift: confirmed at `bundle.py:631-680`.
+- Fork J symlink rejection: confirmed in `bundle.py` (7 call sites) and `streaming.py:85`.
+- Fork K no-shared-handles: confirmed in `lazy.py::materialize` (open-read-close per call).
+- Fork L portable-bundle replay guard: confirmed both `validate_forward_pass` and `validate_saved_activations` paths at `validation/core.py:59, 98`.
+- Fork M nested BlobRef resave rejection: confirmed — though the check is slightly over-eager (see Codex #4).
+
+## Summary
+
+The sprint's in-scope code paths work. 1054 tests pass. API ergonomics are clean: `tl.save(log, path)` + `tl.load(path)` + `log.to_pandas()` read as expected.
+
+The two issues that block release:
+1. **Path traversal CVE in bundle load** — CRITICAL security bug, any user loading untrusted bundles is vulnerable.
+2. **Two-pass streaming is broken** — HIGH functional bug, selective streaming produces empty bundles and silent misbehavior. This path isn't tested at all (Codex LOW #5).
+
+Both are narrow enough to fix in a single follow-up spec (~100-150 LoC). I'd dispatch **IO-S9: security + two-pass streaming** as the final task before merging this branch to main.

--- a/.project-context/plans/io-sprint/final_review_codex.md
+++ b/.project-context/plans/io-sprint/final_review_codex.md
@@ -1,0 +1,42 @@
+# Final Adversarial Review: `main..codex/io-sprint`
+
+**Verdict:** REQUEST_CHANGES
+
+## Findings
+
+1. **CRITICAL** — `torchlens/_io/bundle.py:1024`, `torchlens/_io/bundle.py:1054`, `torchlens/_io/rehydrate.py:385`, `torchlens/_io/lazy.py:65`
+
+   `manifest.json`'s `relative_path` is trusted as-is and only checked for existence / symlink status. Nothing enforces that it stays inside the bundle root or even under `blobs/`. A malicious manifest can point to `../outside.safetensors` and `tl.load()` will happily read it; I reproduced this locally with a temp fixture. This defeats the sprint's symlink-hardening story and is a real path-traversal bug.
+
+   **Recommendation:** Normalize each manifest path with `resolve()`, require it to stay under `<bundle>/blobs/`, and reject absolute paths or `..` escapes in every load/materialize path (`load`, eager verify, lazy materialize, fast-copy source validation).
+
+2. **HIGH** — `torchlens/user_funcs.py:362`, `torchlens/user_funcs.py:389`, `torchlens/postprocess/__init__.py:199`
+
+   `log_forward_pass(..., layers_to_save=[...], save_activations_to=...)` is broken in the two-pass path. The writer is created during the metadata-only exhaustive pass, finalized at postprocess step 19 before any requested activations are re-saved, and never reattached for the fast pass. Result: the returned log has in-memory activations only, `activation_ref` stays unset, `keep_activations_in_memory=False` is ignored, and the on-disk bundle is empty. I reproduced this locally.
+
+   **Recommendation:** Either reject `save_activations_to` when `layers_to_save` requires the two-pass path, or plumb streaming through the fast pass so the writer is created/finalized around the pass that actually saves activations.
+
+3. **HIGH** — `torchlens/_io/bundle.py:272`, `README.md:205`
+
+   `tl.load()` still does a raw `pickle.load()` of `metadata.pkl`. That means loading an untrusted portable bundle can execute arbitrary code, but the new public save/load docs do not warn about that anywhere visible. Given that portable bundles are now a first-class advertised API, this is a security footgun.
+
+   **Recommendation:** Add an explicit warning to the README and API docstrings that `tl.load()` must only be used on trusted bundles, or replace `metadata.pkl` with a non-executable metadata format.
+
+4. **MEDIUM** — `torchlens/_io/bundle.py:119`, `torchlens/_io/bundle.py:877`, `torchlens/_io/scrub.py:188`
+
+   `save()` rejects any model log containing nested `BlobRef`s before it knows whether those fields are being persisted. That blocks valid flows like `lazy=True, materialize_nested=False` followed by `save(..., include_captured_args=False)` or `include_rng_states=False`, even though scrub would drop those fields anyway. I reproduced this locally.
+
+   **Recommendation:** Make the nested-blob preflight aware of `include_captured_args` / `include_rng_states`, or move the check after effective field-policy resolution so dropped fields do not spuriously fail the save.
+
+5. **LOW** — `tests/test_io_streaming.py:121`, `tests/test_io_streaming.py:143`, `tests/test_io_streaming.py:167`
+
+   The streaming integration suite only covers the single-pass `layers_to_save="all"` path. There is no test for `save_activations_to` combined with selective layer requests, which is why the two-pass regression above was missed.
+
+   **Recommendation:** Add coverage for selective streaming in both `keep_activations_in_memory=True` and `False` modes, and add a traversal test for malicious manifest `relative_path` values.
+
+## Confirmed
+
+- Step 19 runs unconditionally when `_activation_writer` is present, and step 20 is separately gated on `not _keep_activations_in_memory` (`torchlens/postprocess/__init__.py:199-206`, `:261-265`).
+- Streaming is actually strict: `BundleStreamWriter` rejects `strict=False`, and `write_blob()` always calls `is_supported_for_save(..., strict=True)` (`torchlens/_io/streaming.py:64-81`, `:160-172`).
+- Fork L's validation guard covers both `ModelLog.validate_saved_activations()` and the `ModelLog.validate_forward_pass` alias, for eager and lazy portable loads (`torchlens/validation/core.py:45-65`, `:68-99`; `torchlens/data_classes/model_log.py:704-705`).
+- Fork K's no-shared-handles claim looks accurate: lazy refs call `safetensors.torch.load_file()` per materialization and do not retain file handles (`torchlens/_io/lazy.py:67-108`).

--- a/.project-context/plans/io-sprint/plan.md
+++ b/.project-context/plans/io-sprint/plan.md
@@ -1,0 +1,619 @@
+# TorchLens I/O Sprint Plan (Round 6)
+
+**Branch**: `codex/io-sprint`
+**Goal**: comprehensive, frictionless I/O for ModelLog and its children — pickle, pandas/CSV/Parquet/JSON, activation-to-disk (including streaming during forward pass), symmetric loading.
+**Out of scope**: visualization (graphviz, ELK, dagua), tar archival utilities, gradient streaming during backward.
+**Inputs**: `.project-context/research/io-audit-{claude,codex}.md`, `.project-context/plans/io-sprint/review_round_{1,2,3,4,5}.md`.
+**This revision cleans up Round-5 text-consistency findings. Change log at bottom.**
+
+---
+
+## 1. Design Forks — Resolved
+
+### Fork A. Archival format
+**Decision**: **directory bundle only**, containing a scrubbed pickle, safetensors-only tensor blobs, and a rich manifest. `safetensors` is a **hard dependency** of the bundle path. No tar this sprint. No `pack_bundle` utility — out of scope.
+
+Bundle layout:
+```
+<bundle_dir>/
+  manifest.json               # authoritative index; see §2
+  metadata.pkl                # scrubbed ModelLog state
+  blobs/
+    0000000001.safetensors
+    0000000002.safetensors
+    ...                       # one file per persisted tensor; filename = zero-padded opaque blob id
+```
+
+Filenames are zero-padded monotonically-assigned blob ids. Human-readable layer labels live only in `manifest.json`.
+
+**Pickle-scrub contract** — addresses Round-2 findings #1/#2 + Round-3 finding #2.
+
+**Authoritative source of truth**: each class in torchlens gains a `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attribute that explicitly lists every attribute present on instances of that class (not just fields in FIELD_ORDER) and the policy for each. The scrubber consumes this spec. A completeness lint (in S1 tests) walks every live instance attribute on a canonical ModelLog and asserts each name appears in its class's spec.
+
+Classes requiring a `PORTABLE_STATE_SPEC`:
+- `ModelLog`
+- `LayerPassLog`
+- `LayerLog`
+- `ModuleLog`, `ModulePassLog`
+- `ParamLog`
+- `BufferLog`
+- `FuncCallLocation`
+- Any accessor class that ends up in the object graph
+
+Policy vocabulary:
+- `keep`: pickle as-is (primitives, containers of primitives, stable torch objects like `torch.dtype`).
+- `blob(kind)`: tensor-valued; replace with `BlobRef(blob_id, kind=...)` and record in manifest.
+- `blob_recursive(kind)`: walk container recursively; tensors blobified; non-tensor leaves passed through.
+- `drop`: set to `None` (live callables, `_param_ref`, transient build state).
+- `stringify`: replace with `"<scrubbed:TypeName>"` (fall-through for user-supplied non-portable objects).
+- `weakref_strip`: existing `__getstate__` weakref-nulling behavior, applied automatically.
+
+Policy by class (abbreviated — full matrix in `torchlens/_io/scrub.py`):
+
+| Class | Field | Policy |
+|-------|-------|--------|
+| LayerPassLog | `activation` | `blob("activation")` (scalar 0-d recorded inline in manifest) |
+| LayerPassLog | `gradient` | `blob("gradient")` |
+| LayerPassLog | `captured_args`, `captured_kwargs` | `blob_recursive("captured_arg")` if `include_captured_args=True`, else `drop` |
+| LayerPassLog | `children_tensor_versions` | `blob_recursive("child_version")` if `include_captured_args=True`, else `drop` |
+| LayerPassLog | `func_rng_states` | `blob_recursive("rng_state")` if `include_rng_states=True`, else `drop` |
+| LayerPassLog | `func_applied` | `drop` |
+| LayerPassLog | `func_config` | `blob_recursive("func_config")` with `stringify` fallback for unknown non-tensor objects |
+| LayerPassLog | `parent_layer_log` | `drop` (rebuilt on load from manifest + layer_dict_all_keys graph) |
+| LayerPassLog | all other FIELD_ORDER columns | `keep` |
+| LayerPassLog | `_source_model_log_ref` (weakref) | `weakref_strip` |
+| LayerLog | `func_applied`, `activation_postfunc` | `drop` (live callables; not portable). `LayerPassLog.func_name` (a string) is retained for identification; no callable recovery on load. Replay is out of scope for portable bundles per Fork L. |
+| LayerLog | `_source_model_log_ref` | `weakref_strip` |
+| LayerLog | all other columns | `keep` |
+| ModuleLog | `extra_attributes` | `blob_recursive("module_meta")` with `stringify` fallback |
+| ModuleLog | `_source_model_log_ref` | `weakref_strip` |
+| ModulePassLog | `forward_args`, `forward_kwargs` | `blob_recursive("module_arg")` if `include_captured_args=True`, else `drop`. Summary fields (`forward_args_summary`, `forward_kwargs_summary`) always `keep`. |
+| ParamLog | `_param_ref` | `drop` (pins `nn.Parameter`) |
+| ParamLog | all other columns | `keep` |
+| BufferLog | Inherits LayerPassLog policy (is a subclass) | — |
+| FuncCallLocation | `_frame_func_obj` | `drop` |
+| FuncCallLocation | `_frame`, `_linecache_entry` if present | `drop` |
+| FuncCallLocation | `code_context`, `func_signature`, `func_docstring`, `call_line`, etc. | `keep` |
+| ModelLog | `activation_postfunc` | `drop`; record `activation_postfunc_repr: str` if present |
+| ModelLog | `_module_logs`, `_buffer_accessor`, `_module_build_data` | `drop` (rebuilt on load — existing behavior) |
+| ModelLog | `_optimizer` if present | `drop` |
+| ModelLog | `_saved_gradients_set`, `_mod_*`, `_module_metadata`, `_module_forward_args` | `drop` (transient build state) |
+| ModelLog | all other FIELD_ORDER columns and configuration fields | `keep` |
+| Any | Attribute not in spec | Lint failure during S1 tests (`tests/test_io_scrub_policy.py` in S1). |
+
+Adding a new attribute to any of these classes in a future PR requires updating the class's `PORTABLE_STATE_SPEC` — enforced by the S1 lint.
+
+**Completeness lint placement**: lives in S1 (`tests/test_io_scrub_policy.py`), not S7. This means the guarantee is active from the moment scrubber lands. Fixes Round-3 finding #8.
+
+**Rehydration contract on load** — addresses Round-2 finding #1 + Round-3 finding #1.
+
+All blob materialization happens in a dedicated loader (`torchlens/_io/rehydrate.py::rehydrate_model_log(scrubbed_state, manifest, bundle_path, *, lazy, map_location, materialize_nested)`), NOT in `__setstate__`. `__setstate__` runs only default-fill + weakref restoration, never touches disk.
+
+This split is critical: `__setstate__` has no way to receive `map_location` from the caller, and it also runs on plain `pickle.load()` of a scrubbed state dict where the bundle root may not be accessible at all. The loader wraps `__setstate__` and then applies the rehydration pass.
+
+**Default changes** — addresses Round-3 finding #1 on RAM blow-up:
+- `torchlens.save(..., include_captured_args=False, include_rng_states=False)` are now the **defaults**. Captured args and RNG states balloon bundle size and their tensors are rarely interesting for post-hoc analysis. Users opt in explicitly when they want richer analysis artifacts (e.g. for downstream tools that consume captured_args). **Note**: portable-loaded ModelLogs do NOT support `validate_forward_pass()` regardless of include flags (Fork L).
+- New load-time flag: `torchlens.load(path, lazy=False, map_location="cpu", materialize_nested=True)`. When `materialize_nested=False` with `lazy=True`, nested tensor refs stay as `BlobRef`-like objects — power-user mode for cases where capture-arg bundles would not fit in RAM.
+
+Rehydration behavior by mode:
+- `lazy=False` (default): `.activation`/`.gradient` materialized; nested tensors materialized with `map_location`.
+- `lazy=True, materialize_nested=True` (default for lazy): `.activation`/`.gradient` remain refs; nested tensors materialized eagerly. Common case: user wants metadata access + on-demand activations without RAM cost, and wants captured-arg / rng-state tensors immediately usable (e.g. for downstream analysis tools that read `layer.captured_args[0]` as a real tensor). Validation/replay is NOT a use case — Fork L.
+- `lazy=True, materialize_nested=False` (expert): everything lazy. User explicitly accepts that `.captured_args[0]` may still be a `BlobRef` and calls `rehydrate_nested(model_log)` later when needed.
+
+`map_location` is honored in all three modes. Safetensors accepts it directly.
+
+**Plain-pickle backward compat**:
+`pickle.dump(model_log, f)` / `pickle.load(f)` continue to work via the existing `__getstate__` hooks (weakref strip only — no scrub). Limitations of current plain pickle (callables fragility, `_param_ref` pinning) are unchanged. Portable representation is `torchlens.save()`.
+
+**Compat contract resolution** — addresses Round-2 finding #14:
+Plain `pickle.dump/load` is supported for this release; a `DeprecationWarning` fires on `pickle.load` of any ModelLog with `io_format_version` field missing (old pickles from before this sprint). No deprecation warning on `pickle.dump` of a fresh ModelLog (users still allowed to produce plain pickles; they just aren't the portable format). Tested in `tests/test_io_plain_pickle.py`.
+
+### Fork B. Load granularity
+**Decision**: `lazy=False` is **the default**. Lazy is opt-in via `torchlens.load(path, lazy=True)`.
+
+Rationale (addresses Round-2 finding #5):
+- Existing TorchLens internal methods assume `.activation` is a tensor when present.
+- A full audit of every public and semi-public method is out of scope for this sprint.
+- Making lazy opt-in means users who want it accept the "call `materialize_activation()` before doing tensor ops" contract explicitly.
+- A future sprint can flip the default after a full compat audit.
+
+`.activation` stays `tensor | None` throughout. `.activation_ref` is populated whenever a blob exists on disk (lazy or eager load). After `lazy=True` load, `.activation` is `None` and user must call `materialize_activation()` to get a tensor. After `lazy=False` load, both `.activation` and `.activation_ref` are populated.
+
+### Fork C. Pandas-export scope
+**Decision**: DataFrames at six log levels: layer-pass, aggregate layer, module-pass, module, param, buffer.
+
+`ModulePassLog.forward_args_summary` and `ModulePassLog.forward_kwargs_summary` new fields — addresses Round-2 finding #9 + Round-3 finding #5.
+- During postprocess step `_build_module_logs`, **before** the existing GC step that clears `forward_args`/`forward_kwargs`, two summary strings are computed using a recursive formatter:
+  - Tensor → `"Tensor(shape=(1,3,224,224), dtype=float32)"`.
+  - Primitive (bool/int/float/str/None) → `repr(value)`.
+  - List/Tuple → `"[" + ", ".join(format(v) for v in seq) + "]"`.
+  - Dict → `"{" + ", ".join(f"{k}: {format(v)}" for k,v in d.items()) + "}"`.
+  - Other object → `f"<{type(value).__name__}>"`.
+- Stored as `forward_args_summary: str` and `forward_kwargs_summary: str` on ModulePassLog.
+- `ModulePassLog.to_pandas()` includes both columns. kwargs-heavy modules and dict/list-nested inputs are preserved.
+- Existing GC behavior unchanged; `forward_args` / `forward_kwargs` still cleared after the summary pass.
+
+### Fork D. Streaming-save architecture
+**Decision**: during forward pass, write the sidecar at `save_tensor_data()` completion; activation remains in memory until the postprocess evict step runs. Selective streaming hooks the exhaustive pass only. **Bundle finalization is split from activation eviction** into two separate postprocess steps (addresses Round-3 finding #3).
+
+Concrete pipeline positions — addresses Round-2 finding #3 and Round-3 finding #3.
+
+Current 18-step postprocess pipeline (imperative code in `postprocess/__init__.py`): this sprint adds two steps at the end:
+```
+Step 19: _finalize_streamed_bundle       (NEW, always runs when writer present)
+Step 20: _evict_streamed_activations     (NEW, conditional on keep_activations_in_memory=False)
+```
+
+**Step 19 gate**: `ModelLog._activation_writer is not None`. Writer computes sha256 per blob, writes `manifest.json`, writes scrubbed `metadata.pkl`, atomic rename `<path>.tmp.<uuid>/` → `<path>/`. **After rename, iterates all `_pending_blob_id` entries and ALWAYS attaches `.activation_ref = LazyActivationRef(..., source_bundle_path=<final path>, expected_sha256=...)`. Does NOT touch `.activation`.** Applies regardless of `keep_activations_in_memory`. Addresses Round-4 finding #3: the returned log is genuinely disk-backed in both modes because `.activation_ref` is always populated after streaming.
+
+**Step 20 gate**: step 19 ran successfully AND `model_log._keep_activations_in_memory is False`. Nulls `.activation` only. `.activation_ref` is already populated from step 19.
+
+Sequence for `log_forward_pass(..., save_activations_to=path, keep_activations_in_memory=True)` (default):
+1. Writer opens `<path>.tmp.<uuid4>/blobs/`.
+2. During forward: each `save_tensor_data()` writes `NNNNNNNNNN.safetensors`, records `blob_id` on the LayerPassLog. `.activation` unchanged.
+3. Postprocess steps 1-18 run normally with in-memory tensors.
+4. Step 19: writer finalizes; `.activation_ref` attached to every streamed layer pointing at final path.
+5. Step 20: skipped (gate false).
+6. Return. Log has `.activation` (tensor) AND `.activation_ref` (LazyActivationRef). Fully disk-backed.
+
+Sequence for `keep_activations_in_memory=False`:
+1-4. Same as above.
+5. Step 20 runs: `.activation = None`. `.activation_ref` already populated from step 19.
+6. Return. Log has `.activation=None`, `.activation_ref` populated. Disk-only.
+
+This symmetrizes the two modes: in both cases the bundle is durable and the log knows where its data lives. Only difference is whether in-memory tensors are retained.
+
+**Streaming strictness** — addresses Round-3 finding #6:
+Streaming is **always strict**. If `tensor_policy` returns an error on an activation mid-stream (sparse, meta, nested, DTensor, etc.), the writer aborts: the `.tmp.<uuid>/` dir is kept with `PARTIAL` + `REASON` files, `TorchLensIOError` is raised with the offending blob_id + layer label. No lenient streaming path. Rationale: streaming is a live capture pipeline; silently skipping a layer mid-pass is too confusing. Users who need lenient behavior should capture normally, then call `torchlens.save(..., strict=False)` post-hoc.
+
+**Non-tensor `activation_postfunc` guard** — addresses Round-2 finding #4.
+Single rule applied to both streaming and post-hoc save: if `activation_postfunc is not None` AND `save_activations_to is not None` (streaming) OR `torchlens.save()` is called with `include_activations=True` (post-hoc), validate that `activation_postfunc` output type is `torch.Tensor`. Check is performed:
+- **Streaming**: at the first `save_tensor_data()` call where the writer would be invoked. If the post-postfunc value is not a `torch.Tensor`, the writer is aborted immediately, `.tmp.<uuid>/` dir gets a `PARTIAL` sentinel + `REASON` file describing the issue, `TorchLensIOError` is raised, forward pass terminates. No partially-written bundle masquerades as valid.
+- **Post-hoc save**: `torchlens.save()` inspects the first LayerPassLog with a saved activation; if the activation's type differs from `torch.Tensor` (the postfunc output was retained), raise `TorchLensIOError` before any blob is written.
+
+**Atomicity scope** (unchanged from v2): random uuid temp dir; local-same-fs best-effort; non-local FS documented as unsupported.
+
+**Temp-dir cleanup**: `torchlens.cleanup_tmp(path, force=False)` finds sibling `<path>.tmp.*` directories with a `PARTIAL` sentinel and removes them. Without `PARTIAL`, only removes after user confirmation.
+
+**Gradient streaming**: out of scope. Post-hoc `torchlens.save(model_log, path, include_gradients=True)` bundles any populated `.gradient` fields.
+
+### Fork E. Unsupported-tensor policy
+**Decision**: **`strict=True` is the default for `torchlens.save()`**. Lenient skip is opt-in.
+
+Rationale — addresses Round-2 finding #6:
+- Silent partial bundles are an unsafe default for research/CI artifacts.
+- Users hitting a sparse/meta/quantized tensor deserve a loud error that tells them to deal with it.
+- `strict=False` remains available for users who knowingly want best-effort archival.
+
+Supported tensor matrix (unchanged from v2 in scope):
+
+| Tensor kind | strict=True | strict=False |
+|-------------|-------------|--------------|
+| Dense CPU/CUDA standard dtypes | Save | Save |
+| Non-contiguous | `.contiguous()` then save | Same |
+| Sparse COO/CSR, quantized, nested, tensor subclass, DTensor/FSDP shard, complex32 | `TorchLensIOError` with field name + reason | Skip, record in `manifest.unsupported_tensors`, warn once |
+| Meta tensors | `TorchLensIOError` (no data) | Skip, record |
+
+### Fork F. Version & integrity policy
+**Decision**: PEP 440 parsing where applicable; sha256 over safetensors file bytes on disk.
+
+Addresses Round-2 finding #7.
+
+Version parsing:
+- `torchlens_version`, `torch_version`, `python_version` parsed with `packaging.version.Version`. Nightly/pre-release identifiers compared per PEP 440 semantics.
+- On parse failure (non-conforming string): fall back to string equality; emit `UserWarning` naming the unparseable version.
+- Version policy table (Fork E in v2 plan, unchanged structure but explicit parse rules):
+
+| Scenario | Load behavior |
+|----------|---------------|
+| `io_format_version > current` | Raise `TorchLensIOError` before opening `metadata.pkl` |
+| `io_format_version < current` | Load with `DeprecationWarning` listing missing fields |
+| `io_format_version == current` | Load normally |
+| `torch_version` major mismatch | Raise `TorchLensIOError` (pre-open) |
+| `torch_version` minor mismatch | Load with `UserWarning` |
+| `torchlens_version` newer | Load with `UserWarning` |
+| `torchlens_version` older | Load with info log only |
+| `python_version` major mismatch | Attempt load; wrap any pickle error in `TorchLensIOError` with version hint |
+| Safetensors backend missing | Raise `TorchLensIOError` with install hint |
+| Manifest unparseable | Raise `TorchLensIOError` |
+| Manifest blob_id without file | Raise `TorchLensIOError` (lists missing blobs) |
+| Blob checksum mismatch | Raise `TorchLensIOError` (names blob_id) |
+| Unknown extra files in `blobs/` | `UserWarning`, continue |
+
+Checksum semantics:
+- `sha256` field = hex of `hashlib.sha256(open(blob_path, "rb").read()).hexdigest()` — literal file bytes on disk after safetensors write.
+- Checksum verified lazily on `materialize()` for `lazy=True` loads, eagerly on load for `lazy=False`.
+
+### Fork G. Exception contract
+**Decision**: all bundle-layer errors wrap in `TorchLensIOError`. Addresses Round-2 finding #12.
+
+- `torchlens._io.TorchLensIOError` is the single exception type for bundle failures.
+- Implementation: bundle save/load code catches `OSError`, `pickle.UnpicklingError`, `safetensors`-raised errors, JSON parse errors, key errors on manifest structure, and re-raises as `TorchLensIOError` with `__cause__` chained.
+- Plain `pickle.load()` of a ModelLog via user-written code does not go through the wrap — callers of plain pickle accept Python's native pickle errors.
+- Tested in `tests/test_io_bundle.py`.
+
+### Fork H. Lazy-resave drift
+**Decision**: record source-bundle manifest sha256 at load + verify each source blob's sha256 before fast-copy. Addresses Round-2 finding #8 + Round-3 finding #4.
+
+Two layers of defense:
+1. **Manifest-level**: at load time, capture `source_manifest_sha256 = sha256(manifest.json)` into ModelLog private `_source_bundle_manifest_sha256`. On resave, re-hash the source manifest and compare. If differs → `TorchLensIOError("source bundle manifest has changed since load; materialize refs and retry")`.
+2. **Blob-level**: for each `LazyActivationRef` about to be fast-copied, re-hash the source blob file on disk and compare against the sha256 recorded in that manifest entry. If differs → `TorchLensIOError("blob at <path> tampered since load; materialize and retry")`.
+
+Rationale: manifest-only check misses an attacker/corruption that replaces blob bytes but leaves the manifest intact. Per-blob verify catches it at the cost of reading the bytes once — still cheaper than decoding safetensors + re-encoding (no torch involvement).
+
+If either check fails, the user must call `.materialize_activation()` on every ref (which itself does a sha256 check during materialize) and then resave — at which point the new blobs are written fresh from in-memory tensors.
+
+### Fork I. Operational shape
+**Decision**: directory-of-one-blob-per-tensor is the intentional format for this sprint. Finding #11 is **deferred**, not resolved.
+
+Documentation note (`.project-context/knowledge/io_architecture.md` and README):
+> "For models with >10,000 saved layers or deployment on network filesystems, bundle save creates many small files. A future release may add chunked blob formats. This sprint prioritizes random-access lazy loads over file-count optimization."
+
+Not claiming resolution we haven't earned.
+
+### Fork J. Filesystem safety
+**Decision**: reject symlinks in bundle directories and temp dirs. Addresses Round-3 finding #7.
+
+- `torchlens.save()` fails with `TorchLensIOError` if any path inside `<path>/` (after write) is a symlink. Save writes real files only.
+- `torchlens.load()` rejects a bundle if `manifest.json`, `metadata.pkl`, the `blobs/` directory, or any file under `blobs/` is a symlink. `TorchLensIOError`.
+- `torchlens.cleanup_tmp(path)` rejects `.tmp.*` entries that are symlinks (not removed, reported instead). Only real directories directly under the expected parent are cleaned.
+- Rationale: symlinks can escape the bundle root, hide tampered content outside the bundle, and make `cleanup_tmp` delete unrelated paths.
+
+### Fork K. Thread-safety and reader lifecycle
+**Decision**: no long-lived shared safetensors readers. `LazyActivationRef.materialize()` opens, reads, verifies sha256, and closes per call. Addresses Round-3 finding #9.
+
+- Rationale: torchlens is already single-threaded (see existing `warn_parallel` in user_funcs). Shared mmap + refcounting would add complexity for zero benefit.
+- Trade-off: materializing the same ref twice re-reads and re-hashes. Acceptable because users typically materialize once and cache via `.activation = <tensor>`.
+- `cleanup()` becomes trivial: no open handles to close (documented).
+
+### Fork L. Replay / validation support on portable bundles
+**Decision**: **`validate_forward_pass` and `validate_saved_activations` are NOT supported on ModelLogs loaded from portable bundles**. Addresses Round-4 finding #1.
+
+Rationale:
+- Preserving live torch callables (`func_applied`) across versions is a losing battle: torch function refactors rename internals, jit wrappers change shape, and `torch._VF` internals drift.
+- Re-binding by `func_name` on load is plausible for most common ops but fragile; making replay "work sometimes" is worse than "never" for a feature used for correctness validation.
+- Users who need replay have two paths:
+  1. Keep the ModelLog in memory and run `validate_forward_pass()` before saving.
+  2. Use plain `pickle.dump(model_log, f)` / `pickle.load(f)` (existing, unchanged). Plain pickle preserves live callables at the cost of cross-version fragility — fine for same-session/same-machine workflows.
+- Portable bundle is for **archival, analysis, and sharing of captured metadata + activations**, not for replay.
+
+Implementation:
+- On `torchlens.load(path)`, loaded ModelLogs carry a private flag `_loaded_from_bundle = True`.
+- `validate_forward_pass()` and `validate_saved_activations()` check this flag first and raise `TorchLensIOError("validate_forward_pass requires live func_applied callables; portable bundles drop them — either run validation before saving or use plain pickle")`.
+- Documented prominently in docstrings + README + `.project-context/knowledge/io_architecture.md`.
+- Removes "validation-ready bundle" language from anywhere in the plan and docs.
+
+Future sprint may add best-effort re-binding by name — out of scope now.
+
+### Fork M. Resave with nested BlobRefs
+**Decision**: `torchlens.save()` rejects ModelLogs that still contain nested `BlobRef` objects (from `lazy=True, materialize_nested=False` mode). User must call `torchlens.rehydrate_nested(model_log)` first. Addresses Round-4 finding #2.
+
+Rationale:
+- The nested refs carry `blob_id` + source bundle + sha256, so we COULD fast-copy them like `LazyActivationRef` — but nested refs live inside arbitrary user containers (dicts, lists, custom structures), and walking them for both drift-verify and path-update is substantially more error-prone than materializing.
+- Expert mode users who opted into `materialize_nested=False` have already accepted "I know what I'm doing"; adding one call before resave is acceptable.
+
+Implementation: at the start of `torchlens.save()`, scan for any lingering `BlobRef` in nested fields. If found, raise `TorchLensIOError("ModelLog contains unmaterialized nested blob references. Call torchlens.rehydrate_nested(model_log) before saving.")` with an actionable message.
+
+---
+
+## 2. Manifest Schema v1 (unchanged from v2)
+
+```json
+{
+  "io_format_version": 1,
+  "torchlens_version": "1.2.0",
+  "torch_version": "2.5.0",
+  "python_version": "3.11.5",
+  "platform": "linux-x86_64",
+  "created_at": "2026-04-23T13:05:00Z",
+  "bundle_format": "directory",
+  "n_layers": 152,
+  "n_activation_blobs": 152,
+  "n_gradient_blobs": 0,
+  "n_auxiliary_blobs": 304,
+  "tensors": [
+    {
+      "blob_id": "0000000001",
+      "kind": "activation",
+      "label": "conv2d_1_1:2",
+      "relative_path": "blobs/0000000001.safetensors",
+      "backend": "safetensors",
+      "shape": [1, 64, 112, 112],
+      "dtype": "float32",
+      "device_at_save": "cuda:0",
+      "layout": "strided",
+      "bytes": 3211264,
+      "sha256": "3f5c..."
+    }
+  ],
+  "unsupported_tensors": [
+    {"label": "sparse_layer:1", "kind": "activation", "reason": "sparse_coo layout not supported this release"}
+  ]
+}
+```
+
+`kind` values: `activation`, `gradient`, `captured_arg`, `child_version`, `rng_state`, `module_arg`, `func_config`.
+
+---
+
+## 3. Public API Surface
+
+### Top-level `torchlens`
+```python
+torchlens.save(
+    model_log: ModelLog,
+    path: str | Path,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,
+    include_captured_args: bool = False,   # CHANGED v4: default False (bundle size + RAM)
+    include_rng_states: bool = False,      # CHANGED v4: default False
+    strict: bool = True,
+    overwrite: bool = False,
+) -> None
+
+torchlens.load(
+    path: str | Path,
+    *,
+    lazy: bool = False,
+    map_location: str | torch.device = "cpu",
+    materialize_nested: bool = True,       # NEW v4: controls nested-tensor eager load
+) -> ModelLog
+
+torchlens.cleanup_tmp(
+    path: str | Path,
+    *,
+    force: bool = False,
+) -> list[Path]
+
+torchlens.rehydrate_nested(             # NEW v4: power-user full materialization
+    model_log: ModelLog,
+    *,
+    map_location: str | torch.device = "cpu",
+) -> None
+```
+
+### On `ModelLog`
+```python
+model_log.save(path, **kwargs)
+ModelLog.load(path, **kwargs)             # classmethod
+
+model_log.to_pandas() -> pd.DataFrame
+model_log.to_csv(path, **kwargs)
+model_log.to_parquet(path, **kwargs)
+model_log.to_json(path, *, orient="records")
+```
+
+### Accessors
+```python
+# existing:
+model_log.layers.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.modules.to_pandas() / ...
+
+# NEW:
+model_log.params.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.buffers.to_pandas() / ...
+
+# Per-log:
+module_log.to_pandas() / ...
+module_pass_log.to_pandas() / ...         # NEW, reads forward_args_summary
+```
+
+### Streaming at capture time
+```python
+log_forward_pass(
+    ...,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
+)
+```
+
+### LazyActivationRef
+```python
+class LazyActivationRef:
+    blob_id: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device_at_save: str
+    source_bundle_path: Path
+    kind: Literal["activation", "gradient"]
+    expected_sha256: str                   # recorded at save/load for drift detection (Fork H)
+
+    def materialize(self, *, map_location="cpu") -> torch.Tensor:
+        """Open, read, verify sha256, close (Fork K — no long-lived handles)."""
+```
+
+### Resave-lazy semantics
+```python
+model_log = torchlens.load("a/", lazy=True)
+model_log.save("b/")
+# If source manifest sha256 matches the one captured at load: shutil.copy blobs from a/ to b/.
+# If source manifest differs from recorded digest OR source deleted: raise TorchLensIOError
+#   "source bundle at a/ has changed or is gone; call .materialize_activation() on all layers and retry."
+# No silent drift.
+```
+
+---
+
+## 4. Spec Decomposition
+
+All specs must pass: `ruff check . --fix && mypy torchlens/ && pytest tests/ -m smoke -x --tb=short`.
+
+### Group 1 — Foundations (parallel-safe)
+
+**IO-S1. Pickle hardening: scrub policy + rehydrate loader + PORTABLE_STATE_SPEC lint + version tagging + accessor reconstruction**
+- `torchlens/_io/__init__.py`: `IO_FORMAT_VERSION=1`, `TorchLensIOError`, `BlobRef` NamedTuple, `FieldPolicy` enum (keep/blob/blob_recursive/drop/stringify/weakref_strip).
+- Add `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attr on ModelLog, LayerPassLog, LayerLog, ModuleLog, ModulePassLog, ParamLog, BufferLog, FuncCallLocation per Fork A table.
+- `torchlens/_io/scrub.py`: `scrub_for_save(model_log, **include_flags) -> (scrubbed_state, list[BlobSpec])`. Driven purely by `PORTABLE_STATE_SPEC`.
+- `torchlens/_io/rehydrate.py`: `rehydrate_model_log(scrubbed_state, manifest, bundle_path, *, lazy, map_location, materialize_nested)`. Single entry point for all blob materialization. `__setstate__` only does default-fill + weakref restore; never touches disk.
+- `torchlens/_io/accessor_rebuild.py`: shared helper extracted from `postprocess/finalization.py:671-681`.
+- Expand `__setstate__` on ModelLog, LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog, ModulePassLog with version-aware default-fill.
+- Files: `torchlens/_io/__init__.py`, `scrub.py`, `rehydrate.py`, `accessor_rebuild.py` (all NEW); `torchlens/data_classes/{model_log,layer_pass_log,layer_log,param_log,buffer_log,module_log,func_call_location}.py`; `torchlens/postprocess/finalization.py` (extract helper).
+- Tests:
+  - `tests/test_io_pickle.py` (NEW) — scrub round-trip; accessor rebuild; default-fill from forged older pickle; version hard-fail on newer; plain-pickle unchanged.
+  - `tests/test_io_scrub_policy.py` (NEW) — **PORTABLE_STATE_SPEC completeness lint**: for each class, instantiate a canonical live example, walk `vars(instance)`, assert every attribute name appears in `PORTABLE_STATE_SPEC`. Fails CI if any new attribute added without a policy entry. Moved from S7 to S1 per Round-3 finding #8.
+- Size: **~440 LoC** (up from 400 due to PORTABLE_STATE_SPEC surfaces + rehydrate loader separation).
+
+**IO-S2. ParamAccessor / BufferAccessor / ModulePassLog.to_pandas() + forward_args_summary + forward_kwargs_summary**
+- New FIELD_ORDER tuples in `constants.py`.
+- Recursive summary formatter in `torchlens/data_classes/_summary.py` (new) producing strings per Fork C rules.
+- `ModulePassLog.forward_args_summary` and `forward_kwargs_summary` fields populated in `_build_module_logs` BEFORE the existing GC step.
+- New `to_pandas()` methods on ParamAccessor, BufferAccessor, ModulePassLog.
+- Files: `torchlens/data_classes/{param_log,buffer_log,module_log,_summary}.py`, `torchlens/constants.py`, `torchlens/postprocess/finalization.py` (add summary capture before GC).
+- Tests: `tests/test_io_pandas.py` (NEW) — schema shape; empty accessor; summary correctness with mixed tensor/primitive/list/dict/kwargs args; summary survives GC; both `_args_summary` and `_kwargs_summary` present.
+- Size: **~280 LoC** (up from 240; adds kwargs summary + recursive formatter).
+
+### Group 2 — Exports + bundle (serial: S3 after S2; S4 after S1)
+
+**IO-S3. Export wrappers: to_csv / to_parquet / to_json on all seven DataFrame producers**
+- Wrappers on ModelLog, LayerAccessor, ModuleAccessor, ModuleLog, ModulePassLog, ParamAccessor, BufferAccessor.
+- `pyarrow` optional via `pip install torchlens[io]`; clear `ImportError` if missing.
+- Files: `torchlens/data_classes/{interface,layer_log,module_log,param_log,buffer_log}.py`, `pyproject.toml`.
+- Tests: `tests/test_io_export.py` — round-trip + schema stability + ImportError on parquet.
+- Size: **~220 LoC**.
+
+**IO-S4. Bundle save/load (eager post-hoc) + manifest v1 + integrity + exception contract**
+- `torchlens/_io/bundle.py`: `save` (post-hoc) and `load`. Integrates scrub (S1), tensor_policy (below), and manifest.
+- `torchlens/_io/manifest.py`: schema class, sha256 hashing, PEP 440 version parsing, policy enforcement.
+- `torchlens/_io/tensor_policy.py`: implements supported-tensor matrix; returns `(Ok | SkipReason | Error)` per tensor; respects `strict` flag.
+- All bundle errors wrap in `TorchLensIOError` (Fork G).
+- ModelLog gets `.save()` / `.load()` sugar; `torchlens` exports `save`, `load`, `cleanup_tmp`.
+- Files: `torchlens/_io/{bundle,manifest,tensor_policy}.py` (NEW); `torchlens/data_classes/model_log.py`; `torchlens/__init__.py`; `torchlens/user_funcs.py`.
+- Tests: `tests/test_io_bundle.py` (NEW) — eager round-trip; strict default raises on sparse; `strict=False` skips + records; every row in the Fork F version-policy table (13 rows); corrupt manifest / missing blob / truncated safetensors / checksum tamper all raise `TorchLensIOError`; overwrite semantics; non-tensor postfunc rejected at save; include flags combos; Fork L assertion (`validate_forward_pass` on portable-loaded log raises).
+- Size: **~480 LoC**.
+
+### Group 3 — Streaming + lazy (serial)
+
+**IO-S5. Streaming-save during forward pass + postprocess steps 19+20 + streaming-strict + cleanup_tmp + symlink rejection**
+- `torchlens/_io/streaming.py`: `BundleStreamWriter`. Open `<path>.tmp.<uuid>/blobs/` (reject if path exists as symlink), receive `(blob_id, tensor)` synchronously, consult `tensor_policy` per tensor (streaming is **always strict** — Round-3 finding #6), write safetensors. On `finalize()`: compute sha256 per blob, write manifest, write scrubbed `metadata.pkl`, rename temp dir → final path. Returns set of blob ids + final path for ref-patching.
+- Instrument `LayerPassLog.save_tensor_data()` with writer callout; gated to exhaustive-pass call site only (`capture/output_tensors.py:866-900`).
+- **Step 19 `_finalize_streamed_bundle`** registered in `postprocess/__init__.py`: always runs if writer present. Handles manifest write, scrubbed metadata.pkl write, atomic rename.
+- **Step 20 `_evict_streamed_activations`** registered after step 19: runs only if writer present AND `keep_activations_in_memory=False`. **Only** nulls `.activation`. `.activation_ref` was already attached by step 19. No path-patching here.
+- Non-tensor postfunc guard: writer verifies first received tensor is `torch.Tensor`; if not, abort, mark `.tmp.<uuid>/PARTIAL`, raise `TorchLensIOError` (Fork D rule).
+- Symlink rejection: writer refuses to open if `<path>` exists as a symlink; load side already covered by S4 + Fork J.
+- `torchlens.cleanup_tmp(path, force=False)` utility (rejects symlink temp dirs — Round-3 finding #7).
+- Files: `torchlens/_io/streaming.py` (NEW), `torchlens/_io/bundle.py`, `torchlens/data_classes/{layer_pass_log,model_log}.py`, `torchlens/user_funcs.py`, `torchlens/postprocess/{__init__,finalization}.py`.
+- Tests: `tests/test_io_streaming.py` (NEW) — blobs written during pass (verify timestamps); step 19 always runs and bundle is finalized on keep_activations_in_memory=True; step 20 gated correctly; mid-pass exception leaves PARTIAL; non-tensor postfunc aborts; sparse/meta/nested tensor mid-stream raises `TorchLensIOError` with PARTIAL preserved; lazy refs point to final path not temp; cleanup_tmp ignores symlinks; `activation_sink` callable path.
+- Size: **~440 LoC** (up from 400 due to step split + strictness + symlink rejection).
+
+**IO-S6. Lazy activation references + two-level drift guard + lazy-resave fast-copy + rehydrate_nested + no-shared-handles**
+- Flesh out `torchlens/_io/lazy.py`: `LazyActivationRef(blob_id, shape, dtype, device_at_save, source_bundle_path, kind, expected_sha256)`; `materialize(map_location="cpu")` opens safetensors fresh, reads, verifies sha256 against `expected_sha256`, closes, returns tensor (Fork K: no shared readers).
+- `LayerPassLog.materialize_activation(map_location="cpu") -> Tensor` (and `.materialize_gradient()`).
+- `torchlens.rehydrate_nested(model_log, map_location="cpu")`: power-user function for when user did `lazy=True, materialize_nested=False`. Walks nested containers, replaces any remaining `BlobRef` with real tensors.
+- ModelLog records `_source_bundle_manifest_sha256` at load time.
+- Lazy-resave fast-copy path in `torchlens/_io/bundle.py::save` (Fork H two-layer):
+  1. Verify `sha256(source/manifest.json) == _source_bundle_manifest_sha256`; else raise.
+  2. For each `LazyActivationRef` about to be copied: verify `sha256(source/blobs/<blob_id>.safetensors) == ref.expected_sha256`; else raise.
+  3. Only then `shutil.copy` to new bundle.
+- Cleanup: `ModelLog.cleanup()` documents "no long-lived handles to close" (Fork K).
+- Files: `torchlens/_io/lazy.py` (EXPAND), `torchlens/data_classes/{layer_pass_log,cleanup}.py`, `torchlens/_io/bundle.py`, `torchlens/_io/rehydrate.py`, `torchlens/validation/invariants.py` (clear-error path on portable-loaded logs per Fork L).
+- Tests: `tests/test_io_lazy.py` (NEW) — shape/dtype accessible without disk read; materialize bit-exact vs eager; map_location honored; manifest-level drift (mutate manifest) raises; **blob-level drift (mutate a single blob file, leave manifest intact) also raises** (Round-3 finding #4); fast-copy on clean source; validation APIs raise `TorchLensIOError` on any portable-loaded ModelLog (both eager and lazy per Fork L); `rehydrate_nested` populates nested BlobRefs; no open file handles leak after materialize.
+- Size: **~400 LoC** (up from 360 due to per-blob drift + rehydrate_nested + expected_sha256 field).
+
+### Group 4 — Integration tests + docs (parallel)
+
+**IO-S7. Integration + corruption regression suite**
+- End-to-end: capture → stream-save → lazy-load → materialize → to_parquet → re-load.
+- Corruption battery: truncated safetensors, missing blob, corrupt pickle, tampered manifest, stale counts, unknown extra files, checksum mismatch. Each must raise `TorchLensIOError` with specific message.
+- Forged older-format pickle loads with `DeprecationWarning`.
+- DataParallel/DDP sanity skip (torchlens already `warn_parallel`; streaming inherits).
+- Cross-feature integration: end-to-end streaming → lazy-load → materialize → to_parquet → reload. (PORTABLE_STATE_SPEC completeness lint is owned by S1, not here.)
+- Files: `tests/test_io_integration.py` (NEW), `tests/test_io_plain_pickle.py` (NEW), minor updates to `test_save_new_activations.py`.
+- Size: **~380 LoC**.
+
+**IO-S8. Docs**
+- Docstrings on every new public API with copy-pasteable examples.
+- README "Save and Load" section.
+- `.project-context/knowledge/io_architecture.md` (NEW): bundle layout, manifest schema, tensor matrix, version policy, operational-shape note (Fork I).
+- Files: `torchlens/_io/__init__.py`, `torchlens/__init__.py`, `torchlens/data_classes/model_log.py`, `README.md`, `.project-context/knowledge/io_architecture.md` (NEW).
+- Size: **~160 LoC**.
+
+Total: ~2640 LoC (up from 2460 in v2).
+
+---
+
+## 5. Spec Dependency Graph
+
+```
+S1 ─┬─> S4 ─┬─> S5 ──> S6 ──> S7
+    │       │
+S2 ─┴─> S3 ─┘                S8 (docs, parallel with S7)
+```
+
+---
+
+## 6. Risk Register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Unsupported tensor layouts | strict=True default raises; strict=False opt-in records in manifest. |
+| R2 | Scrub misses a new field added in a future release | S1 `PORTABLE_STATE_SPEC` completeness lint walks `vars(instance)` per class; CI fails if any new attribute is added without a policy entry. |
+| R3 | Disk-full / crash mid-stream | `.tmp.<uuid>/PARTIAL` sentinel; `cleanup_tmp` utility. |
+| R4 | Lingering nested `BlobRef`s in expert `materialize_nested=False` mode | Nested containers eager-materialized by default (`materialize_nested=True`); expert `materialize_nested=False` mode requires `rehydrate_nested()` before resave (Fork M). Validation/replay is out of scope on all portable-loaded logs per Fork L. |
+| R5 | Lazy cleanup vs live safetensors handles | No long-lived handles: `materialize()` opens/reads/closes per call (Fork K). `cleanup()` is trivial. |
+| R6 | Format drift in N+1 | `io_format_version` + migration helpers (S1). |
+| R7 | CUDA bundle on CPU host | `map_location="cpu"` default; safetensors handles it. |
+| R8 | Streaming writer blocks | Synchronous by design; documented. |
+| R9 | pyarrow install weight | Optional via extras. |
+| R10 | Many small files (directory format) | Documented tradeoff (Fork I); deferred to future sprint. |
+| R11 | NFS/Windows rename edge cases | Documented: local-same-fs best-effort. |
+| R12 | Source bundle mutated between lazy load and resave | Two-layer drift check (Fork H): manifest sha256 + per-blob sha256 both verified before fast-copy; either mismatch raises `TorchLensIOError`. |
+| R13 | DataParallel/DDP multiple capture | Torchlens is single-process; inherit existing warning. |
+| R14 | Exception handling ambiguity | All bundle errors wrap `TorchLensIOError` (Fork G). |
+| R15 | User expects `validate_forward_pass` on portable-loaded ModelLog | Hard-raise `TorchLensIOError` on portable-loaded logs (Fork L); docstring + README + tests. |
+| R16 | Resave with nested BlobRefs silently corrupts | Hard-raise `TorchLensIOError` telling user to call `rehydrate_nested()` first (Fork M). |
+
+---
+
+## 7. Execution Plan
+
+| Round | Specs | Gate |
+|-------|-------|------|
+| 1 | S1 ‖ S2 | Pickle scrub round-trip green; new pandas schemas green. |
+| 2 | S3 (after S2) ‖ S4 (after S1) | All export formats green; bundle round-trip green; version policy table tested. |
+| 3 | S5 (after S4) | Streaming + step 19 green; postprocess sees tensors; lazy refs point at final path. |
+| 4 | S6 (after S5) | Lazy load + materialize bit-exact; source drift detected; resave fast-copy. |
+| 5 | S7 ‖ S8 | Integration corruption battery green; docs complete. |
+| 6 | Phase 5 dual review (me + `/codex:review`). |
+
+---
+
+## 8. Stop-and-Ask Triggers
+
+- End of this plan revision — **NOW**
+- Any public API signature change beyond additions
+- Any bump of `io_format_version` in the future
+- End of Phase 5 (which review findings to fix)
+
+---
+
+## 9. Success Criteria (binary)
+
+- [ ] `torchlens.save(model_log, path)` + `torchlens.load(path)` round-trip everything on the supported-tensor matrix
+- [ ] Six log-level DataFrames + `.to_csv/.to_parquet/.to_json` on all seven producers
+- [ ] `log_forward_pass(..., save_activations_to=path)` streams during pass; postprocess unaffected
+- [ ] `keep_activations_in_memory=False` evicts post-pass; lazy refs point to final (post-rename) path
+- [ ] Lazy load preserves metadata access without disk read; `materialize_activation()` bit-exact
+- [ ] Source-drift detection works
+- [ ] Every row in the Fork F version-policy table has a test (13 rows)
+- [ ] All bundle errors raise `TorchLensIOError`
+- [ ] Scrub-policy lint passes
+- [ ] Plain pickle still works with deprecation warning on pre-sprint pickles only
+- [ ] `pytest tests/ -m "not slow"` green
+- [ ] `ruff check . && mypy torchlens/` green
+
+---
+
+## 10. Change Log vs Round 4 (addresses all 4 findings)
+
+| Finding | Severity | Resolution |
+|---------|----------|-----------|
+| R4-1 Validation broken on portable bundles because func_applied is dropped | HIGH | New Fork L: explicitly declare `validate_forward_pass` / `validate_saved_activations` unsupported on portable-loaded ModelLogs. `_loaded_from_bundle` flag + hard-raise with actionable message. Removed all "validation-ready bundle" language. Users who need replay keep logs in memory or use plain pickle. |
+| R4-2 No resave contract for `materialize_nested=False` mode | MEDIUM | New Fork M: `torchlens.save()` pre-scans for nested `BlobRef`; raises `TorchLensIOError` with a "call `rehydrate_nested()` first" hint if any found. |
+| R4-3 Step-19/20 split left keep-in-memory path un-disk-backed | MEDIUM | Fork D rewritten: step 19 ALWAYS attaches `.activation_ref` (independent of `keep_activations_in_memory`). Step 20 only nulls `.activation`. Returned log is genuinely disk-backed in both modes. |
+| R4-4 Public API sketch + risk register lagged v4 design | LOW | Synced `LazyActivationRef` sketch to include `expected_sha256`. Risk register R4/R5 updated to reflect Fork K/M. Added R15/R16 for new Fork L/M behaviors. |
+
+## Change Log vs Round 3 (see plan_v4.md for detailed Round-3 resolutions)
+
+All 9 Round-3 findings were resolved in v4 and verified by the Round-4 reviewer. Summary retained in `review_round_4.md`.

--- a/.project-context/plans/io-sprint/plan_v1.md
+++ b/.project-context/plans/io-sprint/plan_v1.md
@@ -1,0 +1,272 @@
+# TorchLens I/O Sprint Plan (Round 1)
+
+**Branch**: `codex/io-sprint`
+**Goal**: comprehensive, frictionless I/O for ModelLog and its children — pickle, pandas/CSV/Parquet/JSON, activation-to-disk (including on-the-fly streaming), symmetric loading.
+**Out of scope**: visualization (graphviz, ELK, dagua).
+**Inputs**: `.project-context/research/io-audit-claude.md`, `.project-context/research/io-audit-codex.md`.
+
+---
+
+## 1. Design Forks — Resolved
+
+### Fork A. Primary save format
+**Decision**: multi-format bundle — **pickle (nested state) + safetensors (tensor blobs) + manifest.json (version / shape index)**.
+
+Why (resolving audit disagreement):
+- Claude proposed parquet-primary. Parquet is fundamentally tabular; it cannot round-trip `func_rng_states`, `func_autocast_state`, `captured_args` (nested dicts with torch objects), or `func_applied` callables without lossy flattening.
+- Codex proposed a bundle; this matches how the data shape actually is. Pickle handles nested Python, safetensors handles tensors safely and version-stably, a small manifest.json carries version metadata and enables partial/lazy reads.
+- Parquet/CSV/JSON remain first-class **export** targets for tabular views (layers/passes/modules/params/buffers DataFrames), not the primary archival format.
+
+Bundle layout:
+```
+<bundle>/
+  manifest.json            # io_format_version, torchlens_version, torch_version, python_version, counts
+  metadata.pkl             # ModelLog with activations stubbed to LazyActivationRef keyed by layer label
+  activations/
+    <layer_label_pass>.safetensors    # one file per saved tensor (activation) when present
+    <layer_label_pass>.grad.safetensors  # one file per saved gradient when present
+  frames/                  # optional source-context snapshots if save_source_context=True
+```
+
+Single-file alternative: `<bundle>.tlens` (.tar.gz of the directory). Both forms supported; directory is default (faster incremental access, friendlier to tools).
+
+### Fork B. Default load granularity
+**Decision**: **lazy by default** when a bundle contains activations; **eager when no activation sidecars** (nothing to defer).
+
+Why:
+- RAM pressure is the primary motivation of the sprint.
+- `LazyActivationRef.materialize()` makes it one call to force-load.
+- `torchlens.load(path, lazy=False)` for users who prefer the old behavior.
+
+### Fork C. Pandas-export scope
+**Decision**: DataFrames at **all five log levels**: layer-pass (ModelLog), aggregate layer, module, param, buffer.
+
+Current gaps: ParamAccessor and BufferAccessor have no `to_pandas()`. Add them for symmetry.
+
+### Fork D. Streaming-save architecture
+**Decision**: single instrumentation point at `LayerPassLog.save_tensor_data()` (layer_pass_log.py:455-501). All three capture sites (`_make_layer_log_entry` at output_tensors.py:866, fast-path overwrite at output_tensors.py:608, source refresh at source_tensors.py:316) already converge there.
+
+Mechanism: `log_forward_pass(..., save_activations_to: str | Path | None = None)`. When set, ModelLog holds an `_activation_writer` (protocol below) that receives `(layer_label_with_pass, tensor)` immediately after the clone/detach/device/postfunc pipeline inside `save_tensor_data`. The in-memory activation is still kept unless user also passes `keep_activations_in_memory=False`, in which case it is replaced with a `LazyActivationRef` pointing at the just-written sidecar.
+
+Atomicity: writer writes to `<bundle>.tmp/activations/…` and renames on forward-pass success. On exception, the temp directory is kept for debugging (warning logged, user can delete or retry). No partial bundle ever exposed under the final path.
+
+### Fork E. Backward compatibility
+**Decision**: version-tagged pickle + loader-side default-fill for `N-1` minor versions.
+
+Add:
+- `IO_FORMAT_VERSION = 1` constant in `torchlens/_io/__init__.py`
+- `io_format_version` field on ModelLog (set in `__init__`)
+- `__setstate__` on ModelLog, LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog: read version from state, default-fill missing fields, warn if loaded from a newer torchlens than current
+- manifest.json also carries version so bundle loaders can check before opening the pickle
+
+---
+
+## 2. Public API Surface (proposed)
+
+### On `torchlens` (top-level)
+```python
+torchlens.save(model_log, path, *,
+               include_activations=True,
+               include_gradients=True,
+               format="bundle",      # "bundle" | "tar" (tar.gz of bundle)
+               compression="zstd")   # for safetensors-compatible compression of tensors
+    -> None
+
+torchlens.load(path, *,
+               lazy=True,
+               map_location="cpu")   # passed to safetensors loader
+    -> ModelLog
+```
+
+### On `ModelLog`
+```python
+# Save/load
+model_log.save(path, **kwargs)        # sugar for torchlens.save(self, path, **kwargs)
+ModelLog.load(path, **kwargs)         # classmethod, equivalent to torchlens.load
+
+# Tabular exports (already exists: to_pandas)
+model_log.to_pandas() -> pd.DataFrame
+model_log.to_csv(path, **kwargs)      # one-row-per-layer-pass
+model_log.to_parquet(path, **kwargs)
+model_log.to_json(path, *, orient="records")
+
+# Streaming — at capture time, not after the fact:
+# log_forward_pass gets new kwargs:
+#   save_activations_to: str | Path | None = None
+#   keep_activations_in_memory: bool = True
+#   activation_sink: Callable[[str, torch.Tensor], None] | None = None
+```
+
+### On accessors (new / expanded)
+```python
+# Existing on ModelLog namespace:
+model_log.layers.to_pandas() -> pd.DataFrame       # LayerAccessor (exists)
+model_log.modules.to_pandas() -> pd.DataFrame      # ModuleAccessor (exists)
+# New:
+model_log.params.to_pandas() -> pd.DataFrame       # ParamAccessor — ADD
+model_log.buffers.to_pandas() -> pd.DataFrame      # BufferAccessor — ADD
+
+# All accessors gain:
+.to_csv(path), .to_parquet(path), .to_json(path)
+```
+
+### LazyActivationRef (new)
+```python
+class LazyActivationRef:
+    path: Path
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device   # recorded device at save time
+
+    def materialize(self, *, map_location=None) -> torch.Tensor: ...
+    # Implicit materialization on direct access (attribute passthrough for shape/dtype is free,
+    # any torch op triggers materialize). NOT a torch.Tensor subclass — keep the distinction
+    # explicit; user code that needs a tensor calls .materialize() or accesses .activation which
+    # materializes on read.
+```
+
+Rationale for not subclassing Tensor: subclassing breaks `isinstance(x, torch.Tensor)` semantics in subtle ways and fights `__torch_function__`. Explicit materialization is honest and cheap.
+
+### LayerPassLog helpers
+```python
+layer_pass.activation         # → torch.Tensor, or LazyActivationRef if lazy and not yet materialized
+layer_pass.materialize_activation(*, map_location=None) -> torch.Tensor
+layer_pass.has_saved_activations: bool  # True even when lazy
+```
+
+---
+
+## 3. Spec Decomposition
+
+Specs are Codex-dispatchable, self-contained, each must include unit tests and pass all three quality gates (`ruff check . --fix && mypy torchlens/ && pytest tests/ -m smoke -x --tb=short`). Execution groups run serially; specs inside a group are independent and CAN be dispatched in parallel but default is one-at-a-time per branch.
+
+### Group 1 — Foundations (dispatch in parallel)
+
+**IO-S1. Pickle hardening + version tagging + accessor reconstruction on load**
+- Add `torchlens/_io/__init__.py` with `IO_FORMAT_VERSION = 1`, `TorchLensIOError`, helpers for default-fill.
+- Add `io_format_version` field to ModelLog.
+- Expand `ModelLog.__setstate__` to:
+  - Read version, warn on unknown-newer, default-fill missing fields.
+  - Rebuild `_module_logs` via ModuleAccessor and `_buffer_accessor` via BufferAccessor using the same logic in `postprocess/finalization.py:671-681` (extract to a shared helper).
+- Add `__setstate__` default-fill to LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog.
+- Files: `torchlens/_io/__init__.py` (NEW), `torchlens/data_classes/model_log.py`, `layer_pass_log.py`, `layer_log.py`, `param_log.py`, `buffer_log.py`, `module_log.py`, `postprocess/finalization.py` (extract helper only).
+- Tests: `tests/test_io_pickle.py` (NEW) — round-trip preserves all FIELD_ORDER columns; accessors functional after load; default-fill from stubbed older pickle; version warning on newer.
+- Size: ~240 LoC.
+
+**IO-S2. ParamAccessor.to_pandas() + BufferAccessor.to_pandas()**
+- Mirror the field-selection pattern from LayerAccessor.to_pandas (`layer_log.py:665-687`).
+- Define param and buffer DataFrame schemas in FIELD_ORDER-style tuples in `torchlens/constants.py`.
+- Files: `torchlens/data_classes/param_log.py`, `buffer_log.py`, `constants.py`.
+- Tests: `tests/test_io_pandas.py` (NEW) — schema shape, NaN handling, empty-accessor case.
+- Size: ~160 LoC.
+
+### Group 2 — Tabular exports and bundle save/load (serial, S1 must land first)
+
+**IO-S3. Export wrappers: to_csv / to_parquet / to_json on all DataFrames**
+- Add `to_csv(path, **kwargs)`, `to_parquet(path, **kwargs)`, `to_json(path, *, orient="records", **kwargs)` to: ModelLog (via `interface.py`), LayerAccessor, ModuleAccessor, ModuleLog, ParamAccessor, BufferAccessor.
+- pyarrow added as optional dep with import-time lazy check; parquet methods raise a clear `ImportError` with install hint if missing.
+- Files: `torchlens/data_classes/interface.py`, `layer_log.py`, `module_log.py`, `param_log.py`, `buffer_log.py`, `pyproject.toml` (add `pyarrow` to `[extra] io`).
+- Tests: `tests/test_io_export.py` (NEW) — round-trip csv/parquet/json, schema stability, optional-dep error.
+- Size: ~200 LoC. DEPENDS ON: S2.
+
+**IO-S4. Bundle save/load (pickle + safetensors + manifest)**
+- Implement `torchlens.save(model_log, path, ...)` and `torchlens.load(path, ...)` in `torchlens/_io/bundle.py`.
+- Add safetensors as optional dep; bundle format falls back to `torch.save` for tensors if safetensors unavailable (warn-once).
+- Manifest schema v1: `{io_format_version, torchlens_version, torch_version, python_version, created_at, n_layers, n_activations, n_gradients, bundle_format}`.
+- ModelLog gets `.save(path, ...)` sugar and `ModelLog.load(path)` classmethod.
+- tar.gz (`format="tar"`) writes the same directory layout and streams into a single `.tlens` file.
+- Files: `torchlens/_io/bundle.py` (NEW), `torchlens/_io/manifest.py` (NEW), `torchlens/_io/__init__.py`, `torchlens/data_classes/model_log.py`, `torchlens/__init__.py` (export `save`/`load`), `torchlens/user_funcs.py` (re-export).
+- Tests: `tests/test_io_bundle.py` (NEW) — round-trip eager, round-trip lazy, tar form, missing safetensors fallback, manifest mismatch, disk-full mid-write (monkeypatched).
+- Size: ~320 LoC. DEPENDS ON: S1.
+
+### Group 3 — Streaming + lazy (serial, S4 must land first)
+
+**IO-S5. Streaming-save during forward pass**
+- Add `save_activations_to: str | Path | None` and `keep_activations_in_memory: bool = True` and `activation_sink: Callable[[str, torch.Tensor], None] | None = None` to `log_forward_pass` (user_funcs.py).
+- When `save_activations_to` is set: write directly to `<path>.tmp/` during the pass, rename to `<path>` on success; on exception, keep `.tmp/` and emit a warning with a resume hint.
+- ModelLog gains a private `_activation_writer` attribute (contextvar-friendly).
+- Instrument `LayerPassLog.save_tensor_data()` (layer_pass_log.py:455-501): after the current tensor-prep pipeline (clone / detach / output_device / postfunc under pause_logging), call `model_log._activation_writer(label_with_pass, self.activation)` when present; if `keep_activations_in_memory=False`, replace `self.activation` with a `LazyActivationRef`.
+- Files: `torchlens/data_classes/layer_pass_log.py`, `torchlens/data_classes/model_log.py`, `torchlens/user_funcs.py`, `torchlens/_io/streaming.py` (NEW), `torchlens/_io/lazy.py` (NEW, stub here — fleshed out in S6).
+- Tests: `tests/test_io_streaming.py` (NEW) — artifacts written during pass, mid-pass exception leaves `.tmp/`, atomic rename, sink callback, `keep_activations_in_memory=False` evicts tensor, round-trip with `torchlens.load`.
+- Size: ~270 LoC. DEPENDS ON: S4.
+
+**IO-S6. Lazy activation references**
+- Flesh out `LazyActivationRef` in `torchlens/_io/lazy.py`: holds `path`, `shape`, `dtype`, `device_at_save`; `materialize(map_location=None) -> Tensor` reads safetensors.
+- `LayerPassLog.materialize_activation(map_location=None)` materializes and replaces `self.activation` in place.
+- Bundle loader (from S4) returns ModelLog with activations populated as `LazyActivationRef` when `lazy=True`.
+- Non-subclass approach: direct attribute access to `.activation` returns the ref; user must call materialize to get a tensor. `.tensor_shape` / `.tensor_dtype` / `.tensor_memory` on LayerPassLog already provide metadata without materializing.
+- Files: `torchlens/_io/lazy.py` (EXPAND), `torchlens/data_classes/layer_pass_log.py`, `torchlens/_io/bundle.py` (already present from S4 but loader wiring lives here).
+- Tests: `tests/test_io_lazy.py` (NEW) — lazy load preserves shape/dtype metadata without reading tensor, materialize correctness (bitwise equality with eager load), device mapping, memory footprint.
+- Size: ~240 LoC. DEPENDS ON: S4, S5.
+
+### Group 4 — Tests + docs (serial, after S6)
+
+**IO-S7. Integration regression suite**
+- End-to-end: capture → save (streaming and post-hoc) → load (lazy and eager) → to_pandas → to_parquet round-trips.
+- Large-model memory-footprint test (skipped with `@pytest.mark.slow` if too heavy for CI).
+- Cross-version default-fill (forge an older-format pickle by hand; assert load succeeds with warning).
+- Safetensors-missing fallback path.
+- Files: `tests/test_io_integration.py` (NEW), minor updates to existing `test_save_new_activations.py`.
+- Size: ~280 LoC. DEPENDS ON: S1-S6.
+
+**IO-S8. Docs + public API**
+- Module-level docstrings on new APIs with copy-pasteable examples.
+- Update `README.md` (short I/O section) and `torchlens/__init__.py` docstring surface.
+- Add `.project-context/knowledge/io_architecture.md` describing bundle layout and format-version policy.
+- No release notes in this sprint — user gates that.
+- Files: `torchlens/_io/__init__.py`, `torchlens/_io/bundle.py`, `torchlens/_io/lazy.py`, `torchlens/_io/streaming.py`, `torchlens/__init__.py`, `torchlens/data_classes/model_log.py`, `README.md`, `.project-context/knowledge/io_architecture.md` (NEW).
+- Size: ~120 LoC.
+
+---
+
+## 4. Risk Register (sprint-local)
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Safetensors can't store arbitrary dtypes (meta, sparse) | Fallback to `torch.save` for those layers, record in manifest. |
+| R2 | `func_applied` callable identity drift across torch versions breaks pickle | Already present as a risk; document. Not in sprint scope to fix. |
+| R3 | Disk full mid-stream leaves orphan `.tmp/` | Emit clear warning with path + `torchlens.cleanup_tmp(path)` utility. |
+| R4 | Lazy refs leak through pandas export (saved as `<LazyActivationRef>` repr) | DataFrame exporters never touch `.activation` directly; only metadata fields. Add assertion in tests. |
+| R5 | Circular-ref cleanup (`ModelLog.cleanup()`) after lazy load deletes refs that materialize would need | `cleanup()` becomes aware of lazy state: closes bundle handles before clearing. Unit test. |
+| R6 | pickle-format drift in N+1 sprint breaks N-1 loads | `io_format_version` bump + explicit migration table. Test both directions. |
+| R7 | CUDA tensor loaded on CPU-only host | `map_location="cpu"` default; `torch.load`-style semantics on safetensors loader. |
+| R8 | Large tensor single-file write blocks event loop in streaming | Streaming writer is synchronous; document. Async writer is out of scope. |
+| R9 | Parquet dependency (pyarrow) adds install weight | Make optional via extras; clear ImportError if used without install. |
+| R10 | `include_activations=True` bundle is huge for multi-GB models; user doesn't realize | Save emits a summary: "Wrote N activations, X GB total." |
+
+---
+
+## 5. Execution Plan
+
+| Round | Specs | Gate after |
+|-------|-------|------------|
+| 1 | S1, S2 (parallel-safe, different files) | All quality gates green on branch |
+| 2 | S3, S4 (serial: S3 after S2 lands; S4 after S1 lands — can overlap) | Bundle round-trip proven |
+| 3 | S5, S6 (S5 first, S6 reads S5's writer) | Streaming + lazy E2E proven |
+| 4 | S7, S8 (parallel) | Full regression suite green |
+| 5 | Adversarial review (Codex) + self-review — Phase 5 of sprint | User-facing findings list |
+
+One feature branch `codex/io-sprint`. Each spec is one Codex dispatch. Quality gates mandatory before next dispatch.
+
+---
+
+## 6. Stop-and-Ask Triggers (from directive)
+
+- End of Phase 2 (this document) — **NOW**
+- Any public API signature change beyond additions — none planned; flag if it comes up
+- New dep (`safetensors`, `pyarrow`): both optional via extras; flag if consensus is to make required
+- Pickle-format break vs N-1 — none planned; flag if it becomes unavoidable
+- End of Phase 5 — which review findings to fix
+
+---
+
+## 7. Success Criteria (binary)
+
+- [ ] `model_log.save(path)` and `torchlens.load(path)` round-trip tensors (lazy and eager)
+- [ ] `model_log.to_pandas()` + `.to_csv` + `.to_parquet` + `.to_json` at 5 log levels
+- [ ] `log_forward_pass(..., save_activations_to=path)` streams to disk during pass
+- [ ] Activations can be loaded back lazily without RAM spike
+- [ ] `pytest tests/ -m "not slow"` green; all quality gates green
+- [ ] No regression in existing smoke tests
+- [ ] Every new public API has docstring with example
+- [ ] Old pickles (from torchlens 1.0.2) load with a deprecation warning

--- a/.project-context/plans/io-sprint/plan_v2.md
+++ b/.project-context/plans/io-sprint/plan_v2.md
@@ -1,0 +1,452 @@
+# TorchLens I/O Sprint Plan (Round 2)
+
+**Branch**: `codex/io-sprint`
+**Goal**: comprehensive, frictionless I/O for ModelLog and its children — pickle, pandas/CSV/Parquet/JSON, activation-to-disk (including on-the-fly streaming during forward pass), symmetric loading.
+**Out of scope**: visualization (graphviz, ELK, dagua).
+**Inputs**: `.project-context/research/io-audit-claude.md`, `.project-context/research/io-audit-codex.md`, `.project-context/plans/io-sprint/review_round_1.md`.
+**This revision**: addresses all 23 findings of `review_round_1.md`. Change log at bottom.
+
+---
+
+## 1. Design Forks — Resolved
+
+### Fork A. Archival format
+**Decision**: **directory bundle only** (no tar this sprint) containing a scrubbed-state pickle, safetensors-only tensor blobs, and a rich manifest. `safetensors` is a **hard dependency** of the bundle path.
+
+Bundle layout:
+```
+<bundle_dir>/
+  manifest.json            # see schema below — authoritative index
+  metadata.pkl             # ModelLog with tensor fields stubbed to blob ids; scrubbed of non-portable objects
+  blobs/
+    0000000001.safetensors
+    0000000002.safetensors
+    ...                    # one file per saved tensor, filename is stable opaque blob id
+```
+
+Filenames are zero-padded monotonically-assigned blob ids (`0000000001.safetensors`). Human-readable layer labels (which contain `:` and other filesystem-unsafe characters) live only inside `manifest.json`, never in paths. Addresses review finding #5.
+
+**Pickle scrubbing contract** (addresses finding #1):
+Before `metadata.pkl` is written, a scrub pass walks the ModelLog state and:
+- Replaces `LayerPassLog.activation` / `.gradient` / `.children_tensor_versions` tensors with `BlobRef(blob_id)` stubs.
+- Replaces any tensors found inside `captured_args` / `captured_kwargs` / `forward_args` / `forward_kwargs` / `func_rng_states` with `BlobRef(blob_id)` stubs (unless `include_captured_args=False`, in which case they are dropped).
+- Drops `func_applied` (live torch callable) — recorded by `func_name` string already.
+- Drops `activation_postfunc` (user callable, may be a lambda) — recorded as `activation_postfunc_repr` string if present.
+- Drops `_param_ref` on ParamLog (pins an `nn.Parameter`, not portable).
+- Clears `FuncCallLocation._frame_func_obj` (already done by disabled-source path; make unconditional on save).
+- Clears any `extra_attributes` on ModelLog flagged non-serializable (explicit allow-list).
+
+The scrubbed state is versioned (`io_format_version=1`); `__setstate__` restores `BlobRef` stubs as `LazyActivationRef` and reconstructs dropped fields with sentinel values (`func_applied=None`, `activation_postfunc=None`, `_param_ref=None`). Existing `__getstate__` logic (strip weakrefs) continues to run on the pickle layer.
+
+**Plain-pickle backward compat** (addresses finding #14):
+`pickle.dump(model_log, f)` and `pickle.load(f)` continue to work. In this path, the existing `__getstate__` hooks run (weakref strip only) — no scrubbing — so the limitations of the current pickle surface are unchanged (callables and `_param_ref` remain). Users who want the portable, scrubbed representation use `torchlens.save(path)`. Plain pickle is kept supported, not deprecated, for at least this release cycle. Test coverage: `tests/test_io_plain_pickle.py`.
+
+### Fork B. Default load granularity & API shape
+**Decision**: **lazy default when bundle has activations; eager otherwise. `.activation` stays `tensor | None`. Lazy refs live on a separate field `.activation_ref`.**
+
+Addresses findings #7 and #8.
+
+Semantics after `torchlens.load(path, lazy=True)`:
+- For each LayerPassLog that had a saved activation:
+  - `.activation` is **None**
+  - `.activation_ref` is a `LazyActivationRef` carrying shape/dtype/device_at_save/blob_id
+  - `.tensor_shape`, `.tensor_dtype`, `.tensor_memory`, `.has_saved_activations` are all populated (metadata survives without materialization)
+- `LayerPassLog.materialize_activation(*, map_location="cpu") -> torch.Tensor` reads from disk, stores into `.activation`, and returns it. `.activation_ref` remains for idempotent re-materialization.
+- `torchlens.load(path, lazy=False)` eagerly materializes every activation during load — equivalent to calling `materialize_activation()` on every layer.
+
+Existing TorchLens internal code that reads `.activation.shape` etc. continues to work on eager-loaded bundles (the common case) and fails loudly (AttributeError on None) on lazy-loaded bundles with clear error messaging. We **do not** auto-materialize on internal accesses — finding #8 is addressed by explicit eager opt-out plus a documented lazy-compatibility list.
+
+**Lazy-compatibility audit** (part of S6): the following internal methods are verified lazy-safe or are updated to call `materialize_activation()` as needed:
+- `validate_forward_pass` (reads `.activation`) — adds explicit check; raises a clear error if activations are lazy and `materialize=False` was passed.
+- `validate_saved_activations` — same.
+- String reprs and `to_pandas()` — already read only metadata fields, not `.activation`. No change.
+- `cleanup()` — becomes lazy-aware: closes any open safetensors file handles, then nulls out refs.
+
+### Fork C. Pandas-export scope
+**Decision**: DataFrames at **six log levels**: layer-pass (ModelLog), aggregate layer, module-pass (new), module, param, buffer.
+
+Adds `ModulePassLog.to_pandas()` to resolve finding #19 — includes `forward_args` / `forward_kwargs` shape metadata (tensors replaced by shape/dtype strings for pandas rows).
+
+### Fork D. Streaming-save architecture
+**Decision**: during forward pass, write the sidecar immediately at `save_tensor_data()` completion; **do not** evict the in-memory tensor until a new **post-pass eviction step** runs inside postprocess. Selective streaming hooks the exhaustive pass only, not fast-path refresh sites.
+
+Addresses findings #2 and #12.
+
+Concrete flow:
+1. `log_forward_pass(..., save_activations_to=path)` creates ModelLog with `_activation_writer = BundleStreamWriter(path + ".tmp")`.
+2. Inside `LayerPassLog.save_tensor_data()` (layer_pass_log.py:455-501), after the existing clone / detach / output_device / `activation_postfunc` pipeline, the writer receives `(blob_id, self.activation)` and writes `blob_id.safetensors` to `<path>.tmp/blobs/`. `self.activation` is **unchanged** at this point.
+3. Writer is invoked **only from the exhaustive-pass call site** (`capture/output_tensors.py:866-900`). The fast-path overwrite sites (`output_tensors.py:608-644`, `source_tensors.py:316-322`) are NOT instrumented for streaming (those support `save_new_activations` which has known issues; streaming is a first-pass feature).
+4. Postprocess runs as usual with real tensors in memory.
+5. New postprocess step **`_evict_streamed_activations`** (added to the 18-step pipeline) runs last if `keep_activations_in_memory=False`: for each layer with a streamed sidecar, replaces `.activation` with None, sets `.activation_ref` to a `LazyActivationRef` pointing at the sidecar.
+6. Writer writes `manifest.json` and `metadata.pkl` atomically at the end, then renames `<path>.tmp` → `<path>`.
+
+**Atomicity scope** (addresses finding #11):
+- Temp-dir suffix is random (`<path>.tmp.{uuid4}`) so two concurrent writers never collide.
+- `<path>` must not exist at start (fail fast with `FileExistsError`). User can pass `overwrite=True` to allow replacement; replacement does rename-old-then-rename-new, accepting a small window of inconsistency.
+- Rename + fsync documented as local-same-filesystem best-effort. Cross-filesystem and NFS atomicity explicitly NOT claimed; docstring warns.
+
+**Unsupported-writer state & cleanup** (addresses finding #22):
+- `torchlens.cleanup_tmp(path)` is a public utility added in S5 that searches `<path>.tmp.*` siblings and removes them (after confirmation prompt unless `force=True`).
+- On exception during streaming: the `.tmp.<uuid>` directory is kept, a warning naming the path is emitted, and the writer emits `<path>.tmp.<uuid>/PARTIAL` sentinel file so `cleanup_tmp` can identify it safely.
+
+**Non-tensor activation_postfunc guard** (addresses finding #6):
+If `save_activations_to` is set AND `activation_postfunc` is passed AND postfunc output is not a `torch.Tensor`, raise `TorchLensIOError` at forward start with a clear message. This check is a one-liner on the first call (after postfunc applied to sentinel input-shape tensor) or runtime-first-layer — latter is simpler: the sink validates the type of the first tensor it sees; if not `torch.Tensor`, the whole write aborts and `.tmp` directory is kept.
+
+**Gradient streaming** (addresses finding #3):
+Gradients are **NOT** streamed during backward in this sprint. Rationale: backward is user-initiated, may not happen, may fail halfway, and lacks the single instrumentation point that forward has.
+
+Post-hoc gradient bundling IS supported: `torchlens.save(model_log, path, include_gradients=True)` after `log_forward_pass` + user-run backward. If any LayerPassLog has `.gradient` populated, it is written to `blobs/NNNNNNNNNN.safetensors` with `kind="gradient"` in the manifest. `include_gradients=True` with no populated gradients is a no-op (not an error).
+
+This preserves the user promise (grads can be archived) without taking on a gradient-streaming design this sprint.
+
+### Fork E. Backward compat & version policy
+**Decision**: version-tagged manifest + default-fill `__setstate__` + explicit mismatch policy table.
+
+Addresses findings #14 and #15.
+
+Version policy table:
+| Scenario | Load behavior |
+|----------|---------------|
+| `io_format_version` == current | Load normally |
+| `io_format_version` < current | Load with default-fill, emit `DeprecationWarning` naming missing fields |
+| `io_format_version` > current | Hard-fail with `TorchLensIOError`: "bundle requires torchlens >= X; refusing to load" |
+| `torchlens_version` < current, same format version | Load, emit info log |
+| `torchlens_version` > current, same format version | Load with `UserWarning` |
+| `torch_version` major mismatch (e.g. 1.x ↔ 2.x) | Hard-fail with `TorchLensIOError`: "bundle produced with torch X; incompatible major" |
+| `torch_version` minor mismatch | Load with `UserWarning` |
+| `python_version` major mismatch | Load attempt; if pickle opcode fails, raise with a descriptive error referencing the version |
+| Safetensors backend absent | Hard-fail: "bundle requires safetensors; pip install safetensors" |
+| Manifest missing or unparseable | Hard-fail |
+| Blob file missing from manifest index | Hard-fail with the specific missing blob_id |
+| Blob checksum mismatch | Hard-fail |
+| Unknown extra files in bundle | Warning, continue |
+
+---
+
+## 2. Manifest Schema v1
+
+```json
+{
+  "io_format_version": 1,
+  "torchlens_version": "1.2.0",
+  "torch_version": "2.5.0",
+  "python_version": "3.11.5",
+  "platform": "linux-x86_64",
+  "created_at": "2026-04-23T13:05:00Z",
+  "bundle_format": "directory",
+  "n_layers": 152,
+  "n_activation_blobs": 152,
+  "n_gradient_blobs": 0,
+  "tensors": [
+    {
+      "blob_id": "0000000001",
+      "kind": "activation",
+      "label": "conv2d_1_1:2",
+      "relative_path": "blobs/0000000001.safetensors",
+      "backend": "safetensors",
+      "shape": [1, 64, 112, 112],
+      "dtype": "float32",
+      "device_at_save": "cuda:0",
+      "layout": "strided",
+      "bytes": 3211264,
+      "sha256": "3f5c..."
+    }
+  ],
+  "unsupported_tensors": [
+    {"label": "sparse_layer:1", "reason": "sparse_coo layout not supported this release"}
+  ]
+}
+```
+
+Addresses finding #10.
+
+---
+
+## 3. Supported Tensor Matrix
+
+Addresses finding #13.
+
+| Tensor kind | Status | Behavior on save |
+|-------------|--------|------------------|
+| Dense CPU / CUDA (`float16`, `bfloat16`, `float32`, `float64`, `int*`, `uint8`, `bool`, `complex64`, `complex128`) | Supported | Written via safetensors |
+| Non-contiguous | Supported | `.contiguous()` called before write; documented |
+| Sparse COO / CSR | Not supported this sprint | Skipped with warning, entry added to `unsupported_tensors`, `.activation_ref` stays None |
+| Quantized | Not supported | Same as above |
+| Meta tensors (`device="meta"`) | Skipped | No data to persist; metadata preserved in manifest only |
+| Nested tensors | Not supported | Skipped with warning |
+| Tensor subclasses (unknown) | Not supported | Skipped with warning |
+| DTensor / FSDP local shard | Not supported | Skipped with warning; user must gather first |
+| Complex dtypes (complex32) | Not supported (safetensors limitation) | Skipped with warning |
+
+`torchlens.save()` with unsupported tensors never errors; it writes what it can and records what it skipped in `unsupported_tensors`. Loading such a bundle produces LayerPassLogs with `activation=None` and a clear "skipped at save time" note on load. This is a deliberate choice for defensive UX — exceptions would make one weird layer break a whole 1000-layer archive.
+
+The strict alternative (`strict=True` kwarg) raises on first unsupported tensor. Default is lenient.
+
+---
+
+## 4. Public API Surface
+
+### Top-level `torchlens`
+```python
+torchlens.save(
+    model_log: ModelLog,
+    path: str | Path,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,    # no-op if no gradients populated
+    include_captured_args: bool = True,
+    overwrite: bool = False,
+    strict: bool = False,
+) -> None
+
+torchlens.load(
+    path: str | Path,
+    *,
+    lazy: bool = True,
+    map_location: str | torch.device = "cpu",
+) -> ModelLog
+
+torchlens.cleanup_tmp(
+    path: str | Path,
+    *,
+    force: bool = False,
+) -> list[Path]    # returns list of cleaned-up .tmp.* dirs
+```
+
+**Removed from v1 plan**: `format="tar"`, `compression="zstd"` (findings #4 and #21).
+
+### On `ModelLog`
+```python
+model_log.save(path, **kwargs)          # sugar for torchlens.save(self, path, **kwargs)
+ModelLog.load(path, **kwargs)           # classmethod
+
+model_log.to_pandas() -> pd.DataFrame
+model_log.to_csv(path, **kwargs)
+model_log.to_parquet(path, **kwargs)
+model_log.to_json(path, *, orient="records")
+```
+
+### On accessors (all six gain .to_csv / .to_parquet / .to_json)
+```python
+model_log.layers.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.modules.to_pandas() / ...
+model_log.params.to_pandas() / ...     # NEW
+model_log.buffers.to_pandas() / ...    # NEW
+
+module_log.to_pandas() / ...           # exists (one row per layer inside a single module)
+module_pass_log.to_pandas() / ...      # NEW — one row per module pass
+```
+
+### Streaming at capture time (`log_forward_pass`)
+```python
+log_forward_pass(
+    ...,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
+)
+```
+- `save_activations_to=path`: writes a full bundle as capture progresses; returns a lazy-enabled ModelLog.
+- `activation_sink`: low-level callable for custom destinations (e.g. S3, shared memory); mutually-exclusive with `save_activations_to`.
+- `keep_activations_in_memory=False`: post-pass eviction step replaces `.activation` with None and sets `.activation_ref`.
+
+### Re-saving a lazy-loaded bundle (addresses finding #23)
+```python
+# lazy-loaded bundle, user modified nothing:
+model_log = torchlens.load("a/", lazy=True)
+model_log.save("b/")           # copies blobs from a/ to b/ without materializing (fast path)
+
+# lazy-loaded bundle, user materialized some activations:
+t = model_log.layer_list[3].materialize_activation()
+# hypothetically: t = user modifies activation in place — we don't support that cleanly
+model_log.save("b/")           # re-writes only materialized layers; un-materialized ones are copied from source bundle
+
+# lazy-loaded bundle, source bundle deleted mid-session:
+# materialize anything not already in memory first, or save() will raise clearly
+```
+
+Implementation: `save()` iterates layers. For each that has `.activation` populated: normal write. For each that is lazy-only and `.activation_ref.source_bundle_path` exists and is intact: `shutil.copy` the sidecar file to the new bundle. For each that is lazy-only and source is gone/corrupt: raise with instruction to materialize first. Edge-case covered by integration test.
+
+---
+
+## 5. Spec Decomposition
+
+Quality gates mandatory for every spec: `ruff check . --fix && mypy torchlens/ && pytest tests/ -m smoke -x --tb=short`. LoC estimates revised upward per finding #20.
+
+### Group 1 — Foundations (parallel-safe on different files)
+
+**IO-S1. Pickle hardening: scrubbing + version tagging + accessor reconstruction**
+- Add `torchlens/_io/__init__.py` with `IO_FORMAT_VERSION = 1`, `TorchLensIOError`, `BlobRef` NamedTuple.
+- Add `torchlens/_io/scrub.py`: `scrub_for_save(model_log, include_captured_args=True) -> (scrubbed_dict, list[BlobSpec])`. Walks the ModelLog, produces scrubbed pickle state and a catalog of tensors needing blob persistence. This is the single source of truth for what-gets-scrubbed.
+- Expand ModelLog `__setstate__` to: read version, default-fill, rebuild `_module_logs` and `_buffer_accessor` (share helper extracted from `postprocess/finalization.py:671-681`), restore `BlobRef` → `LazyActivationRef`.
+- Add `__setstate__` default-fill to LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog, ModulePassLog.
+- Files: `torchlens/_io/__init__.py` (NEW), `torchlens/_io/scrub.py` (NEW), `torchlens/_io/accessor_rebuild.py` (NEW, shared by pickle + bundle), `torchlens/data_classes/{model_log,layer_pass_log,layer_log,param_log,buffer_log,module_log}.py`, `torchlens/postprocess/finalization.py` (extract helper only).
+- Tests: `tests/test_io_pickle.py` (NEW) — round-trip scrubbed ModelLog; accessors rebuilt correctly; default-fill from forged older pickle; version hard-fail on newer; plain-pickle unchanged.
+- Size: **~360 LoC** (up from 240).
+
+**IO-S2. ParamAccessor.to_pandas(), BufferAccessor.to_pandas(), ModulePassLog.to_pandas()**
+- Mirror `LayerAccessor.to_pandas` (`layer_log.py:665-687`).
+- FIELD_ORDER constants for param, buffer, module-pass.
+- Files: `torchlens/data_classes/{param_log,buffer_log,module_log}.py`, `torchlens/constants.py`.
+- Tests: `tests/test_io_pandas.py` (NEW) — schema shape; empty accessor; NaN; `forward_args` shape-stringification on module-pass rows.
+- Size: **~200 LoC** (up from 160, adds module-pass).
+
+### Group 2 — Tabular export + bundle (serial: S3 after S2, S4 after S1)
+
+**IO-S3. to_csv / to_parquet / to_json export wrappers**
+- Wrappers on every DataFrame producer: ModelLog, LayerAccessor, ModuleAccessor, ModuleLog, ModulePassLog, ParamAccessor, BufferAccessor.
+- `pyarrow` optional via `pip install torchlens[io]`; clear ImportError with install hint if `to_parquet` called without it.
+- Files: `torchlens/data_classes/{interface,layer_log,module_log,param_log,buffer_log}.py`, `pyproject.toml` (extras).
+- Tests: `tests/test_io_export.py` (NEW) — round-trip CSV / parquet / JSON; ImportError on parquet without pyarrow; schema stability.
+- Size: **~220 LoC**.
+
+**IO-S4. Bundle save (eager post-hoc), manifest v1, supported-tensor matrix, integrity checks on load**
+- `torchlens/_io/bundle.py`: `save(model_log, path, ...)` and `load(path, ...)`.
+- `torchlens/_io/manifest.py`: schema class, writer, reader, validator.
+- `torchlens/_io/tensor_policy.py`: implements the supported-tensor matrix, returns `(ok|skip_reason)` for each tensor.
+- Safetensors required. Missing → hard-fail with install hint.
+- Manifest `tensors` table populated; sha256 checksum per blob; shape/dtype/device_at_save recorded.
+- Load-time integrity: verify every manifest blob_id exists on disk; checksum on open (lazy — done at materialization for lazy loads, at load for eager); version policy table enforced.
+- Files: `torchlens/_io/{bundle,manifest,tensor_policy}.py` (NEW); `torchlens/data_classes/model_log.py` (sugar methods); `torchlens/__init__.py`; `torchlens/user_funcs.py`.
+- Tests: `tests/test_io_bundle.py` (NEW) — eager save/load round-trip; unsupported tensor lenient + strict; version mismatch table; corrupted manifest; missing blob file; checksum tampering; disk-full at various points (monkeypatched); overwrite semantics; re-save of lazy bundle (fast-copy path).
+- Size: **~420 LoC** (up from 320).
+
+### Group 3 — Streaming + lazy (serial: S5 after S4, S6 after S5)
+
+**IO-S5. Streaming-save during forward pass + eviction postprocess step + cleanup_tmp utility**
+- `torchlens/_io/streaming.py`: `BundleStreamWriter` opens `<path>.tmp.<uuid>/blobs/`, receives `(blob_id, tensor)` calls, finalizes manifest + metadata.pkl + rename at end.
+- Instrument `LayerPassLog.save_tensor_data()` (layer_pass_log.py:455-501) with writer callout; only activated by the **exhaustive-pass call site** (`output_tensors.py:866-900`). Fast-path overwrite sites remain untouched.
+- New postprocess step `_evict_streamed_activations` appended to the 18-step pipeline (gate: `keep_activations_in_memory=False`).
+- Non-tensor `activation_postfunc` check: on first tensor passed to sink, `assert isinstance(t, torch.Tensor)`; else abort with clear error and retain `.tmp.<uuid>`.
+- `torchlens.cleanup_tmp(path, force=False)` finds `<path>.tmp.*` siblings with `PARTIAL` sentinel, removes after confirmation.
+- Files: `torchlens/_io/streaming.py` (NEW), `torchlens/_io/bundle.py` (finalize handoff), `torchlens/data_classes/layer_pass_log.py`, `torchlens/data_classes/model_log.py` (holds `_activation_writer`, updated cleanup logic), `torchlens/user_funcs.py` (new kwargs), `torchlens/postprocess/finalization.py` (new eviction step), `torchlens/postprocess/__init__.py` (step registration).
+- Tests: `tests/test_io_streaming.py` (NEW) — sidecars written during pass (not after); mid-pass exception leaves `.tmp.<uuid>` with `PARTIAL`; `activation_sink` callable path; non-tensor postfunc rejected; `keep_activations_in_memory=False` evicts post-pass, not mid-pass (verify postprocess sees tensors); cleanup_tmp finds and removes partial dirs.
+- Size: **~380 LoC** (up from 270).
+
+**IO-S6. Lazy activation references + lazy-compatibility audit**
+- Flesh out `torchlens/_io/lazy.py`: `LazyActivationRef(blob_id, shape, dtype, device_at_save, source_bundle_path)` with `materialize(map_location="cpu")`.
+- `LayerPassLog.materialize_activation(*, map_location="cpu") -> torch.Tensor`: materializes, stores into `.activation`, keeps `.activation_ref`, returns.
+- Audit list: verify `validate_forward_pass`, `validate_saved_activations`, cleanup, string reprs, and `to_pandas()` against lazy logs. Update where needed with clear error messages (no silent auto-materialize).
+- Cleanup: closes any open safetensors mmap handles before nulling refs.
+- Re-save of lazy bundle: `save()` copies sidecars when source still intact; materializes-then-writes otherwise; raises clearly if source gone and not materialized.
+- Files: `torchlens/_io/lazy.py` (EXPAND from S5 stub), `torchlens/data_classes/layer_pass_log.py`, `torchlens/data_classes/cleanup.py`, `torchlens/validation/invariants.py`, `torchlens/_io/bundle.py` (lazy-resave path).
+- Tests: `tests/test_io_lazy.py` (NEW) — shape/dtype accessible without materialize; materialize correctness (bit-for-bit equality with eager); map_location works; open-handle cleanup; resave fast-copy; resave with source-bundle deleted raises clearly; validation APIs error clearly on lazy-only logs.
+- Size: **~340 LoC** (up from 240).
+
+### Group 4 — Integration tests + docs (parallel-safe)
+
+**IO-S7. Integration + corruption test suite**
+- End-to-end: capture → stream-save → lazy-load → to_parquet round-trip.
+- Corruption: truncated safetensors, missing blob, corrupt pickle, tampered manifest, stale blob counts.
+- Forged older-format pickle loads with warning.
+- DataParallel / DDP sanity (skipped if no CUDA): confirms capture path remains single-process (torchlens is not DP-safe; explicit warning recorded).
+- Files: `tests/test_io_integration.py` (NEW), minor updates to `test_save_new_activations.py`.
+- Size: **~360 LoC** (up from 280).
+
+**IO-S8. Docs + bundle utilities**
+- Docstrings on all new public APIs with copy-pasteable examples.
+- `torchlens/_io/pack.py`: `torchlens.pack_bundle(bundle_dir, out_tar)` and `unpack_bundle(out_tar, into_dir)` — **eager-only tar archival utility** for users who want a single file. Explicitly not random-access; documented.
+- README section (short) under "Save and Load".
+- `.project-context/knowledge/io_architecture.md`: bundle layout, manifest schema, tensor matrix, version policy.
+- Files: `torchlens/_io/__init__.py`, `torchlens/_io/pack.py` (NEW), `torchlens/__init__.py`, `torchlens/data_classes/model_log.py`, `README.md`, `.project-context/knowledge/io_architecture.md` (NEW).
+- Size: **~180 LoC** (up from 120, adds pack utility).
+
+---
+
+## 6. Spec Dependency Graph
+
+```
+S1 ─┬─> S4 ─┬─> S5 ──> S6 ──> S7
+    │       │                  ▲
+S2 ─┴─> S3 ─┘                  │
+                        S8 ────┘ (docs depend on all)
+```
+
+Total LoC: ~2460 (up from 1830 in v1).
+
+---
+
+## 7. Risk Register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Unsupported tensor layouts (sparse/meta/DTensor) | Skipped with warning by default; `strict=True` raises; manifest records all skipped. |
+| R2 | `func_applied`/`activation_postfunc` pickle fragility | Scrubbed at save time; null sentinels on load; recorded by name/repr string. |
+| R3 | Disk-full / crash mid-stream | `.tmp.<uuid>/` preserved with `PARTIAL` sentinel; `cleanup_tmp` utility provided. |
+| R4 | Lazy refs leak into DataFrames | Exporters only read metadata fields. Assertion in tests that no `LazyActivationRef` repr appears in DataFrame cells. |
+| R5 | Lazy cleanup vs live file handles | `cleanup()` closes safetensors handles before nulling. Tested. |
+| R6 | Pickle-format drift in N+1 | `io_format_version` policy table; migration helpers required before bumping version. |
+| R7 | CUDA bundle loaded on CPU host | `map_location="cpu"` default; safetensors loader accepts it. |
+| R8 | Streaming writer blocks event loop | Synchronous writes; documented. Async out of scope. |
+| R9 | pyarrow install weight | Optional via extras; clear error if used without. |
+| R10 | Large bundle on tiny model feels heavy | `pack_bundle` utility for single-file archival; docs explain directory-vs-tar. |
+| R11 | Thousands of tiny blobs on huge model | Documented; chunked-blob design deferred to a future sprint. |
+| R12 | NFS / Windows rename semantics | Docstring scopes atomicity claim to local same-fs. Non-local FS guidance in docs. |
+| R13 | User deletes source bundle after lazy load | `materialize_activation` raises clear error; `save()` raises clearly if asked to resave without materialization. |
+| R14 | DataParallel / DDP multiple capture paths | Torchlens is already single-process-only (existing `warn_parallel`). Documented; streaming inherits that constraint. |
+
+---
+
+## 8. Execution Plan
+
+| Round | Specs | Gate |
+|-------|-------|------|
+| 1 | S1 ‖ S2 | pickle round-trip green; param/buffer DataFrames green |
+| 2 | S3 (after S2) ‖ S4 (after S1) | bundle save/load round-trip green; all export formats green |
+| 3 | S5 (after S4) | streaming green; eviction doesn't break postprocess |
+| 4 | S6 (after S5) | lazy load + materialize green; validation APIs updated |
+| 5 | S7 ‖ S8 | integration regression + docs |
+| 6 | Phase 5 dual review (me + `/codex:review`) |
+
+---
+
+## 9. Stop-and-Ask Triggers
+
+- End of this plan revision — **NOW** (present to user for approval)
+- Any public API signature change beyond additions
+- Bundle format bump (io_format_version increase) in the future
+- End of Phase 5 (which review findings to fix)
+
+---
+
+## 10. Success Criteria (binary)
+
+- [ ] `torchlens.save(model_log, path)` + `torchlens.load(path)` round-trip including all supported tensor layouts
+- [ ] Six log-level DataFrames + `.to_csv/.to_parquet/.to_json` on every one
+- [ ] `log_forward_pass(..., save_activations_to=path)` streams during pass; bundle openable immediately after forward
+- [ ] `keep_activations_in_memory=False` path works end-to-end with postprocess intact
+- [ ] Lazy load preserves metadata access without disk read; `materialize_activation()` bit-exact
+- [ ] `pytest tests/ -m "not slow"` green; ruff + mypy + smoke green
+- [ ] Old pickles (v1.0.2 plain `pickle.dump(model_log)`) load with deprecation warning
+- [ ] Corruption tests green (truncated blob, missing blob, corrupted pickle, tampered manifest)
+- [ ] `cleanup_tmp` utility removes `.tmp.<uuid>` dirs safely
+
+---
+
+## 11. Change Log vs Round 1
+
+| Finding | Severity | Resolution |
+|---------|----------|-----------|
+| 1 | CRITICAL | Pickle scrubbing contract (Fork A + S1). |
+| 2 | CRITICAL | Eviction moves to postprocess step (Fork D); save_tensor_data no longer mutates `.activation`. |
+| 3 | CRITICAL | Gradient streaming cut; post-hoc gradient bundling only; manifest records `kind="gradient"`. |
+| 4 | CRITICAL | tar/tar.gz removed from core API; optional `pack_bundle` utility in S8 for archival only, eager-only. |
+| 5 | CRITICAL | Opaque zero-padded blob ids in paths; human labels live only in manifest. |
+| 6 | CRITICAL | Non-tensor `activation_postfunc` guard added to S5; aborts streaming with clear error. |
+| 7 | HIGH | `.activation` stays tensor-or-None; `.activation_ref` holds LazyActivationRef; explicit `materialize_activation()`. |
+| 8 | HIGH | No auto-materialize; validation APIs updated to raise clearly; eager opt-out with `lazy=False`. |
+| 9 | HIGH | Safetensors required; no fallback; `torch.save` removed from bundle path. |
+| 10 | HIGH | Manifest v1 schema with per-tensor table, checksums, backend, device_at_save, layout, bytes. |
+| 11 | HIGH | Unique-uuid temp dirs; atomicity scoped to local-fs best-effort; rename semantics documented. |
+| 12 | HIGH | Streaming hooks exhaustive-pass site only; fast-path sites untouched. |
+| 13 | HIGH | Explicit supported-tensor matrix; skipped tensors recorded in manifest; strict mode available. |
+| 14 | HIGH | Plain `pickle.dump(model_log)` stays supported with explicit contract and test. |
+| 15 | HIGH | Version policy table (Fork E). |
+| 16 | HIGH | Directory default kept; `pack_bundle` utility for single-file; thousands-of-blobs issue documented. |
+| 17 | HIGH | Corruption test battery (S7); exact exception types in specs. |
+| 18 | HIGH | `frames/` removed from bundle layout (not needed; source context handled by scrubbed FuncCallLocation). |
+| 19 | MEDIUM | ModulePassLog added to pandas scope. |
+| 20 | MEDIUM | LoC estimates revised up ~35% across the board; dependencies explicit in §6. |
+| 21 | MEDIUM | `compression="zstd"` removed. |
+| 22 | MEDIUM | `cleanup_tmp` utility owned by S5. |
+| 23 | MEDIUM | Re-save of lazy bundle: fast-copy sidecars when source intact, raise clearly otherwise. |

--- a/.project-context/plans/io-sprint/plan_v3.md
+++ b/.project-context/plans/io-sprint/plan_v3.md
@@ -1,0 +1,495 @@
+# TorchLens I/O Sprint Plan (Round 3)
+
+**Branch**: `codex/io-sprint`
+**Goal**: comprehensive, frictionless I/O for ModelLog and its children — pickle, pandas/CSV/Parquet/JSON, activation-to-disk (including streaming during forward pass), symmetric loading.
+**Out of scope**: visualization (graphviz, ELK, dagua), tar archival utilities, gradient streaming during backward.
+**Inputs**: `.project-context/research/io-audit-{claude,codex}.md`, `.project-context/plans/io-sprint/review_round_{1,2}.md`.
+**This revision addresses all 12 Round-2 findings. Change log at bottom.**
+
+---
+
+## 1. Design Forks — Resolved
+
+### Fork A. Archival format
+**Decision**: **directory bundle only**, containing a scrubbed pickle, safetensors-only tensor blobs, and a rich manifest. `safetensors` is a **hard dependency** of the bundle path. No tar this sprint. No `pack_bundle` utility — out of scope.
+
+Bundle layout:
+```
+<bundle_dir>/
+  manifest.json               # authoritative index; see §2
+  metadata.pkl                # scrubbed ModelLog state
+  blobs/
+    0000000001.safetensors
+    0000000002.safetensors
+    ...                       # one file per persisted tensor; filename = zero-padded opaque blob id
+```
+
+Filenames are zero-padded monotonically-assigned blob ids. Human-readable layer labels live only in `manifest.json`.
+
+**Pickle-scrub contract (complete field policy)** — addresses Round-2 finding #1, #2.
+
+Before `metadata.pkl` is written, the scrubber walks the ModelLog state and applies this policy exhaustively (deny-list first, then allow-list for each class):
+
+| Field | Class | Policy |
+|-------|-------|--------|
+| `activation` | LayerPassLog | Replace tensor with `BlobRef(blob_id, kind="activation")`. Scalars (0-d) recorded inline in manifest. |
+| `gradient` | LayerPassLog | Replace tensor with `BlobRef(blob_id, kind="gradient")`. |
+| `captured_args`, `captured_kwargs` | LayerPassLog | If `include_captured_args=True` (default): walk recursively, each tensor → `BlobRef(kind="captured_arg")`. Non-tensor leaves preserved. If `include_captured_args=False`: set to `None`. |
+| `children_tensor_versions` | LayerPassLog | If `include_captured_args=True`: each tensor → `BlobRef(kind="child_version")`. Else `None`. |
+| `func_rng_states` | LayerPassLog | If `include_rng_states=True` (default): each tensor → `BlobRef(kind="rng_state")`. Else `None`. |
+| `forward_args`, `forward_kwargs` | ModulePassLog | If `include_captured_args=True`: walk, tensors → `BlobRef(kind="module_arg")`. Else `None`. |
+| `func_applied` | LayerPassLog | Drop unconditionally (recorded by `func_name` string). |
+| `activation_postfunc` | ModelLog | Drop unconditionally; record `activation_postfunc_repr: str` if present. |
+| `_param_ref` | ParamLog | Drop unconditionally (pins `nn.Parameter`, not portable). |
+| `_frame_func_obj` | FuncCallLocation | Clear unconditionally (already done by disabled-source path). |
+| `func_config` | LayerPassLog | Recursively walk: primitives (bool/int/float/str/None) kept; tensors → `BlobRef(kind="func_config")`; anything else (user subclasses, unknown objects) → replaced with `"<scrubbed:TypeName>"` string placeholder. |
+| `extra_attributes` | ModuleLog, ModelLog, any data class exposing one | Same policy as `func_config`: primitives + containers of primitives pass; tensors blobified; other objects stringified. |
+| Any attribute not enumerated above | Any | Default: attempt pickle. On `PicklingError` during scrub, replace with `"<scrubbed:TypeName>"` and log at `WARNING`. |
+
+The scrub policy is implemented once in `torchlens/_io/scrub.py` with unit tests that enumerate every known `FIELD_ORDER` column. Adding a new field requires updating the policy (guarded by a lint check in S7 tests).
+
+**Rehydration contract on load** — addresses Round-2 finding #1 fully.
+
+On `torchlens.load(path, lazy=False)` (default):
+- `.activation` / `.gradient`: fully materialized to `torch.Tensor`; `.activation_ref` / `.gradient_ref` also populated for idempotency.
+- All other `BlobRef`s in nested containers (`captured_args`, `captured_kwargs`, `children_tensor_versions`, `func_rng_states`, `forward_args`, `forward_kwargs`, `func_config`): **eagerly materialized** during `__setstate__` — replaced in place with the real tensor. Validation and replay code sees real tensors everywhere.
+
+On `torchlens.load(path, lazy=True)` (opt-in):
+- `.activation` / `.gradient`: **NOT** materialized. `.activation_ref` / `.gradient_ref` populated; `.activation` / `.gradient` are `None`.
+- Nested container tensors: **still eagerly materialized** (lazy never applies to nested fields). Keeps lazy simple and keeps validation paths intact.
+
+This means lazy mode only defers the two fields that dominate memory cost (activations + gradients). Everything else loads eagerly.
+
+**Plain-pickle backward compat**:
+`pickle.dump(model_log, f)` / `pickle.load(f)` continue to work via the existing `__getstate__` hooks (weakref strip only — no scrub). Limitations of current plain pickle (callables fragility, `_param_ref` pinning) are unchanged. Portable representation is `torchlens.save()`.
+
+**Compat contract resolution** — addresses Round-2 finding #14:
+Plain `pickle.dump/load` is supported for this release; a `DeprecationWarning` fires on `pickle.load` of any ModelLog with `io_format_version` field missing (old pickles from before this sprint). No deprecation warning on `pickle.dump` of a fresh ModelLog (users still allowed to produce plain pickles; they just aren't the portable format). Tested in `tests/test_io_plain_pickle.py`.
+
+### Fork B. Load granularity
+**Decision**: `lazy=False` is **the default**. Lazy is opt-in via `torchlens.load(path, lazy=True)`.
+
+Rationale (addresses Round-2 finding #5):
+- Existing TorchLens internal methods assume `.activation` is a tensor when present.
+- A full audit of every public and semi-public method is out of scope for this sprint.
+- Making lazy opt-in means users who want it accept the "call `materialize_activation()` before doing tensor ops" contract explicitly.
+- A future sprint can flip the default after a full compat audit.
+
+`.activation` stays `tensor | None` throughout. `.activation_ref` is populated whenever a blob exists on disk (lazy or eager load). After `lazy=True` load, `.activation` is `None` and user must call `materialize_activation()` to get a tensor. After `lazy=False` load, both `.activation` and `.activation_ref` are populated.
+
+### Fork C. Pandas-export scope
+**Decision**: DataFrames at six log levels: layer-pass, aggregate layer, module-pass, module, param, buffer.
+
+`ModulePassLog.forward_args_summary` new field — addresses Round-2 finding #9.
+- During postprocess step `_build_module_logs`, **before** the existing GC step that clears `forward_args`/`forward_kwargs`, a short summary string is computed: `[shape=(1,3,224,224) dtype=float32]` per tensor arg, primitives rendered directly. Stored as `forward_args_summary: str` on ModulePassLog.
+- `ModulePassLog.to_pandas()` reads from the summary field, not from live `forward_args`.
+- Existing GC behavior unchanged.
+
+### Fork D. Streaming-save architecture
+**Decision**: during forward pass, write the sidecar at `save_tensor_data()` completion; activation remains in memory until a new postprocess step `_evict_streamed_activations` runs. Selective streaming hooks the exhaustive pass only.
+
+Concrete pipeline position — addresses Round-2 finding #3.
+
+Current 18-step postprocess pipeline (from `postprocess/__init__.py`): numbered steps running in order. This sprint adds step 19 at the end:
+```
+Step 19: _evict_streamed_activations   (NEW)
+```
+Gate: runs only if `ModelLog._activation_writer is not None` AND `model_log._keep_activations_in_memory is False`.
+
+Sequence for `log_forward_pass(..., save_activations_to=path, keep_activations_in_memory=False)`:
+1. Writer opens `<path>.tmp.<uuid4>/blobs/`.
+2. During forward: each `save_tensor_data()` call writes `NNNNNNNNNN.safetensors` and records `blob_id` on the LayerPassLog (new private field `_pending_blob_id`). `.activation` unchanged.
+3. Postprocess steps 1-18 run normally with tensors in memory.
+4. Step 19 runs: writer finalizes `manifest.json` with full blob table + checksums, writes `metadata.pkl` (scrubbed), renames `<path>.tmp.<uuid>/` → `<path>/`. On successful rename, iterates all `_pending_blob_id` entries and replaces `LayerPassLog.activation` with `None`, sets `.activation_ref = LazyActivationRef(blob_id=..., source_bundle_path=<final_path>)`. Ref holds the FINAL path, never the temp path.
+5. ModelLog is returned with lazy refs pointing at the stable `<path>`.
+
+If `keep_activations_in_memory=True` (default), Step 19 still runs manifest + metadata.pkl + rename, but **does not** null out `.activation`. The returned ModelLog has activations in memory AND disk-backed.
+
+**Non-tensor `activation_postfunc` guard** — addresses Round-2 finding #4.
+Single rule applied to both streaming and post-hoc save: if `activation_postfunc is not None` AND `save_activations_to is not None` (streaming) OR `torchlens.save()` is called with `include_activations=True` (post-hoc), validate that `activation_postfunc` output type is `torch.Tensor`. Check is performed:
+- **Streaming**: at the first `save_tensor_data()` call where the writer would be invoked. If the post-postfunc value is not a `torch.Tensor`, the writer is aborted immediately, `.tmp.<uuid>/` dir gets a `PARTIAL` sentinel + `REASON` file describing the issue, `TorchLensIOError` is raised, forward pass terminates. No partially-written bundle masquerades as valid.
+- **Post-hoc save**: `torchlens.save()` inspects the first LayerPassLog with a saved activation; if the activation's type differs from `torch.Tensor` (the postfunc output was retained), raise `TorchLensIOError` before any blob is written.
+
+**Atomicity scope** (unchanged from v2): random uuid temp dir; local-same-fs best-effort; non-local FS documented as unsupported.
+
+**Temp-dir cleanup**: `torchlens.cleanup_tmp(path, force=False)` finds sibling `<path>.tmp.*` directories with a `PARTIAL` sentinel and removes them. Without `PARTIAL`, only removes after user confirmation.
+
+**Gradient streaming**: out of scope. Post-hoc `torchlens.save(model_log, path, include_gradients=True)` bundles any populated `.gradient` fields.
+
+### Fork E. Unsupported-tensor policy
+**Decision**: **`strict=True` is the default for `torchlens.save()`**. Lenient skip is opt-in.
+
+Rationale — addresses Round-2 finding #6:
+- Silent partial bundles are an unsafe default for research/CI artifacts.
+- Users hitting a sparse/meta/quantized tensor deserve a loud error that tells them to deal with it.
+- `strict=False` remains available for users who knowingly want best-effort archival.
+
+Supported tensor matrix (unchanged from v2 in scope):
+
+| Tensor kind | strict=True | strict=False |
+|-------------|-------------|--------------|
+| Dense CPU/CUDA standard dtypes | Save | Save |
+| Non-contiguous | `.contiguous()` then save | Same |
+| Sparse COO/CSR, quantized, nested, tensor subclass, DTensor/FSDP shard, complex32 | `TorchLensIOError` with field name + reason | Skip, record in `manifest.unsupported_tensors`, warn once |
+| Meta tensors | `TorchLensIOError` (no data) | Skip, record |
+
+### Fork F. Version & integrity policy
+**Decision**: PEP 440 parsing where applicable; sha256 over safetensors file bytes on disk.
+
+Addresses Round-2 finding #7.
+
+Version parsing:
+- `torchlens_version`, `torch_version`, `python_version` parsed with `packaging.version.Version`. Nightly/pre-release identifiers compared per PEP 440 semantics.
+- On parse failure (non-conforming string): fall back to string equality; emit `UserWarning` naming the unparseable version.
+- Version policy table (Fork E in v2 plan, unchanged structure but explicit parse rules):
+
+| Scenario | Load behavior |
+|----------|---------------|
+| `io_format_version > current` | Raise `TorchLensIOError` before opening `metadata.pkl` |
+| `io_format_version < current` | Load with `DeprecationWarning` listing missing fields |
+| `io_format_version == current` | Load normally |
+| `torch_version` major mismatch | Raise `TorchLensIOError` (pre-open) |
+| `torch_version` minor mismatch | Load with `UserWarning` |
+| `torchlens_version` newer | Load with `UserWarning` |
+| `torchlens_version` older | Load with info log only |
+| `python_version` major mismatch | Attempt load; wrap any pickle error in `TorchLensIOError` with version hint |
+| Safetensors backend missing | Raise `TorchLensIOError` with install hint |
+| Manifest unparseable | Raise `TorchLensIOError` |
+| Manifest blob_id without file | Raise `TorchLensIOError` (lists missing blobs) |
+| Blob checksum mismatch | Raise `TorchLensIOError` (names blob_id) |
+| Unknown extra files in `blobs/` | `UserWarning`, continue |
+
+Checksum semantics:
+- `sha256` field = hex of `hashlib.sha256(open(blob_path, "rb").read()).hexdigest()` — literal file bytes on disk after safetensors write.
+- Checksum verified lazily on `materialize()` for `lazy=True` loads, eagerly on load for `lazy=False`.
+
+### Fork G. Exception contract
+**Decision**: all bundle-layer errors wrap in `TorchLensIOError`. Addresses Round-2 finding #12.
+
+- `torchlens._io.TorchLensIOError` is the single exception type for bundle failures.
+- Implementation: bundle save/load code catches `OSError`, `pickle.UnpicklingError`, `safetensors`-raised errors, JSON parse errors, key errors on manifest structure, and re-raises as `TorchLensIOError` with `__cause__` chained.
+- Plain `pickle.load()` of a ModelLog via user-written code does not go through the wrap — callers of plain pickle accept Python's native pickle errors.
+- Tested in `tests/test_io_bundle.py`.
+
+### Fork H. Lazy-resave drift
+**Decision**: record source-bundle manifest sha256 at load time; verify at resave. Addresses Round-2 finding #8.
+
+- `LazyActivationRef.source_bundle_path` records bundle dir.
+- Loader captures `source_manifest_sha256 = sha256(manifest.json)` at load time into ModelLog private `_source_bundle_manifest_sha256`.
+- On `model_log.save(new_path)` fast-copy path: re-hash source manifest; if it doesn't match recorded digest, raise `TorchLensIOError` telling user to materialize all refs and retry.
+- Prevents silent corruption from concurrent source-bundle mutation.
+
+### Fork I. Operational shape
+**Decision**: directory-of-one-blob-per-tensor is the intentional format for this sprint. Finding #11 is **deferred**, not resolved.
+
+Documentation note (`.project-context/knowledge/io_architecture.md` and README):
+> "For models with >10,000 saved layers or deployment on network filesystems, bundle save creates many small files. A future release may add chunked blob formats. This sprint prioritizes random-access lazy loads over file-count optimization."
+
+Not claiming resolution we haven't earned.
+
+---
+
+## 2. Manifest Schema v1 (unchanged from v2)
+
+```json
+{
+  "io_format_version": 1,
+  "torchlens_version": "1.2.0",
+  "torch_version": "2.5.0",
+  "python_version": "3.11.5",
+  "platform": "linux-x86_64",
+  "created_at": "2026-04-23T13:05:00Z",
+  "bundle_format": "directory",
+  "n_layers": 152,
+  "n_activation_blobs": 152,
+  "n_gradient_blobs": 0,
+  "n_auxiliary_blobs": 304,
+  "tensors": [
+    {
+      "blob_id": "0000000001",
+      "kind": "activation",
+      "label": "conv2d_1_1:2",
+      "relative_path": "blobs/0000000001.safetensors",
+      "backend": "safetensors",
+      "shape": [1, 64, 112, 112],
+      "dtype": "float32",
+      "device_at_save": "cuda:0",
+      "layout": "strided",
+      "bytes": 3211264,
+      "sha256": "3f5c..."
+    }
+  ],
+  "unsupported_tensors": [
+    {"label": "sparse_layer:1", "kind": "activation", "reason": "sparse_coo layout not supported this release"}
+  ]
+}
+```
+
+`kind` values: `activation`, `gradient`, `captured_arg`, `child_version`, `rng_state`, `module_arg`, `func_config`.
+
+---
+
+## 3. Public API Surface
+
+### Top-level `torchlens`
+```python
+torchlens.save(
+    model_log: ModelLog,
+    path: str | Path,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,
+    include_captured_args: bool = True,
+    include_rng_states: bool = True,
+    strict: bool = True,              # CHANGED from v2: strict is now default
+    overwrite: bool = False,
+) -> None
+
+torchlens.load(
+    path: str | Path,
+    *,
+    lazy: bool = False,               # CHANGED from v2: lazy is now opt-in
+    map_location: str | torch.device = "cpu",
+) -> ModelLog
+
+torchlens.cleanup_tmp(
+    path: str | Path,
+    *,
+    force: bool = False,
+) -> list[Path]
+```
+
+### On `ModelLog`
+```python
+model_log.save(path, **kwargs)
+ModelLog.load(path, **kwargs)             # classmethod
+
+model_log.to_pandas() -> pd.DataFrame
+model_log.to_csv(path, **kwargs)
+model_log.to_parquet(path, **kwargs)
+model_log.to_json(path, *, orient="records")
+```
+
+### Accessors
+```python
+# existing:
+model_log.layers.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.modules.to_pandas() / ...
+
+# NEW:
+model_log.params.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.buffers.to_pandas() / ...
+
+# Per-log:
+module_log.to_pandas() / ...
+module_pass_log.to_pandas() / ...         # NEW, reads forward_args_summary
+```
+
+### Streaming at capture time
+```python
+log_forward_pass(
+    ...,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
+)
+```
+
+### LazyActivationRef
+```python
+class LazyActivationRef:
+    blob_id: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device_at_save: str
+    source_bundle_path: Path
+    kind: Literal["activation", "gradient"]
+
+    def materialize(self, *, map_location="cpu") -> torch.Tensor: ...
+```
+
+### Resave-lazy semantics
+```python
+model_log = torchlens.load("a/", lazy=True)
+model_log.save("b/")
+# If source manifest sha256 matches the one captured at load: shutil.copy blobs from a/ to b/.
+# If source manifest differs from recorded digest OR source deleted: raise TorchLensIOError
+#   "source bundle at a/ has changed or is gone; call .materialize_activation() on all layers and retry."
+# No silent drift.
+```
+
+---
+
+## 4. Spec Decomposition
+
+All specs must pass: `ruff check . --fix && mypy torchlens/ && pytest tests/ -m smoke -x --tb=short`.
+
+### Group 1 — Foundations (parallel-safe)
+
+**IO-S1. Pickle hardening: complete scrub policy + version tagging + accessor reconstruction**
+- `torchlens/_io/__init__.py`: `IO_FORMAT_VERSION=1`, `TorchLensIOError`, `BlobRef` NamedTuple.
+- `torchlens/_io/scrub.py`: full policy table from Fork A. One public entry `scrub_for_save(model_log, **include_flags) -> (scrubbed_state, list[BlobSpec])`. Walks every class field; tested by enumerating every FIELD_ORDER column and asserting the policy is applied correctly.
+- `torchlens/_io/rehydrate.py`: inverse — reads scrubbed state + loads tensors from disk, reassembles nested structures, returns live ModelLog.
+- Expand `__setstate__` on ModelLog, LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog, ModulePassLog with version-aware default-fill.
+- Accessor reconstruction helper extracted from `postprocess/finalization.py:671-681`.
+- Files: `torchlens/_io/__init__.py`, `scrub.py`, `rehydrate.py`, `accessor_rebuild.py` (all NEW); `torchlens/data_classes/{model_log,layer_pass_log,layer_log,param_log,buffer_log,module_log}.py`; `torchlens/postprocess/finalization.py`.
+- Tests: `tests/test_io_pickle.py` (NEW) — scrub policy coverage lint, round-trip scrubbed state, accessor rebuild, default-fill from forged older pickle, version hard-fail on newer, plain-pickle compat unchanged.
+- Size: **~400 LoC**.
+
+**IO-S2. ParamAccessor / BufferAccessor / ModulePassLog.to_pandas() + forward_args_summary field**
+- New FIELD_ORDER tuples in `constants.py`.
+- `ModulePassLog.forward_args_summary` field populated in `_build_module_logs` before existing GC. Short format: `"(shape=(1,3,224,224) dtype=float32, shape=(), dtype=int64)"`.
+- New `to_pandas()` methods on ParamAccessor, BufferAccessor, ModulePassLog.
+- Files: `torchlens/data_classes/{param_log,buffer_log,module_log}.py`, `torchlens/constants.py`, `torchlens/postprocess/finalization.py` (add summary capture).
+- Tests: `tests/test_io_pandas.py` (NEW) — schema shape, empty accessor, summary correctness with mixed tensor/primitive args, summary survives GC.
+- Size: **~240 LoC**.
+
+### Group 2 — Exports + bundle (serial: S3 after S2; S4 after S1)
+
+**IO-S3. Export wrappers: to_csv / to_parquet / to_json on all seven DataFrame producers**
+- Wrappers on ModelLog, LayerAccessor, ModuleAccessor, ModuleLog, ModulePassLog, ParamAccessor, BufferAccessor.
+- `pyarrow` optional via `pip install torchlens[io]`; clear `ImportError` if missing.
+- Files: `torchlens/data_classes/{interface,layer_log,module_log,param_log,buffer_log}.py`, `pyproject.toml`.
+- Tests: `tests/test_io_export.py` — round-trip + schema stability + ImportError on parquet.
+- Size: **~220 LoC**.
+
+**IO-S4. Bundle save/load (eager post-hoc) + manifest v1 + integrity + exception contract**
+- `torchlens/_io/bundle.py`: `save` (post-hoc) and `load`. Integrates scrub (S1), tensor_policy (below), and manifest.
+- `torchlens/_io/manifest.py`: schema class, sha256 hashing, PEP 440 version parsing, policy enforcement.
+- `torchlens/_io/tensor_policy.py`: implements supported-tensor matrix; returns `(Ok | SkipReason | Error)` per tensor; respects `strict` flag.
+- All bundle errors wrap in `TorchLensIOError` (Fork G).
+- ModelLog gets `.save()` / `.load()` sugar; `torchlens` exports `save`, `load`, `cleanup_tmp`.
+- Files: `torchlens/_io/{bundle,manifest,tensor_policy}.py` (NEW); `torchlens/data_classes/model_log.py`; `torchlens/__init__.py`; `torchlens/user_funcs.py`.
+- Tests: `tests/test_io_bundle.py` (NEW) — eager round-trip; strict default raises on sparse; `strict=False` skips + records; all 12 version-policy rows; corrupt manifest / missing blob / truncated safetensors / checksum tamper all raise `TorchLensIOError`; overwrite semantics; non-tensor postfunc rejected at save; include flags combos.
+- Size: **~480 LoC**.
+
+### Group 3 — Streaming + lazy (serial)
+
+**IO-S5. Streaming-save during forward pass + postprocess step 19 + cleanup_tmp**
+- `torchlens/_io/streaming.py`: `BundleStreamWriter`. Open `<path>.tmp.<uuid>/blobs/`, receive `(blob_id, tensor)` synchronously, write safetensors. On `finalize()`: write manifest, write scrubbed `metadata.pkl`, rename to `<path>`, return set of blob ids for ref-patching.
+- Instrument `LayerPassLog.save_tensor_data()` with writer callout; gated to exhaustive-pass call site only (`capture/output_tensors.py:866-900`).
+- New postprocess step `_evict_streamed_activations` registered as step 19 in `postprocess/__init__.py`. Runs only when writer active AND `keep_activations_in_memory=False`. Patches LazyActivationRef with final (post-rename) path.
+- Non-tensor postfunc guard: writer verifies first received tensor is `torch.Tensor`; if not, abort, mark `.tmp.<uuid>/PARTIAL`, raise `TorchLensIOError` (Fork D rule).
+- `torchlens.cleanup_tmp(path, force=False)` utility.
+- Files: `torchlens/_io/streaming.py` (NEW), `torchlens/_io/bundle.py`, `torchlens/data_classes/{layer_pass_log,model_log}.py`, `torchlens/user_funcs.py`, `torchlens/postprocess/{__init__,finalization}.py`.
+- Tests: `tests/test_io_streaming.py` (NEW) — blobs written during pass (verify timestamps); mid-pass exception leaves PARTIAL; non-tensor postfunc aborts before writing blob; `keep_activations_in_memory=False` evicts after postprocess (step 19 ordering); lazy refs point to final path not temp; cleanup_tmp finds PARTIAL dirs; `activation_sink` callable path.
+- Size: **~400 LoC**.
+
+**IO-S6. Lazy activation references + source-drift guard + lazy-resave fast-copy**
+- Flesh out `torchlens/_io/lazy.py`: `LazyActivationRef(blob_id, shape, dtype, device_at_save, source_bundle_path, kind)`; `materialize(map_location="cpu")` reads safetensors, verifies sha256 against manifest at first read, caches result.
+- `LayerPassLog.materialize_activation(map_location="cpu") -> Tensor` (and `.materialize_gradient()`).
+- ModelLog records `_source_bundle_manifest_sha256` at load time for drift detection.
+- Lazy-resave fast-copy path in `torchlens/_io/bundle.py::save`: for each lazy-only layer, if source manifest digest matches recorded value, `shutil.copy` blob file from source bundle to new bundle; otherwise raise `TorchLensIOError` with remediation hint (Fork H).
+- Cleanup: `ModelLog.cleanup()` closes any open safetensors handles before nulling refs.
+- Files: `torchlens/_io/lazy.py` (EXPAND), `torchlens/data_classes/{layer_pass_log,cleanup}.py`, `torchlens/_io/bundle.py`, `torchlens/validation/invariants.py` (clear-error path for lazy-only logs).
+- Tests: `tests/test_io_lazy.py` (NEW) — shape/dtype accessible without disk read; materialize bit-exact vs eager; map_location; source-drift detection (mutate source manifest between load and resave → raises); fast-copy on clean source; validation API raises clearly on lazy-only.
+- Size: **~360 LoC**.
+
+### Group 4 — Integration tests + docs (parallel)
+
+**IO-S7. Integration + corruption regression suite**
+- End-to-end: capture → stream-save → lazy-load → materialize → to_parquet → re-load.
+- Corruption battery: truncated safetensors, missing blob, corrupt pickle, tampered manifest, stale counts, unknown extra files, checksum mismatch. Each must raise `TorchLensIOError` with specific message.
+- Forged older-format pickle loads with `DeprecationWarning`.
+- DataParallel/DDP sanity skip (torchlens already `warn_parallel`; streaming inherits).
+- Scrub-policy lint test: iterate all `FIELD_ORDER` columns, assert each has explicit policy entry.
+- Files: `tests/test_io_integration.py` (NEW), `tests/test_io_plain_pickle.py` (NEW), minor updates to `test_save_new_activations.py`.
+- Size: **~380 LoC**.
+
+**IO-S8. Docs**
+- Docstrings on every new public API with copy-pasteable examples.
+- README "Save and Load" section.
+- `.project-context/knowledge/io_architecture.md` (NEW): bundle layout, manifest schema, tensor matrix, version policy, operational-shape note (Fork I).
+- Files: `torchlens/_io/__init__.py`, `torchlens/__init__.py`, `torchlens/data_classes/model_log.py`, `README.md`, `.project-context/knowledge/io_architecture.md` (NEW).
+- Size: **~160 LoC**.
+
+Total: ~2640 LoC (up from 2460 in v2).
+
+---
+
+## 5. Spec Dependency Graph
+
+```
+S1 ─┬─> S4 ─┬─> S5 ──> S6 ──> S7
+    │       │
+S2 ─┴─> S3 ─┘                S8 (docs, parallel with S7)
+```
+
+---
+
+## 6. Risk Register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Unsupported tensor layouts | strict=True default raises; strict=False opt-in records in manifest. |
+| R2 | Scrub misses a new field added in a future release | S7 lint test enumerates FIELD_ORDER; CI fails if new field lacks policy entry. |
+| R3 | Disk-full / crash mid-stream | `.tmp.<uuid>/PARTIAL` sentinel; `cleanup_tmp` utility. |
+| R4 | Lazy refs inside nested containers confuse validation | Nested containers always eager-materialized; lazy only `.activation`/`.gradient`. |
+| R5 | Lazy cleanup vs live safetensors handles | `cleanup()` closes handles before nulling. Tested. |
+| R6 | Format drift in N+1 | `io_format_version` + migration helpers (S1). |
+| R7 | CUDA bundle on CPU host | `map_location="cpu"` default; safetensors handles it. |
+| R8 | Streaming writer blocks | Synchronous by design; documented. |
+| R9 | pyarrow install weight | Optional via extras. |
+| R10 | Many small files (directory format) | Documented tradeoff (Fork I); deferred to future sprint. |
+| R11 | NFS/Windows rename edge cases | Documented: local-same-fs best-effort. |
+| R12 | Source bundle mutated between lazy load and resave | Manifest sha256 check on resave; raise clearly. |
+| R13 | DataParallel/DDP multiple capture | Torchlens is single-process; inherit existing warning. |
+| R14 | Exception handling ambiguity | All bundle errors wrap `TorchLensIOError` (Fork G). |
+
+---
+
+## 7. Execution Plan
+
+| Round | Specs | Gate |
+|-------|-------|------|
+| 1 | S1 ‖ S2 | Pickle scrub round-trip green; new pandas schemas green. |
+| 2 | S3 (after S2) ‖ S4 (after S1) | All export formats green; bundle round-trip green; version policy table tested. |
+| 3 | S5 (after S4) | Streaming + step 19 green; postprocess sees tensors; lazy refs point at final path. |
+| 4 | S6 (after S5) | Lazy load + materialize bit-exact; source drift detected; resave fast-copy. |
+| 5 | S7 ‖ S8 | Integration corruption battery green; docs complete. |
+| 6 | Phase 5 dual review (me + `/codex:review`). |
+
+---
+
+## 8. Stop-and-Ask Triggers
+
+- End of this plan revision — **NOW**
+- Any public API signature change beyond additions
+- Any bump of `io_format_version` in the future
+- End of Phase 5 (which review findings to fix)
+
+---
+
+## 9. Success Criteria (binary)
+
+- [ ] `torchlens.save(model_log, path)` + `torchlens.load(path)` round-trip everything on the supported-tensor matrix
+- [ ] Six log-level DataFrames + `.to_csv/.to_parquet/.to_json` on all seven producers
+- [ ] `log_forward_pass(..., save_activations_to=path)` streams during pass; postprocess unaffected
+- [ ] `keep_activations_in_memory=False` evicts post-pass; lazy refs point to final (post-rename) path
+- [ ] Lazy load preserves metadata access without disk read; `materialize_activation()` bit-exact
+- [ ] Source-drift detection works
+- [ ] All 14 version-policy rows tested
+- [ ] All bundle errors raise `TorchLensIOError`
+- [ ] Scrub-policy lint passes
+- [ ] Plain pickle still works with deprecation warning on pre-sprint pickles only
+- [ ] `pytest tests/ -m "not slow"` green
+- [ ] `ruff check . && mypy torchlens/` green
+
+---
+
+## 10. Change Log vs Round 2 (addresses all 12 findings)
+
+| Finding | Resolution |
+|---------|-----------|
+| R2-1 Nested tensor rehydration | Nested tensor fields always eagerly materialized on load (Fork A rehydration contract). Lazy applies only to `.activation`/`.gradient`. |
+| R2-2 Scrub allow-list holes | Fork A policy table covers `func_config`, `extra_attributes`, and default fallback for unknown fields. S7 has a scrub-policy lint test. |
+| R2-3 Eviction pipeline position | Explicit: step 19 in `postprocess/__init__.py`; refs store post-rename final path (Fork D). |
+| R2-4 Non-tensor postfunc inconsistency | Single rule in Fork D applied to both streaming and post-hoc save. |
+| R2-5 Lazy default too aggressive | Flipped: `lazy=False` is default; lazy is opt-in (Fork B). |
+| R2-6 Silent partial bundles | Flipped: `strict=True` is default for save (Fork E). |
+| R2-7 Version parsing + checksum scope | PEP 440 parsing; sha256 over safetensors file bytes on disk (Fork F). |
+| R2-8 Lazy-resave drift | Manifest sha256 captured at load, verified before fast-copy; raise on drift (Fork H). |
+| R2-9 ModulePassLog summary capture | `forward_args_summary` field populated in `_build_module_logs` before existing GC (Fork C + S2). |
+| R2-10 pack_bundle semantics | Cut from sprint. Deferred explicitly. |
+| R2-11 Operational shape | Acknowledged as deferred, not claimed resolved (Fork I). |
+| R2-12 Exception contract | All bundle-layer errors wrap in `TorchLensIOError` (Fork G). |

--- a/.project-context/plans/io-sprint/plan_v4.md
+++ b/.project-context/plans/io-sprint/plan_v4.md
@@ -1,0 +1,583 @@
+# TorchLens I/O Sprint Plan (Round 4)
+
+**Branch**: `codex/io-sprint`
+**Goal**: comprehensive, frictionless I/O for ModelLog and its children — pickle, pandas/CSV/Parquet/JSON, activation-to-disk (including streaming during forward pass), symmetric loading.
+**Out of scope**: visualization (graphviz, ELK, dagua), tar archival utilities, gradient streaming during backward.
+**Inputs**: `.project-context/research/io-audit-{claude,codex}.md`, `.project-context/plans/io-sprint/review_round_{1,2,3}.md`.
+**This revision addresses all 9 Round-3 findings. Change log at bottom.**
+
+---
+
+## 1. Design Forks — Resolved
+
+### Fork A. Archival format
+**Decision**: **directory bundle only**, containing a scrubbed pickle, safetensors-only tensor blobs, and a rich manifest. `safetensors` is a **hard dependency** of the bundle path. No tar this sprint. No `pack_bundle` utility — out of scope.
+
+Bundle layout:
+```
+<bundle_dir>/
+  manifest.json               # authoritative index; see §2
+  metadata.pkl                # scrubbed ModelLog state
+  blobs/
+    0000000001.safetensors
+    0000000002.safetensors
+    ...                       # one file per persisted tensor; filename = zero-padded opaque blob id
+```
+
+Filenames are zero-padded monotonically-assigned blob ids. Human-readable layer labels live only in `manifest.json`.
+
+**Pickle-scrub contract** — addresses Round-2 findings #1/#2 + Round-3 finding #2.
+
+**Authoritative source of truth**: each class in torchlens gains a `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attribute that explicitly lists every attribute present on instances of that class (not just fields in FIELD_ORDER) and the policy for each. The scrubber consumes this spec. A completeness lint (in S1 tests) walks every live instance attribute on a canonical ModelLog and asserts each name appears in its class's spec.
+
+Classes requiring a `PORTABLE_STATE_SPEC`:
+- `ModelLog`
+- `LayerPassLog`
+- `LayerLog`
+- `ModuleLog`, `ModulePassLog`
+- `ParamLog`
+- `BufferLog`
+- `FuncCallLocation`
+- Any accessor class that ends up in the object graph
+
+Policy vocabulary:
+- `keep`: pickle as-is (primitives, containers of primitives, stable torch objects like `torch.dtype`).
+- `blob(kind)`: tensor-valued; replace with `BlobRef(blob_id, kind=...)` and record in manifest.
+- `blob_recursive(kind)`: walk container recursively; tensors blobified; non-tensor leaves passed through.
+- `drop`: set to `None` (live callables, `_param_ref`, transient build state).
+- `stringify`: replace with `"<scrubbed:TypeName>"` (fall-through for user-supplied non-portable objects).
+- `weakref_strip`: existing `__getstate__` weakref-nulling behavior, applied automatically.
+
+Policy by class (abbreviated — full matrix in `torchlens/_io/scrub.py`):
+
+| Class | Field | Policy |
+|-------|-------|--------|
+| LayerPassLog | `activation` | `blob("activation")` (scalar 0-d recorded inline in manifest) |
+| LayerPassLog | `gradient` | `blob("gradient")` |
+| LayerPassLog | `captured_args`, `captured_kwargs` | `blob_recursive("captured_arg")` if `include_captured_args=True`, else `drop` |
+| LayerPassLog | `children_tensor_versions` | `blob_recursive("child_version")` if `include_captured_args=True`, else `drop` |
+| LayerPassLog | `func_rng_states` | `blob_recursive("rng_state")` if `include_rng_states=True`, else `drop` |
+| LayerPassLog | `func_applied` | `drop` |
+| LayerPassLog | `func_config` | `blob_recursive("func_config")` with `stringify` fallback for unknown non-tensor objects |
+| LayerPassLog | `parent_layer_log` | `drop` (rebuilt on load from manifest + layer_dict_all_keys graph) |
+| LayerPassLog | all other FIELD_ORDER columns | `keep` |
+| LayerPassLog | `_source_model_log_ref` (weakref) | `weakref_strip` |
+| LayerLog | `func_applied`, `activation_postfunc` | `drop` (copied from first pass; recoverable from LayerPassLog records or repr string) |
+| LayerLog | `_source_model_log_ref` | `weakref_strip` |
+| LayerLog | all other columns | `keep` |
+| ModuleLog | `extra_attributes` | `blob_recursive("module_meta")` with `stringify` fallback |
+| ModuleLog | `_source_model_log_ref` | `weakref_strip` |
+| ModulePassLog | `forward_args`, `forward_kwargs` | `blob_recursive("module_arg")` if `include_captured_args=True`, else `drop`. Summary fields (`forward_args_summary`, `forward_kwargs_summary`) always `keep`. |
+| ParamLog | `_param_ref` | `drop` (pins `nn.Parameter`) |
+| ParamLog | all other columns | `keep` |
+| BufferLog | Inherits LayerPassLog policy (is a subclass) | — |
+| FuncCallLocation | `_frame_func_obj` | `drop` |
+| FuncCallLocation | `_frame`, `_linecache_entry` if present | `drop` |
+| FuncCallLocation | `code_context`, `func_signature`, `func_docstring`, `call_line`, etc. | `keep` |
+| ModelLog | `activation_postfunc` | `drop`; record `activation_postfunc_repr: str` if present |
+| ModelLog | `_module_logs`, `_buffer_accessor`, `_module_build_data` | `drop` (rebuilt on load — existing behavior) |
+| ModelLog | `_optimizer` if present | `drop` |
+| ModelLog | `_saved_gradients_set`, `_mod_*`, `_module_metadata`, `_module_forward_args` | `drop` (transient build state) |
+| ModelLog | all other FIELD_ORDER columns and configuration fields | `keep` |
+| Any | Attribute not in spec | Lint failure during S1 tests (`tests/test_io_scrub_policy.py` in S1). |
+
+Adding a new attribute to any of these classes in a future PR requires updating the class's `PORTABLE_STATE_SPEC` — enforced by the S1 lint.
+
+**Completeness lint placement**: lives in S1 (`tests/test_io_scrub_policy.py`), not S7. This means the guarantee is active from the moment scrubber lands. Fixes Round-3 finding #8.
+
+**Rehydration contract on load** — addresses Round-2 finding #1 + Round-3 finding #1.
+
+All blob materialization happens in a dedicated loader (`torchlens/_io/rehydrate.py::rehydrate_model_log(scrubbed_state, manifest, bundle_path, *, lazy, map_location, materialize_nested)`), NOT in `__setstate__`. `__setstate__` runs only default-fill + weakref restoration, never touches disk.
+
+This split is critical: `__setstate__` has no way to receive `map_location` from the caller, and it also runs on plain `pickle.load()` of a scrubbed state dict where the bundle root may not be accessible at all. The loader wraps `__setstate__` and then applies the rehydration pass.
+
+**Default changes** — addresses Round-3 finding #1 on RAM blow-up:
+- `torchlens.save(..., include_captured_args=False, include_rng_states=False)` are now the **defaults**. Captured args and RNG states balloon bundle size and their tensors are rarely interesting for post-hoc analysis. Users opt in explicitly: `include_captured_args=True` if they want validation-ready bundles.
+- New load-time flag: `torchlens.load(path, lazy=False, map_location="cpu", materialize_nested=True)`. When `materialize_nested=False` with `lazy=True`, nested tensor refs stay as `BlobRef`-like objects — power-user mode for cases where capture-arg bundles would not fit in RAM.
+
+Rehydration behavior by mode:
+- `lazy=False` (default): `.activation`/`.gradient` materialized; nested tensors materialized with `map_location`.
+- `lazy=True, materialize_nested=True` (default for lazy): `.activation`/`.gradient` remain refs; nested tensors materialized eagerly. Common case: user wants metadata access without activation RAM cost but needs real tensors for validation paths.
+- `lazy=True, materialize_nested=False` (expert): everything lazy. User explicitly accepts that `.captured_args[0]` may still be a `BlobRef` and calls `rehydrate_nested(model_log)` later when needed.
+
+`map_location` is honored in all three modes. Safetensors accepts it directly.
+
+**Plain-pickle backward compat**:
+`pickle.dump(model_log, f)` / `pickle.load(f)` continue to work via the existing `__getstate__` hooks (weakref strip only — no scrub). Limitations of current plain pickle (callables fragility, `_param_ref` pinning) are unchanged. Portable representation is `torchlens.save()`.
+
+**Compat contract resolution** — addresses Round-2 finding #14:
+Plain `pickle.dump/load` is supported for this release; a `DeprecationWarning` fires on `pickle.load` of any ModelLog with `io_format_version` field missing (old pickles from before this sprint). No deprecation warning on `pickle.dump` of a fresh ModelLog (users still allowed to produce plain pickles; they just aren't the portable format). Tested in `tests/test_io_plain_pickle.py`.
+
+### Fork B. Load granularity
+**Decision**: `lazy=False` is **the default**. Lazy is opt-in via `torchlens.load(path, lazy=True)`.
+
+Rationale (addresses Round-2 finding #5):
+- Existing TorchLens internal methods assume `.activation` is a tensor when present.
+- A full audit of every public and semi-public method is out of scope for this sprint.
+- Making lazy opt-in means users who want it accept the "call `materialize_activation()` before doing tensor ops" contract explicitly.
+- A future sprint can flip the default after a full compat audit.
+
+`.activation` stays `tensor | None` throughout. `.activation_ref` is populated whenever a blob exists on disk (lazy or eager load). After `lazy=True` load, `.activation` is `None` and user must call `materialize_activation()` to get a tensor. After `lazy=False` load, both `.activation` and `.activation_ref` are populated.
+
+### Fork C. Pandas-export scope
+**Decision**: DataFrames at six log levels: layer-pass, aggregate layer, module-pass, module, param, buffer.
+
+`ModulePassLog.forward_args_summary` and `ModulePassLog.forward_kwargs_summary` new fields — addresses Round-2 finding #9 + Round-3 finding #5.
+- During postprocess step `_build_module_logs`, **before** the existing GC step that clears `forward_args`/`forward_kwargs`, two summary strings are computed using a recursive formatter:
+  - Tensor → `"Tensor(shape=(1,3,224,224), dtype=float32)"`.
+  - Primitive (bool/int/float/str/None) → `repr(value)`.
+  - List/Tuple → `"[" + ", ".join(format(v) for v in seq) + "]"`.
+  - Dict → `"{" + ", ".join(f"{k}: {format(v)}" for k,v in d.items()) + "}"`.
+  - Other object → `f"<{type(value).__name__}>"`.
+- Stored as `forward_args_summary: str` and `forward_kwargs_summary: str` on ModulePassLog.
+- `ModulePassLog.to_pandas()` includes both columns. kwargs-heavy modules and dict/list-nested inputs are preserved.
+- Existing GC behavior unchanged; `forward_args` / `forward_kwargs` still cleared after the summary pass.
+
+### Fork D. Streaming-save architecture
+**Decision**: during forward pass, write the sidecar at `save_tensor_data()` completion; activation remains in memory until the postprocess evict step runs. Selective streaming hooks the exhaustive pass only. **Bundle finalization is split from activation eviction** into two separate postprocess steps (addresses Round-3 finding #3).
+
+Concrete pipeline positions — addresses Round-2 finding #3 and Round-3 finding #3.
+
+Current 18-step postprocess pipeline (imperative code in `postprocess/__init__.py`): this sprint adds two steps at the end:
+```
+Step 19: _finalize_streamed_bundle       (NEW, always runs when writer present)
+Step 20: _evict_streamed_activations     (NEW, conditional on keep_activations_in_memory=False)
+```
+
+Step 19 gate: `ModelLog._activation_writer is not None`. Always writes manifest, writes scrubbed metadata.pkl, renames temp dir to final path. Unconditional for all streaming captures.
+
+Step 20 gate: same as step 19 AND `model_log._keep_activations_in_memory is False`. Nulls `.activation`, sets `.activation_ref` to a `LazyActivationRef` pointing at the final (post-rename) bundle path.
+
+Sequence for `log_forward_pass(..., save_activations_to=path, keep_activations_in_memory=False)`:
+1. Writer opens `<path>.tmp.<uuid4>/blobs/`.
+2. During forward: each `save_tensor_data()` call writes `NNNNNNNNNN.safetensors` and records `blob_id` on the LayerPassLog (private field `_pending_blob_id`). `.activation` unchanged at this point.
+3. Postprocess steps 1-18 run normally with tensors in memory.
+4. Step 19 `_finalize_streamed_bundle` runs: writer computes sha256 per blob, writes `manifest.json`, writes scrubbed `metadata.pkl` (tensors already on disk → `BlobRef` stubs), atomic rename `<path>.tmp.<uuid>/` → `<path>/`. Always.
+5. Step 20 `_evict_streamed_activations` runs (only if `keep_activations_in_memory=False`): iterates `_pending_blob_id` entries, nulls `.activation`, builds `LazyActivationRef` with **final path** (post-rename).
+6. ModelLog returned.
+
+If `keep_activations_in_memory=True` (default), step 19 still runs and the bundle is finalized; step 20 is skipped. The returned ModelLog has activations in memory AND disk-backed.
+
+**Streaming strictness** — addresses Round-3 finding #6:
+Streaming is **always strict**. If `tensor_policy` returns an error on an activation mid-stream (sparse, meta, nested, DTensor, etc.), the writer aborts: the `.tmp.<uuid>/` dir is kept with `PARTIAL` + `REASON` files, `TorchLensIOError` is raised with the offending blob_id + layer label. No lenient streaming path. Rationale: streaming is a live capture pipeline; silently skipping a layer mid-pass is too confusing. Users who need lenient behavior should capture normally, then call `torchlens.save(..., strict=False)` post-hoc.
+
+**Non-tensor `activation_postfunc` guard** — addresses Round-2 finding #4.
+Single rule applied to both streaming and post-hoc save: if `activation_postfunc is not None` AND `save_activations_to is not None` (streaming) OR `torchlens.save()` is called with `include_activations=True` (post-hoc), validate that `activation_postfunc` output type is `torch.Tensor`. Check is performed:
+- **Streaming**: at the first `save_tensor_data()` call where the writer would be invoked. If the post-postfunc value is not a `torch.Tensor`, the writer is aborted immediately, `.tmp.<uuid>/` dir gets a `PARTIAL` sentinel + `REASON` file describing the issue, `TorchLensIOError` is raised, forward pass terminates. No partially-written bundle masquerades as valid.
+- **Post-hoc save**: `torchlens.save()` inspects the first LayerPassLog with a saved activation; if the activation's type differs from `torch.Tensor` (the postfunc output was retained), raise `TorchLensIOError` before any blob is written.
+
+**Atomicity scope** (unchanged from v2): random uuid temp dir; local-same-fs best-effort; non-local FS documented as unsupported.
+
+**Temp-dir cleanup**: `torchlens.cleanup_tmp(path, force=False)` finds sibling `<path>.tmp.*` directories with a `PARTIAL` sentinel and removes them. Without `PARTIAL`, only removes after user confirmation.
+
+**Gradient streaming**: out of scope. Post-hoc `torchlens.save(model_log, path, include_gradients=True)` bundles any populated `.gradient` fields.
+
+### Fork E. Unsupported-tensor policy
+**Decision**: **`strict=True` is the default for `torchlens.save()`**. Lenient skip is opt-in.
+
+Rationale — addresses Round-2 finding #6:
+- Silent partial bundles are an unsafe default for research/CI artifacts.
+- Users hitting a sparse/meta/quantized tensor deserve a loud error that tells them to deal with it.
+- `strict=False` remains available for users who knowingly want best-effort archival.
+
+Supported tensor matrix (unchanged from v2 in scope):
+
+| Tensor kind | strict=True | strict=False |
+|-------------|-------------|--------------|
+| Dense CPU/CUDA standard dtypes | Save | Save |
+| Non-contiguous | `.contiguous()` then save | Same |
+| Sparse COO/CSR, quantized, nested, tensor subclass, DTensor/FSDP shard, complex32 | `TorchLensIOError` with field name + reason | Skip, record in `manifest.unsupported_tensors`, warn once |
+| Meta tensors | `TorchLensIOError` (no data) | Skip, record |
+
+### Fork F. Version & integrity policy
+**Decision**: PEP 440 parsing where applicable; sha256 over safetensors file bytes on disk.
+
+Addresses Round-2 finding #7.
+
+Version parsing:
+- `torchlens_version`, `torch_version`, `python_version` parsed with `packaging.version.Version`. Nightly/pre-release identifiers compared per PEP 440 semantics.
+- On parse failure (non-conforming string): fall back to string equality; emit `UserWarning` naming the unparseable version.
+- Version policy table (Fork E in v2 plan, unchanged structure but explicit parse rules):
+
+| Scenario | Load behavior |
+|----------|---------------|
+| `io_format_version > current` | Raise `TorchLensIOError` before opening `metadata.pkl` |
+| `io_format_version < current` | Load with `DeprecationWarning` listing missing fields |
+| `io_format_version == current` | Load normally |
+| `torch_version` major mismatch | Raise `TorchLensIOError` (pre-open) |
+| `torch_version` minor mismatch | Load with `UserWarning` |
+| `torchlens_version` newer | Load with `UserWarning` |
+| `torchlens_version` older | Load with info log only |
+| `python_version` major mismatch | Attempt load; wrap any pickle error in `TorchLensIOError` with version hint |
+| Safetensors backend missing | Raise `TorchLensIOError` with install hint |
+| Manifest unparseable | Raise `TorchLensIOError` |
+| Manifest blob_id without file | Raise `TorchLensIOError` (lists missing blobs) |
+| Blob checksum mismatch | Raise `TorchLensIOError` (names blob_id) |
+| Unknown extra files in `blobs/` | `UserWarning`, continue |
+
+Checksum semantics:
+- `sha256` field = hex of `hashlib.sha256(open(blob_path, "rb").read()).hexdigest()` — literal file bytes on disk after safetensors write.
+- Checksum verified lazily on `materialize()` for `lazy=True` loads, eagerly on load for `lazy=False`.
+
+### Fork G. Exception contract
+**Decision**: all bundle-layer errors wrap in `TorchLensIOError`. Addresses Round-2 finding #12.
+
+- `torchlens._io.TorchLensIOError` is the single exception type for bundle failures.
+- Implementation: bundle save/load code catches `OSError`, `pickle.UnpicklingError`, `safetensors`-raised errors, JSON parse errors, key errors on manifest structure, and re-raises as `TorchLensIOError` with `__cause__` chained.
+- Plain `pickle.load()` of a ModelLog via user-written code does not go through the wrap — callers of plain pickle accept Python's native pickle errors.
+- Tested in `tests/test_io_bundle.py`.
+
+### Fork H. Lazy-resave drift
+**Decision**: record source-bundle manifest sha256 at load + verify each source blob's sha256 before fast-copy. Addresses Round-2 finding #8 + Round-3 finding #4.
+
+Two layers of defense:
+1. **Manifest-level**: at load time, capture `source_manifest_sha256 = sha256(manifest.json)` into ModelLog private `_source_bundle_manifest_sha256`. On resave, re-hash the source manifest and compare. If differs → `TorchLensIOError("source bundle manifest has changed since load; materialize refs and retry")`.
+2. **Blob-level**: for each `LazyActivationRef` about to be fast-copied, re-hash the source blob file on disk and compare against the sha256 recorded in that manifest entry. If differs → `TorchLensIOError("blob at <path> tampered since load; materialize and retry")`.
+
+Rationale: manifest-only check misses an attacker/corruption that replaces blob bytes but leaves the manifest intact. Per-blob verify catches it at the cost of reading the bytes once — still cheaper than decoding safetensors + re-encoding (no torch involvement).
+
+If either check fails, the user must call `.materialize_activation()` on every ref (which itself does a sha256 check during materialize) and then resave — at which point the new blobs are written fresh from in-memory tensors.
+
+### Fork I. Operational shape
+**Decision**: directory-of-one-blob-per-tensor is the intentional format for this sprint. Finding #11 is **deferred**, not resolved.
+
+Documentation note (`.project-context/knowledge/io_architecture.md` and README):
+> "For models with >10,000 saved layers or deployment on network filesystems, bundle save creates many small files. A future release may add chunked blob formats. This sprint prioritizes random-access lazy loads over file-count optimization."
+
+Not claiming resolution we haven't earned.
+
+### Fork J. Filesystem safety
+**Decision**: reject symlinks in bundle directories and temp dirs. Addresses Round-3 finding #7.
+
+- `torchlens.save()` fails with `TorchLensIOError` if any path inside `<path>/` (after write) is a symlink. Save writes real files only.
+- `torchlens.load()` rejects a bundle if `manifest.json`, `metadata.pkl`, the `blobs/` directory, or any file under `blobs/` is a symlink. `TorchLensIOError`.
+- `torchlens.cleanup_tmp(path)` rejects `.tmp.*` entries that are symlinks (not removed, reported instead). Only real directories directly under the expected parent are cleaned.
+- Rationale: symlinks can escape the bundle root, hide tampered content outside the bundle, and make `cleanup_tmp` delete unrelated paths.
+
+### Fork K. Thread-safety and reader lifecycle
+**Decision**: no long-lived shared safetensors readers. `LazyActivationRef.materialize()` opens, reads, verifies sha256, and closes per call. Addresses Round-3 finding #9.
+
+- Rationale: torchlens is already single-threaded (see existing `warn_parallel` in user_funcs). Shared mmap + refcounting would add complexity for zero benefit.
+- Trade-off: materializing the same ref twice re-reads and re-hashes. Acceptable because users typically materialize once and cache via `.activation = <tensor>`.
+- `cleanup()` becomes trivial: no open handles to close (documented).
+
+---
+
+## 2. Manifest Schema v1 (unchanged from v2)
+
+```json
+{
+  "io_format_version": 1,
+  "torchlens_version": "1.2.0",
+  "torch_version": "2.5.0",
+  "python_version": "3.11.5",
+  "platform": "linux-x86_64",
+  "created_at": "2026-04-23T13:05:00Z",
+  "bundle_format": "directory",
+  "n_layers": 152,
+  "n_activation_blobs": 152,
+  "n_gradient_blobs": 0,
+  "n_auxiliary_blobs": 304,
+  "tensors": [
+    {
+      "blob_id": "0000000001",
+      "kind": "activation",
+      "label": "conv2d_1_1:2",
+      "relative_path": "blobs/0000000001.safetensors",
+      "backend": "safetensors",
+      "shape": [1, 64, 112, 112],
+      "dtype": "float32",
+      "device_at_save": "cuda:0",
+      "layout": "strided",
+      "bytes": 3211264,
+      "sha256": "3f5c..."
+    }
+  ],
+  "unsupported_tensors": [
+    {"label": "sparse_layer:1", "kind": "activation", "reason": "sparse_coo layout not supported this release"}
+  ]
+}
+```
+
+`kind` values: `activation`, `gradient`, `captured_arg`, `child_version`, `rng_state`, `module_arg`, `func_config`.
+
+---
+
+## 3. Public API Surface
+
+### Top-level `torchlens`
+```python
+torchlens.save(
+    model_log: ModelLog,
+    path: str | Path,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,
+    include_captured_args: bool = False,   # CHANGED v4: default False (bundle size + RAM)
+    include_rng_states: bool = False,      # CHANGED v4: default False
+    strict: bool = True,
+    overwrite: bool = False,
+) -> None
+
+torchlens.load(
+    path: str | Path,
+    *,
+    lazy: bool = False,
+    map_location: str | torch.device = "cpu",
+    materialize_nested: bool = True,       # NEW v4: controls nested-tensor eager load
+) -> ModelLog
+
+torchlens.cleanup_tmp(
+    path: str | Path,
+    *,
+    force: bool = False,
+) -> list[Path]
+
+torchlens.rehydrate_nested(             # NEW v4: power-user full materialization
+    model_log: ModelLog,
+    *,
+    map_location: str | torch.device = "cpu",
+) -> None
+```
+
+### On `ModelLog`
+```python
+model_log.save(path, **kwargs)
+ModelLog.load(path, **kwargs)             # classmethod
+
+model_log.to_pandas() -> pd.DataFrame
+model_log.to_csv(path, **kwargs)
+model_log.to_parquet(path, **kwargs)
+model_log.to_json(path, *, orient="records")
+```
+
+### Accessors
+```python
+# existing:
+model_log.layers.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.modules.to_pandas() / ...
+
+# NEW:
+model_log.params.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.buffers.to_pandas() / ...
+
+# Per-log:
+module_log.to_pandas() / ...
+module_pass_log.to_pandas() / ...         # NEW, reads forward_args_summary
+```
+
+### Streaming at capture time
+```python
+log_forward_pass(
+    ...,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
+)
+```
+
+### LazyActivationRef
+```python
+class LazyActivationRef:
+    blob_id: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device_at_save: str
+    source_bundle_path: Path
+    kind: Literal["activation", "gradient"]
+
+    def materialize(self, *, map_location="cpu") -> torch.Tensor: ...
+```
+
+### Resave-lazy semantics
+```python
+model_log = torchlens.load("a/", lazy=True)
+model_log.save("b/")
+# If source manifest sha256 matches the one captured at load: shutil.copy blobs from a/ to b/.
+# If source manifest differs from recorded digest OR source deleted: raise TorchLensIOError
+#   "source bundle at a/ has changed or is gone; call .materialize_activation() on all layers and retry."
+# No silent drift.
+```
+
+---
+
+## 4. Spec Decomposition
+
+All specs must pass: `ruff check . --fix && mypy torchlens/ && pytest tests/ -m smoke -x --tb=short`.
+
+### Group 1 — Foundations (parallel-safe)
+
+**IO-S1. Pickle hardening: scrub policy + rehydrate loader + PORTABLE_STATE_SPEC lint + version tagging + accessor reconstruction**
+- `torchlens/_io/__init__.py`: `IO_FORMAT_VERSION=1`, `TorchLensIOError`, `BlobRef` NamedTuple, `FieldPolicy` enum (keep/blob/blob_recursive/drop/stringify/weakref_strip).
+- Add `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attr on ModelLog, LayerPassLog, LayerLog, ModuleLog, ModulePassLog, ParamLog, BufferLog, FuncCallLocation per Fork A table.
+- `torchlens/_io/scrub.py`: `scrub_for_save(model_log, **include_flags) -> (scrubbed_state, list[BlobSpec])`. Driven purely by `PORTABLE_STATE_SPEC`.
+- `torchlens/_io/rehydrate.py`: `rehydrate_model_log(scrubbed_state, manifest, bundle_path, *, lazy, map_location, materialize_nested)`. Single entry point for all blob materialization. `__setstate__` only does default-fill + weakref restore; never touches disk.
+- `torchlens/_io/accessor_rebuild.py`: shared helper extracted from `postprocess/finalization.py:671-681`.
+- Expand `__setstate__` on ModelLog, LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog, ModulePassLog with version-aware default-fill.
+- Files: `torchlens/_io/__init__.py`, `scrub.py`, `rehydrate.py`, `accessor_rebuild.py` (all NEW); `torchlens/data_classes/{model_log,layer_pass_log,layer_log,param_log,buffer_log,module_log,func_call_location}.py`; `torchlens/postprocess/finalization.py` (extract helper).
+- Tests:
+  - `tests/test_io_pickle.py` (NEW) — scrub round-trip; accessor rebuild; default-fill from forged older pickle; version hard-fail on newer; plain-pickle unchanged.
+  - `tests/test_io_scrub_policy.py` (NEW) — **PORTABLE_STATE_SPEC completeness lint**: for each class, instantiate a canonical live example, walk `vars(instance)`, assert every attribute name appears in `PORTABLE_STATE_SPEC`. Fails CI if any new attribute added without a policy entry. Moved from S7 to S1 per Round-3 finding #8.
+- Size: **~440 LoC** (up from 400 due to PORTABLE_STATE_SPEC surfaces + rehydrate loader separation).
+
+**IO-S2. ParamAccessor / BufferAccessor / ModulePassLog.to_pandas() + forward_args_summary + forward_kwargs_summary**
+- New FIELD_ORDER tuples in `constants.py`.
+- Recursive summary formatter in `torchlens/data_classes/_summary.py` (new) producing strings per Fork C rules.
+- `ModulePassLog.forward_args_summary` and `forward_kwargs_summary` fields populated in `_build_module_logs` BEFORE the existing GC step.
+- New `to_pandas()` methods on ParamAccessor, BufferAccessor, ModulePassLog.
+- Files: `torchlens/data_classes/{param_log,buffer_log,module_log,_summary}.py`, `torchlens/constants.py`, `torchlens/postprocess/finalization.py` (add summary capture before GC).
+- Tests: `tests/test_io_pandas.py` (NEW) — schema shape; empty accessor; summary correctness with mixed tensor/primitive/list/dict/kwargs args; summary survives GC; both `_args_summary` and `_kwargs_summary` present.
+- Size: **~280 LoC** (up from 240; adds kwargs summary + recursive formatter).
+
+### Group 2 — Exports + bundle (serial: S3 after S2; S4 after S1)
+
+**IO-S3. Export wrappers: to_csv / to_parquet / to_json on all seven DataFrame producers**
+- Wrappers on ModelLog, LayerAccessor, ModuleAccessor, ModuleLog, ModulePassLog, ParamAccessor, BufferAccessor.
+- `pyarrow` optional via `pip install torchlens[io]`; clear `ImportError` if missing.
+- Files: `torchlens/data_classes/{interface,layer_log,module_log,param_log,buffer_log}.py`, `pyproject.toml`.
+- Tests: `tests/test_io_export.py` — round-trip + schema stability + ImportError on parquet.
+- Size: **~220 LoC**.
+
+**IO-S4. Bundle save/load (eager post-hoc) + manifest v1 + integrity + exception contract**
+- `torchlens/_io/bundle.py`: `save` (post-hoc) and `load`. Integrates scrub (S1), tensor_policy (below), and manifest.
+- `torchlens/_io/manifest.py`: schema class, sha256 hashing, PEP 440 version parsing, policy enforcement.
+- `torchlens/_io/tensor_policy.py`: implements supported-tensor matrix; returns `(Ok | SkipReason | Error)` per tensor; respects `strict` flag.
+- All bundle errors wrap in `TorchLensIOError` (Fork G).
+- ModelLog gets `.save()` / `.load()` sugar; `torchlens` exports `save`, `load`, `cleanup_tmp`.
+- Files: `torchlens/_io/{bundle,manifest,tensor_policy}.py` (NEW); `torchlens/data_classes/model_log.py`; `torchlens/__init__.py`; `torchlens/user_funcs.py`.
+- Tests: `tests/test_io_bundle.py` (NEW) — eager round-trip; strict default raises on sparse; `strict=False` skips + records; all 12 version-policy rows; corrupt manifest / missing blob / truncated safetensors / checksum tamper all raise `TorchLensIOError`; overwrite semantics; non-tensor postfunc rejected at save; include flags combos.
+- Size: **~480 LoC**.
+
+### Group 3 — Streaming + lazy (serial)
+
+**IO-S5. Streaming-save during forward pass + postprocess steps 19+20 + streaming-strict + cleanup_tmp + symlink rejection**
+- `torchlens/_io/streaming.py`: `BundleStreamWriter`. Open `<path>.tmp.<uuid>/blobs/` (reject if path exists as symlink), receive `(blob_id, tensor)` synchronously, consult `tensor_policy` per tensor (streaming is **always strict** — Round-3 finding #6), write safetensors. On `finalize()`: compute sha256 per blob, write manifest, write scrubbed `metadata.pkl`, rename temp dir → final path. Returns set of blob ids + final path for ref-patching.
+- Instrument `LayerPassLog.save_tensor_data()` with writer callout; gated to exhaustive-pass call site only (`capture/output_tensors.py:866-900`).
+- **Step 19 `_finalize_streamed_bundle`** registered in `postprocess/__init__.py`: always runs if writer present. Handles manifest write, scrubbed metadata.pkl write, atomic rename.
+- **Step 20 `_evict_streamed_activations`** registered after step 19: runs only if writer present AND `keep_activations_in_memory=False`. Patches `LazyActivationRef` with final (post-rename) path.
+- Non-tensor postfunc guard: writer verifies first received tensor is `torch.Tensor`; if not, abort, mark `.tmp.<uuid>/PARTIAL`, raise `TorchLensIOError` (Fork D rule).
+- Symlink rejection: writer refuses to open if `<path>` exists as a symlink; load side already covered by S4 + Fork J.
+- `torchlens.cleanup_tmp(path, force=False)` utility (rejects symlink temp dirs — Round-3 finding #7).
+- Files: `torchlens/_io/streaming.py` (NEW), `torchlens/_io/bundle.py`, `torchlens/data_classes/{layer_pass_log,model_log}.py`, `torchlens/user_funcs.py`, `torchlens/postprocess/{__init__,finalization}.py`.
+- Tests: `tests/test_io_streaming.py` (NEW) — blobs written during pass (verify timestamps); step 19 always runs and bundle is finalized on keep_activations_in_memory=True; step 20 gated correctly; mid-pass exception leaves PARTIAL; non-tensor postfunc aborts; sparse/meta/nested tensor mid-stream raises `TorchLensIOError` with PARTIAL preserved; lazy refs point to final path not temp; cleanup_tmp ignores symlinks; `activation_sink` callable path.
+- Size: **~440 LoC** (up from 400 due to step split + strictness + symlink rejection).
+
+**IO-S6. Lazy activation references + two-level drift guard + lazy-resave fast-copy + rehydrate_nested + no-shared-handles**
+- Flesh out `torchlens/_io/lazy.py`: `LazyActivationRef(blob_id, shape, dtype, device_at_save, source_bundle_path, kind, expected_sha256)`; `materialize(map_location="cpu")` opens safetensors fresh, reads, verifies sha256 against `expected_sha256`, closes, returns tensor (Fork K: no shared readers).
+- `LayerPassLog.materialize_activation(map_location="cpu") -> Tensor` (and `.materialize_gradient()`).
+- `torchlens.rehydrate_nested(model_log, map_location="cpu")`: power-user function for when user did `lazy=True, materialize_nested=False`. Walks nested containers, replaces any remaining `BlobRef` with real tensors.
+- ModelLog records `_source_bundle_manifest_sha256` at load time.
+- Lazy-resave fast-copy path in `torchlens/_io/bundle.py::save` (Fork H two-layer):
+  1. Verify `sha256(source/manifest.json) == _source_bundle_manifest_sha256`; else raise.
+  2. For each `LazyActivationRef` about to be copied: verify `sha256(source/blobs/<blob_id>.safetensors) == ref.expected_sha256`; else raise.
+  3. Only then `shutil.copy` to new bundle.
+- Cleanup: `ModelLog.cleanup()` documents "no long-lived handles to close" (Fork K).
+- Files: `torchlens/_io/lazy.py` (EXPAND), `torchlens/data_classes/{layer_pass_log,cleanup}.py`, `torchlens/_io/bundle.py`, `torchlens/_io/rehydrate.py`, `torchlens/validation/invariants.py` (clear-error path for lazy-only logs).
+- Tests: `tests/test_io_lazy.py` (NEW) — shape/dtype accessible without disk read; materialize bit-exact vs eager; map_location honored; manifest-level drift (mutate manifest) raises; **blob-level drift (mutate a single blob file, leave manifest intact) also raises** (Round-3 finding #4); fast-copy on clean source; validation API raises clearly on lazy-only; `rehydrate_nested` populates nested BlobRefs; no open file handles leak after materialize.
+- Size: **~400 LoC** (up from 360 due to per-blob drift + rehydrate_nested + expected_sha256 field).
+
+### Group 4 — Integration tests + docs (parallel)
+
+**IO-S7. Integration + corruption regression suite**
+- End-to-end: capture → stream-save → lazy-load → materialize → to_parquet → re-load.
+- Corruption battery: truncated safetensors, missing blob, corrupt pickle, tampered manifest, stale counts, unknown extra files, checksum mismatch. Each must raise `TorchLensIOError` with specific message.
+- Forged older-format pickle loads with `DeprecationWarning`.
+- DataParallel/DDP sanity skip (torchlens already `warn_parallel`; streaming inherits).
+- Scrub-policy lint test: iterate all `FIELD_ORDER` columns, assert each has explicit policy entry.
+- Files: `tests/test_io_integration.py` (NEW), `tests/test_io_plain_pickle.py` (NEW), minor updates to `test_save_new_activations.py`.
+- Size: **~380 LoC**.
+
+**IO-S8. Docs**
+- Docstrings on every new public API with copy-pasteable examples.
+- README "Save and Load" section.
+- `.project-context/knowledge/io_architecture.md` (NEW): bundle layout, manifest schema, tensor matrix, version policy, operational-shape note (Fork I).
+- Files: `torchlens/_io/__init__.py`, `torchlens/__init__.py`, `torchlens/data_classes/model_log.py`, `README.md`, `.project-context/knowledge/io_architecture.md` (NEW).
+- Size: **~160 LoC**.
+
+Total: ~2640 LoC (up from 2460 in v2).
+
+---
+
+## 5. Spec Dependency Graph
+
+```
+S1 ─┬─> S4 ─┬─> S5 ──> S6 ──> S7
+    │       │
+S2 ─┴─> S3 ─┘                S8 (docs, parallel with S7)
+```
+
+---
+
+## 6. Risk Register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Unsupported tensor layouts | strict=True default raises; strict=False opt-in records in manifest. |
+| R2 | Scrub misses a new field added in a future release | S7 lint test enumerates FIELD_ORDER; CI fails if new field lacks policy entry. |
+| R3 | Disk-full / crash mid-stream | `.tmp.<uuid>/PARTIAL` sentinel; `cleanup_tmp` utility. |
+| R4 | Lazy refs inside nested containers confuse validation | Nested containers always eager-materialized; lazy only `.activation`/`.gradient`. |
+| R5 | Lazy cleanup vs live safetensors handles | `cleanup()` closes handles before nulling. Tested. |
+| R6 | Format drift in N+1 | `io_format_version` + migration helpers (S1). |
+| R7 | CUDA bundle on CPU host | `map_location="cpu"` default; safetensors handles it. |
+| R8 | Streaming writer blocks | Synchronous by design; documented. |
+| R9 | pyarrow install weight | Optional via extras. |
+| R10 | Many small files (directory format) | Documented tradeoff (Fork I); deferred to future sprint. |
+| R11 | NFS/Windows rename edge cases | Documented: local-same-fs best-effort. |
+| R12 | Source bundle mutated between lazy load and resave | Manifest sha256 check on resave; raise clearly. |
+| R13 | DataParallel/DDP multiple capture | Torchlens is single-process; inherit existing warning. |
+| R14 | Exception handling ambiguity | All bundle errors wrap `TorchLensIOError` (Fork G). |
+
+---
+
+## 7. Execution Plan
+
+| Round | Specs | Gate |
+|-------|-------|------|
+| 1 | S1 ‖ S2 | Pickle scrub round-trip green; new pandas schemas green. |
+| 2 | S3 (after S2) ‖ S4 (after S1) | All export formats green; bundle round-trip green; version policy table tested. |
+| 3 | S5 (after S4) | Streaming + step 19 green; postprocess sees tensors; lazy refs point at final path. |
+| 4 | S6 (after S5) | Lazy load + materialize bit-exact; source drift detected; resave fast-copy. |
+| 5 | S7 ‖ S8 | Integration corruption battery green; docs complete. |
+| 6 | Phase 5 dual review (me + `/codex:review`). |
+
+---
+
+## 8. Stop-and-Ask Triggers
+
+- End of this plan revision — **NOW**
+- Any public API signature change beyond additions
+- Any bump of `io_format_version` in the future
+- End of Phase 5 (which review findings to fix)
+
+---
+
+## 9. Success Criteria (binary)
+
+- [ ] `torchlens.save(model_log, path)` + `torchlens.load(path)` round-trip everything on the supported-tensor matrix
+- [ ] Six log-level DataFrames + `.to_csv/.to_parquet/.to_json` on all seven producers
+- [ ] `log_forward_pass(..., save_activations_to=path)` streams during pass; postprocess unaffected
+- [ ] `keep_activations_in_memory=False` evicts post-pass; lazy refs point to final (post-rename) path
+- [ ] Lazy load preserves metadata access without disk read; `materialize_activation()` bit-exact
+- [ ] Source-drift detection works
+- [ ] All 14 version-policy rows tested
+- [ ] All bundle errors raise `TorchLensIOError`
+- [ ] Scrub-policy lint passes
+- [ ] Plain pickle still works with deprecation warning on pre-sprint pickles only
+- [ ] `pytest tests/ -m "not slow"` green
+- [ ] `ruff check . && mypy torchlens/` green
+
+---
+
+## 10. Change Log vs Round 3 (addresses all 9 findings)
+
+| Finding | Severity | Resolution |
+|---------|----------|-----------|
+| R3-1 Nested tensor rehydration (map_location + RAM) | HIGH | Rehydration moved from `__setstate__` to a dedicated loader entrypoint that accepts `map_location`. Added `materialize_nested: bool = True` load flag + `torchlens.rehydrate_nested()` power-user function. Flipped `include_captured_args` and `include_rng_states` defaults to `False` to reduce bundle size and RAM by default. (Fork A rehydration contract + Fork B + API surface.) |
+| R3-2 Scrub surface not exhaustive | HIGH | Replaced `FIELD_ORDER` lint with per-class `PORTABLE_STATE_SPEC` covering every live attribute (including `_optimizer`, `parent_layer_log`, `LayerLog.func_applied`, `LayerLog.activation_postfunc`, etc.). Completeness lint walks `vars(instance)` against the spec. (Fork A scrub policy + S1 lint.) |
+| R3-3 Step 19 gate contradictory | HIGH | Split into Step 19 `_finalize_streamed_bundle` (always runs when writer present) and Step 20 `_evict_streamed_activations` (conditional on `keep_activations_in_memory=False`). (Fork D + S5.) |
+| R3-4 Manifest-only drift misses blob tampering | HIGH | Added per-blob sha256 verify before fast-copy. Each `LazyActivationRef` records `expected_sha256`; source blob file is re-hashed before any copy. (Fork H + S6.) |
+| R3-5 forward_args_summary misses kwargs | MEDIUM | Added `forward_kwargs_summary`. Recursive formatter handles list/tuple/dict/primitives. (Fork C + S2.) |
+| R3-6 Streaming unsupported-tensor policy | MEDIUM | Streaming is **always strict**; unsupported tensor mid-pass raises `TorchLensIOError` with PARTIAL sentinel. No lenient streaming. (Fork D + S5.) |
+| R3-7 Symlink handling undefined | MEDIUM | Fork J: all bundle paths and `.tmp.*` entries must be real; symlinks rejected in save/load/cleanup_tmp. (S4 + S5.) |
+| R3-8 Scrub lint lands too late | MEDIUM | Moved scrub-policy completeness lint from S7 to S1 tests. Guarantees active from the moment the scrubber lands. (S1.) |
+| R3-9 Reader thread-safety model | MEDIUM | Fork K: no long-lived shared readers. `materialize()` opens/reads/closes per call. Torchlens remains single-threaded; no locks needed. (Fork K + S6.) |

--- a/.project-context/plans/io-sprint/plan_v5.md
+++ b/.project-context/plans/io-sprint/plan_v5.md
@@ -1,0 +1,619 @@
+# TorchLens I/O Sprint Plan (Round 5)
+
+**Branch**: `codex/io-sprint`
+**Goal**: comprehensive, frictionless I/O for ModelLog and its children — pickle, pandas/CSV/Parquet/JSON, activation-to-disk (including streaming during forward pass), symmetric loading.
+**Out of scope**: visualization (graphviz, ELK, dagua), tar archival utilities, gradient streaming during backward.
+**Inputs**: `.project-context/research/io-audit-{claude,codex}.md`, `.project-context/plans/io-sprint/review_round_{1,2,3,4}.md`.
+**This revision addresses all 4 Round-4 findings. Change log at bottom.**
+
+---
+
+## 1. Design Forks — Resolved
+
+### Fork A. Archival format
+**Decision**: **directory bundle only**, containing a scrubbed pickle, safetensors-only tensor blobs, and a rich manifest. `safetensors` is a **hard dependency** of the bundle path. No tar this sprint. No `pack_bundle` utility — out of scope.
+
+Bundle layout:
+```
+<bundle_dir>/
+  manifest.json               # authoritative index; see §2
+  metadata.pkl                # scrubbed ModelLog state
+  blobs/
+    0000000001.safetensors
+    0000000002.safetensors
+    ...                       # one file per persisted tensor; filename = zero-padded opaque blob id
+```
+
+Filenames are zero-padded monotonically-assigned blob ids. Human-readable layer labels live only in `manifest.json`.
+
+**Pickle-scrub contract** — addresses Round-2 findings #1/#2 + Round-3 finding #2.
+
+**Authoritative source of truth**: each class in torchlens gains a `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attribute that explicitly lists every attribute present on instances of that class (not just fields in FIELD_ORDER) and the policy for each. The scrubber consumes this spec. A completeness lint (in S1 tests) walks every live instance attribute on a canonical ModelLog and asserts each name appears in its class's spec.
+
+Classes requiring a `PORTABLE_STATE_SPEC`:
+- `ModelLog`
+- `LayerPassLog`
+- `LayerLog`
+- `ModuleLog`, `ModulePassLog`
+- `ParamLog`
+- `BufferLog`
+- `FuncCallLocation`
+- Any accessor class that ends up in the object graph
+
+Policy vocabulary:
+- `keep`: pickle as-is (primitives, containers of primitives, stable torch objects like `torch.dtype`).
+- `blob(kind)`: tensor-valued; replace with `BlobRef(blob_id, kind=...)` and record in manifest.
+- `blob_recursive(kind)`: walk container recursively; tensors blobified; non-tensor leaves passed through.
+- `drop`: set to `None` (live callables, `_param_ref`, transient build state).
+- `stringify`: replace with `"<scrubbed:TypeName>"` (fall-through for user-supplied non-portable objects).
+- `weakref_strip`: existing `__getstate__` weakref-nulling behavior, applied automatically.
+
+Policy by class (abbreviated — full matrix in `torchlens/_io/scrub.py`):
+
+| Class | Field | Policy |
+|-------|-------|--------|
+| LayerPassLog | `activation` | `blob("activation")` (scalar 0-d recorded inline in manifest) |
+| LayerPassLog | `gradient` | `blob("gradient")` |
+| LayerPassLog | `captured_args`, `captured_kwargs` | `blob_recursive("captured_arg")` if `include_captured_args=True`, else `drop` |
+| LayerPassLog | `children_tensor_versions` | `blob_recursive("child_version")` if `include_captured_args=True`, else `drop` |
+| LayerPassLog | `func_rng_states` | `blob_recursive("rng_state")` if `include_rng_states=True`, else `drop` |
+| LayerPassLog | `func_applied` | `drop` |
+| LayerPassLog | `func_config` | `blob_recursive("func_config")` with `stringify` fallback for unknown non-tensor objects |
+| LayerPassLog | `parent_layer_log` | `drop` (rebuilt on load from manifest + layer_dict_all_keys graph) |
+| LayerPassLog | all other FIELD_ORDER columns | `keep` |
+| LayerPassLog | `_source_model_log_ref` (weakref) | `weakref_strip` |
+| LayerLog | `func_applied`, `activation_postfunc` | `drop` (copied from first pass; recoverable from LayerPassLog records or repr string) |
+| LayerLog | `_source_model_log_ref` | `weakref_strip` |
+| LayerLog | all other columns | `keep` |
+| ModuleLog | `extra_attributes` | `blob_recursive("module_meta")` with `stringify` fallback |
+| ModuleLog | `_source_model_log_ref` | `weakref_strip` |
+| ModulePassLog | `forward_args`, `forward_kwargs` | `blob_recursive("module_arg")` if `include_captured_args=True`, else `drop`. Summary fields (`forward_args_summary`, `forward_kwargs_summary`) always `keep`. |
+| ParamLog | `_param_ref` | `drop` (pins `nn.Parameter`) |
+| ParamLog | all other columns | `keep` |
+| BufferLog | Inherits LayerPassLog policy (is a subclass) | — |
+| FuncCallLocation | `_frame_func_obj` | `drop` |
+| FuncCallLocation | `_frame`, `_linecache_entry` if present | `drop` |
+| FuncCallLocation | `code_context`, `func_signature`, `func_docstring`, `call_line`, etc. | `keep` |
+| ModelLog | `activation_postfunc` | `drop`; record `activation_postfunc_repr: str` if present |
+| ModelLog | `_module_logs`, `_buffer_accessor`, `_module_build_data` | `drop` (rebuilt on load — existing behavior) |
+| ModelLog | `_optimizer` if present | `drop` |
+| ModelLog | `_saved_gradients_set`, `_mod_*`, `_module_metadata`, `_module_forward_args` | `drop` (transient build state) |
+| ModelLog | all other FIELD_ORDER columns and configuration fields | `keep` |
+| Any | Attribute not in spec | Lint failure during S1 tests (`tests/test_io_scrub_policy.py` in S1). |
+
+Adding a new attribute to any of these classes in a future PR requires updating the class's `PORTABLE_STATE_SPEC` — enforced by the S1 lint.
+
+**Completeness lint placement**: lives in S1 (`tests/test_io_scrub_policy.py`), not S7. This means the guarantee is active from the moment scrubber lands. Fixes Round-3 finding #8.
+
+**Rehydration contract on load** — addresses Round-2 finding #1 + Round-3 finding #1.
+
+All blob materialization happens in a dedicated loader (`torchlens/_io/rehydrate.py::rehydrate_model_log(scrubbed_state, manifest, bundle_path, *, lazy, map_location, materialize_nested)`), NOT in `__setstate__`. `__setstate__` runs only default-fill + weakref restoration, never touches disk.
+
+This split is critical: `__setstate__` has no way to receive `map_location` from the caller, and it also runs on plain `pickle.load()` of a scrubbed state dict where the bundle root may not be accessible at all. The loader wraps `__setstate__` and then applies the rehydration pass.
+
+**Default changes** — addresses Round-3 finding #1 on RAM blow-up:
+- `torchlens.save(..., include_captured_args=False, include_rng_states=False)` are now the **defaults**. Captured args and RNG states balloon bundle size and their tensors are rarely interesting for post-hoc analysis. Users opt in explicitly: `include_captured_args=True` if they want validation-ready bundles.
+- New load-time flag: `torchlens.load(path, lazy=False, map_location="cpu", materialize_nested=True)`. When `materialize_nested=False` with `lazy=True`, nested tensor refs stay as `BlobRef`-like objects — power-user mode for cases where capture-arg bundles would not fit in RAM.
+
+Rehydration behavior by mode:
+- `lazy=False` (default): `.activation`/`.gradient` materialized; nested tensors materialized with `map_location`.
+- `lazy=True, materialize_nested=True` (default for lazy): `.activation`/`.gradient` remain refs; nested tensors materialized eagerly. Common case: user wants metadata access without activation RAM cost but needs real tensors for validation paths.
+- `lazy=True, materialize_nested=False` (expert): everything lazy. User explicitly accepts that `.captured_args[0]` may still be a `BlobRef` and calls `rehydrate_nested(model_log)` later when needed.
+
+`map_location` is honored in all three modes. Safetensors accepts it directly.
+
+**Plain-pickle backward compat**:
+`pickle.dump(model_log, f)` / `pickle.load(f)` continue to work via the existing `__getstate__` hooks (weakref strip only — no scrub). Limitations of current plain pickle (callables fragility, `_param_ref` pinning) are unchanged. Portable representation is `torchlens.save()`.
+
+**Compat contract resolution** — addresses Round-2 finding #14:
+Plain `pickle.dump/load` is supported for this release; a `DeprecationWarning` fires on `pickle.load` of any ModelLog with `io_format_version` field missing (old pickles from before this sprint). No deprecation warning on `pickle.dump` of a fresh ModelLog (users still allowed to produce plain pickles; they just aren't the portable format). Tested in `tests/test_io_plain_pickle.py`.
+
+### Fork B. Load granularity
+**Decision**: `lazy=False` is **the default**. Lazy is opt-in via `torchlens.load(path, lazy=True)`.
+
+Rationale (addresses Round-2 finding #5):
+- Existing TorchLens internal methods assume `.activation` is a tensor when present.
+- A full audit of every public and semi-public method is out of scope for this sprint.
+- Making lazy opt-in means users who want it accept the "call `materialize_activation()` before doing tensor ops" contract explicitly.
+- A future sprint can flip the default after a full compat audit.
+
+`.activation` stays `tensor | None` throughout. `.activation_ref` is populated whenever a blob exists on disk (lazy or eager load). After `lazy=True` load, `.activation` is `None` and user must call `materialize_activation()` to get a tensor. After `lazy=False` load, both `.activation` and `.activation_ref` are populated.
+
+### Fork C. Pandas-export scope
+**Decision**: DataFrames at six log levels: layer-pass, aggregate layer, module-pass, module, param, buffer.
+
+`ModulePassLog.forward_args_summary` and `ModulePassLog.forward_kwargs_summary` new fields — addresses Round-2 finding #9 + Round-3 finding #5.
+- During postprocess step `_build_module_logs`, **before** the existing GC step that clears `forward_args`/`forward_kwargs`, two summary strings are computed using a recursive formatter:
+  - Tensor → `"Tensor(shape=(1,3,224,224), dtype=float32)"`.
+  - Primitive (bool/int/float/str/None) → `repr(value)`.
+  - List/Tuple → `"[" + ", ".join(format(v) for v in seq) + "]"`.
+  - Dict → `"{" + ", ".join(f"{k}: {format(v)}" for k,v in d.items()) + "}"`.
+  - Other object → `f"<{type(value).__name__}>"`.
+- Stored as `forward_args_summary: str` and `forward_kwargs_summary: str` on ModulePassLog.
+- `ModulePassLog.to_pandas()` includes both columns. kwargs-heavy modules and dict/list-nested inputs are preserved.
+- Existing GC behavior unchanged; `forward_args` / `forward_kwargs` still cleared after the summary pass.
+
+### Fork D. Streaming-save architecture
+**Decision**: during forward pass, write the sidecar at `save_tensor_data()` completion; activation remains in memory until the postprocess evict step runs. Selective streaming hooks the exhaustive pass only. **Bundle finalization is split from activation eviction** into two separate postprocess steps (addresses Round-3 finding #3).
+
+Concrete pipeline positions — addresses Round-2 finding #3 and Round-3 finding #3.
+
+Current 18-step postprocess pipeline (imperative code in `postprocess/__init__.py`): this sprint adds two steps at the end:
+```
+Step 19: _finalize_streamed_bundle       (NEW, always runs when writer present)
+Step 20: _evict_streamed_activations     (NEW, conditional on keep_activations_in_memory=False)
+```
+
+**Step 19 gate**: `ModelLog._activation_writer is not None`. Writer computes sha256 per blob, writes `manifest.json`, writes scrubbed `metadata.pkl`, atomic rename `<path>.tmp.<uuid>/` → `<path>/`. **After rename, iterates all `_pending_blob_id` entries and ALWAYS attaches `.activation_ref = LazyActivationRef(..., source_bundle_path=<final path>, expected_sha256=...)`. Does NOT touch `.activation`.** Applies regardless of `keep_activations_in_memory`. Addresses Round-4 finding #3: the returned log is genuinely disk-backed in both modes because `.activation_ref` is always populated after streaming.
+
+**Step 20 gate**: step 19 ran successfully AND `model_log._keep_activations_in_memory is False`. Nulls `.activation` only. `.activation_ref` is already populated from step 19.
+
+Sequence for `log_forward_pass(..., save_activations_to=path, keep_activations_in_memory=True)` (default):
+1. Writer opens `<path>.tmp.<uuid4>/blobs/`.
+2. During forward: each `save_tensor_data()` writes `NNNNNNNNNN.safetensors`, records `blob_id` on the LayerPassLog. `.activation` unchanged.
+3. Postprocess steps 1-18 run normally with in-memory tensors.
+4. Step 19: writer finalizes; `.activation_ref` attached to every streamed layer pointing at final path.
+5. Step 20: skipped (gate false).
+6. Return. Log has `.activation` (tensor) AND `.activation_ref` (LazyActivationRef). Fully disk-backed.
+
+Sequence for `keep_activations_in_memory=False`:
+1-4. Same as above.
+5. Step 20 runs: `.activation = None`. `.activation_ref` already populated from step 19.
+6. Return. Log has `.activation=None`, `.activation_ref` populated. Disk-only.
+
+This symmetrizes the two modes: in both cases the bundle is durable and the log knows where its data lives. Only difference is whether in-memory tensors are retained.
+
+**Streaming strictness** — addresses Round-3 finding #6:
+Streaming is **always strict**. If `tensor_policy` returns an error on an activation mid-stream (sparse, meta, nested, DTensor, etc.), the writer aborts: the `.tmp.<uuid>/` dir is kept with `PARTIAL` + `REASON` files, `TorchLensIOError` is raised with the offending blob_id + layer label. No lenient streaming path. Rationale: streaming is a live capture pipeline; silently skipping a layer mid-pass is too confusing. Users who need lenient behavior should capture normally, then call `torchlens.save(..., strict=False)` post-hoc.
+
+**Non-tensor `activation_postfunc` guard** — addresses Round-2 finding #4.
+Single rule applied to both streaming and post-hoc save: if `activation_postfunc is not None` AND `save_activations_to is not None` (streaming) OR `torchlens.save()` is called with `include_activations=True` (post-hoc), validate that `activation_postfunc` output type is `torch.Tensor`. Check is performed:
+- **Streaming**: at the first `save_tensor_data()` call where the writer would be invoked. If the post-postfunc value is not a `torch.Tensor`, the writer is aborted immediately, `.tmp.<uuid>/` dir gets a `PARTIAL` sentinel + `REASON` file describing the issue, `TorchLensIOError` is raised, forward pass terminates. No partially-written bundle masquerades as valid.
+- **Post-hoc save**: `torchlens.save()` inspects the first LayerPassLog with a saved activation; if the activation's type differs from `torch.Tensor` (the postfunc output was retained), raise `TorchLensIOError` before any blob is written.
+
+**Atomicity scope** (unchanged from v2): random uuid temp dir; local-same-fs best-effort; non-local FS documented as unsupported.
+
+**Temp-dir cleanup**: `torchlens.cleanup_tmp(path, force=False)` finds sibling `<path>.tmp.*` directories with a `PARTIAL` sentinel and removes them. Without `PARTIAL`, only removes after user confirmation.
+
+**Gradient streaming**: out of scope. Post-hoc `torchlens.save(model_log, path, include_gradients=True)` bundles any populated `.gradient` fields.
+
+### Fork E. Unsupported-tensor policy
+**Decision**: **`strict=True` is the default for `torchlens.save()`**. Lenient skip is opt-in.
+
+Rationale — addresses Round-2 finding #6:
+- Silent partial bundles are an unsafe default for research/CI artifacts.
+- Users hitting a sparse/meta/quantized tensor deserve a loud error that tells them to deal with it.
+- `strict=False` remains available for users who knowingly want best-effort archival.
+
+Supported tensor matrix (unchanged from v2 in scope):
+
+| Tensor kind | strict=True | strict=False |
+|-------------|-------------|--------------|
+| Dense CPU/CUDA standard dtypes | Save | Save |
+| Non-contiguous | `.contiguous()` then save | Same |
+| Sparse COO/CSR, quantized, nested, tensor subclass, DTensor/FSDP shard, complex32 | `TorchLensIOError` with field name + reason | Skip, record in `manifest.unsupported_tensors`, warn once |
+| Meta tensors | `TorchLensIOError` (no data) | Skip, record |
+
+### Fork F. Version & integrity policy
+**Decision**: PEP 440 parsing where applicable; sha256 over safetensors file bytes on disk.
+
+Addresses Round-2 finding #7.
+
+Version parsing:
+- `torchlens_version`, `torch_version`, `python_version` parsed with `packaging.version.Version`. Nightly/pre-release identifiers compared per PEP 440 semantics.
+- On parse failure (non-conforming string): fall back to string equality; emit `UserWarning` naming the unparseable version.
+- Version policy table (Fork E in v2 plan, unchanged structure but explicit parse rules):
+
+| Scenario | Load behavior |
+|----------|---------------|
+| `io_format_version > current` | Raise `TorchLensIOError` before opening `metadata.pkl` |
+| `io_format_version < current` | Load with `DeprecationWarning` listing missing fields |
+| `io_format_version == current` | Load normally |
+| `torch_version` major mismatch | Raise `TorchLensIOError` (pre-open) |
+| `torch_version` minor mismatch | Load with `UserWarning` |
+| `torchlens_version` newer | Load with `UserWarning` |
+| `torchlens_version` older | Load with info log only |
+| `python_version` major mismatch | Attempt load; wrap any pickle error in `TorchLensIOError` with version hint |
+| Safetensors backend missing | Raise `TorchLensIOError` with install hint |
+| Manifest unparseable | Raise `TorchLensIOError` |
+| Manifest blob_id without file | Raise `TorchLensIOError` (lists missing blobs) |
+| Blob checksum mismatch | Raise `TorchLensIOError` (names blob_id) |
+| Unknown extra files in `blobs/` | `UserWarning`, continue |
+
+Checksum semantics:
+- `sha256` field = hex of `hashlib.sha256(open(blob_path, "rb").read()).hexdigest()` — literal file bytes on disk after safetensors write.
+- Checksum verified lazily on `materialize()` for `lazy=True` loads, eagerly on load for `lazy=False`.
+
+### Fork G. Exception contract
+**Decision**: all bundle-layer errors wrap in `TorchLensIOError`. Addresses Round-2 finding #12.
+
+- `torchlens._io.TorchLensIOError` is the single exception type for bundle failures.
+- Implementation: bundle save/load code catches `OSError`, `pickle.UnpicklingError`, `safetensors`-raised errors, JSON parse errors, key errors on manifest structure, and re-raises as `TorchLensIOError` with `__cause__` chained.
+- Plain `pickle.load()` of a ModelLog via user-written code does not go through the wrap — callers of plain pickle accept Python's native pickle errors.
+- Tested in `tests/test_io_bundle.py`.
+
+### Fork H. Lazy-resave drift
+**Decision**: record source-bundle manifest sha256 at load + verify each source blob's sha256 before fast-copy. Addresses Round-2 finding #8 + Round-3 finding #4.
+
+Two layers of defense:
+1. **Manifest-level**: at load time, capture `source_manifest_sha256 = sha256(manifest.json)` into ModelLog private `_source_bundle_manifest_sha256`. On resave, re-hash the source manifest and compare. If differs → `TorchLensIOError("source bundle manifest has changed since load; materialize refs and retry")`.
+2. **Blob-level**: for each `LazyActivationRef` about to be fast-copied, re-hash the source blob file on disk and compare against the sha256 recorded in that manifest entry. If differs → `TorchLensIOError("blob at <path> tampered since load; materialize and retry")`.
+
+Rationale: manifest-only check misses an attacker/corruption that replaces blob bytes but leaves the manifest intact. Per-blob verify catches it at the cost of reading the bytes once — still cheaper than decoding safetensors + re-encoding (no torch involvement).
+
+If either check fails, the user must call `.materialize_activation()` on every ref (which itself does a sha256 check during materialize) and then resave — at which point the new blobs are written fresh from in-memory tensors.
+
+### Fork I. Operational shape
+**Decision**: directory-of-one-blob-per-tensor is the intentional format for this sprint. Finding #11 is **deferred**, not resolved.
+
+Documentation note (`.project-context/knowledge/io_architecture.md` and README):
+> "For models with >10,000 saved layers or deployment on network filesystems, bundle save creates many small files. A future release may add chunked blob formats. This sprint prioritizes random-access lazy loads over file-count optimization."
+
+Not claiming resolution we haven't earned.
+
+### Fork J. Filesystem safety
+**Decision**: reject symlinks in bundle directories and temp dirs. Addresses Round-3 finding #7.
+
+- `torchlens.save()` fails with `TorchLensIOError` if any path inside `<path>/` (after write) is a symlink. Save writes real files only.
+- `torchlens.load()` rejects a bundle if `manifest.json`, `metadata.pkl`, the `blobs/` directory, or any file under `blobs/` is a symlink. `TorchLensIOError`.
+- `torchlens.cleanup_tmp(path)` rejects `.tmp.*` entries that are symlinks (not removed, reported instead). Only real directories directly under the expected parent are cleaned.
+- Rationale: symlinks can escape the bundle root, hide tampered content outside the bundle, and make `cleanup_tmp` delete unrelated paths.
+
+### Fork K. Thread-safety and reader lifecycle
+**Decision**: no long-lived shared safetensors readers. `LazyActivationRef.materialize()` opens, reads, verifies sha256, and closes per call. Addresses Round-3 finding #9.
+
+- Rationale: torchlens is already single-threaded (see existing `warn_parallel` in user_funcs). Shared mmap + refcounting would add complexity for zero benefit.
+- Trade-off: materializing the same ref twice re-reads and re-hashes. Acceptable because users typically materialize once and cache via `.activation = <tensor>`.
+- `cleanup()` becomes trivial: no open handles to close (documented).
+
+### Fork L. Replay / validation support on portable bundles
+**Decision**: **`validate_forward_pass` and `validate_saved_activations` are NOT supported on ModelLogs loaded from portable bundles**. Addresses Round-4 finding #1.
+
+Rationale:
+- Preserving live torch callables (`func_applied`) across versions is a losing battle: torch function refactors rename internals, jit wrappers change shape, and `torch._VF` internals drift.
+- Re-binding by `func_name` on load is plausible for most common ops but fragile; making replay "work sometimes" is worse than "never" for a feature used for correctness validation.
+- Users who need replay have two paths:
+  1. Keep the ModelLog in memory and run `validate_forward_pass()` before saving.
+  2. Use plain `pickle.dump(model_log, f)` / `pickle.load(f)` (existing, unchanged). Plain pickle preserves live callables at the cost of cross-version fragility — fine for same-session/same-machine workflows.
+- Portable bundle is for **archival, analysis, and sharing of captured metadata + activations**, not for replay.
+
+Implementation:
+- On `torchlens.load(path)`, loaded ModelLogs carry a private flag `_loaded_from_bundle = True`.
+- `validate_forward_pass()` and `validate_saved_activations()` check this flag first and raise `TorchLensIOError("validate_forward_pass requires live func_applied callables; portable bundles drop them — either run validation before saving or use plain pickle")`.
+- Documented prominently in docstrings + README + `.project-context/knowledge/io_architecture.md`.
+- Removes "validation-ready bundle" language from anywhere in the plan and docs.
+
+Future sprint may add best-effort re-binding by name — out of scope now.
+
+### Fork M. Resave with nested BlobRefs
+**Decision**: `torchlens.save()` rejects ModelLogs that still contain nested `BlobRef` objects (from `lazy=True, materialize_nested=False` mode). User must call `torchlens.rehydrate_nested(model_log)` first. Addresses Round-4 finding #2.
+
+Rationale:
+- The nested refs carry `blob_id` + source bundle + sha256, so we COULD fast-copy them like `LazyActivationRef` — but nested refs live inside arbitrary user containers (dicts, lists, custom structures), and walking them for both drift-verify and path-update is substantially more error-prone than materializing.
+- Expert mode users who opted into `materialize_nested=False` have already accepted "I know what I'm doing"; adding one call before resave is acceptable.
+
+Implementation: at the start of `torchlens.save()`, scan for any lingering `BlobRef` in nested fields. If found, raise `TorchLensIOError("ModelLog contains unmaterialized nested blob references. Call torchlens.rehydrate_nested(model_log) before saving.")` with an actionable message.
+
+---
+
+## 2. Manifest Schema v1 (unchanged from v2)
+
+```json
+{
+  "io_format_version": 1,
+  "torchlens_version": "1.2.0",
+  "torch_version": "2.5.0",
+  "python_version": "3.11.5",
+  "platform": "linux-x86_64",
+  "created_at": "2026-04-23T13:05:00Z",
+  "bundle_format": "directory",
+  "n_layers": 152,
+  "n_activation_blobs": 152,
+  "n_gradient_blobs": 0,
+  "n_auxiliary_blobs": 304,
+  "tensors": [
+    {
+      "blob_id": "0000000001",
+      "kind": "activation",
+      "label": "conv2d_1_1:2",
+      "relative_path": "blobs/0000000001.safetensors",
+      "backend": "safetensors",
+      "shape": [1, 64, 112, 112],
+      "dtype": "float32",
+      "device_at_save": "cuda:0",
+      "layout": "strided",
+      "bytes": 3211264,
+      "sha256": "3f5c..."
+    }
+  ],
+  "unsupported_tensors": [
+    {"label": "sparse_layer:1", "kind": "activation", "reason": "sparse_coo layout not supported this release"}
+  ]
+}
+```
+
+`kind` values: `activation`, `gradient`, `captured_arg`, `child_version`, `rng_state`, `module_arg`, `func_config`.
+
+---
+
+## 3. Public API Surface
+
+### Top-level `torchlens`
+```python
+torchlens.save(
+    model_log: ModelLog,
+    path: str | Path,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,
+    include_captured_args: bool = False,   # CHANGED v4: default False (bundle size + RAM)
+    include_rng_states: bool = False,      # CHANGED v4: default False
+    strict: bool = True,
+    overwrite: bool = False,
+) -> None
+
+torchlens.load(
+    path: str | Path,
+    *,
+    lazy: bool = False,
+    map_location: str | torch.device = "cpu",
+    materialize_nested: bool = True,       # NEW v4: controls nested-tensor eager load
+) -> ModelLog
+
+torchlens.cleanup_tmp(
+    path: str | Path,
+    *,
+    force: bool = False,
+) -> list[Path]
+
+torchlens.rehydrate_nested(             # NEW v4: power-user full materialization
+    model_log: ModelLog,
+    *,
+    map_location: str | torch.device = "cpu",
+) -> None
+```
+
+### On `ModelLog`
+```python
+model_log.save(path, **kwargs)
+ModelLog.load(path, **kwargs)             # classmethod
+
+model_log.to_pandas() -> pd.DataFrame
+model_log.to_csv(path, **kwargs)
+model_log.to_parquet(path, **kwargs)
+model_log.to_json(path, *, orient="records")
+```
+
+### Accessors
+```python
+# existing:
+model_log.layers.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.modules.to_pandas() / ...
+
+# NEW:
+model_log.params.to_pandas() / .to_csv / .to_parquet / .to_json
+model_log.buffers.to_pandas() / ...
+
+# Per-log:
+module_log.to_pandas() / ...
+module_pass_log.to_pandas() / ...         # NEW, reads forward_args_summary
+```
+
+### Streaming at capture time
+```python
+log_forward_pass(
+    ...,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
+)
+```
+
+### LazyActivationRef
+```python
+class LazyActivationRef:
+    blob_id: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device_at_save: str
+    source_bundle_path: Path
+    kind: Literal["activation", "gradient"]
+    expected_sha256: str                   # recorded at save/load for drift detection (Fork H)
+
+    def materialize(self, *, map_location="cpu") -> torch.Tensor:
+        """Open, read, verify sha256, close (Fork K — no long-lived handles)."""
+```
+
+### Resave-lazy semantics
+```python
+model_log = torchlens.load("a/", lazy=True)
+model_log.save("b/")
+# If source manifest sha256 matches the one captured at load: shutil.copy blobs from a/ to b/.
+# If source manifest differs from recorded digest OR source deleted: raise TorchLensIOError
+#   "source bundle at a/ has changed or is gone; call .materialize_activation() on all layers and retry."
+# No silent drift.
+```
+
+---
+
+## 4. Spec Decomposition
+
+All specs must pass: `ruff check . --fix && mypy torchlens/ && pytest tests/ -m smoke -x --tb=short`.
+
+### Group 1 — Foundations (parallel-safe)
+
+**IO-S1. Pickle hardening: scrub policy + rehydrate loader + PORTABLE_STATE_SPEC lint + version tagging + accessor reconstruction**
+- `torchlens/_io/__init__.py`: `IO_FORMAT_VERSION=1`, `TorchLensIOError`, `BlobRef` NamedTuple, `FieldPolicy` enum (keep/blob/blob_recursive/drop/stringify/weakref_strip).
+- Add `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attr on ModelLog, LayerPassLog, LayerLog, ModuleLog, ModulePassLog, ParamLog, BufferLog, FuncCallLocation per Fork A table.
+- `torchlens/_io/scrub.py`: `scrub_for_save(model_log, **include_flags) -> (scrubbed_state, list[BlobSpec])`. Driven purely by `PORTABLE_STATE_SPEC`.
+- `torchlens/_io/rehydrate.py`: `rehydrate_model_log(scrubbed_state, manifest, bundle_path, *, lazy, map_location, materialize_nested)`. Single entry point for all blob materialization. `__setstate__` only does default-fill + weakref restore; never touches disk.
+- `torchlens/_io/accessor_rebuild.py`: shared helper extracted from `postprocess/finalization.py:671-681`.
+- Expand `__setstate__` on ModelLog, LayerPassLog, LayerLog, ParamLog, BufferLog, ModuleLog, ModulePassLog with version-aware default-fill.
+- Files: `torchlens/_io/__init__.py`, `scrub.py`, `rehydrate.py`, `accessor_rebuild.py` (all NEW); `torchlens/data_classes/{model_log,layer_pass_log,layer_log,param_log,buffer_log,module_log,func_call_location}.py`; `torchlens/postprocess/finalization.py` (extract helper).
+- Tests:
+  - `tests/test_io_pickle.py` (NEW) — scrub round-trip; accessor rebuild; default-fill from forged older pickle; version hard-fail on newer; plain-pickle unchanged.
+  - `tests/test_io_scrub_policy.py` (NEW) — **PORTABLE_STATE_SPEC completeness lint**: for each class, instantiate a canonical live example, walk `vars(instance)`, assert every attribute name appears in `PORTABLE_STATE_SPEC`. Fails CI if any new attribute added without a policy entry. Moved from S7 to S1 per Round-3 finding #8.
+- Size: **~440 LoC** (up from 400 due to PORTABLE_STATE_SPEC surfaces + rehydrate loader separation).
+
+**IO-S2. ParamAccessor / BufferAccessor / ModulePassLog.to_pandas() + forward_args_summary + forward_kwargs_summary**
+- New FIELD_ORDER tuples in `constants.py`.
+- Recursive summary formatter in `torchlens/data_classes/_summary.py` (new) producing strings per Fork C rules.
+- `ModulePassLog.forward_args_summary` and `forward_kwargs_summary` fields populated in `_build_module_logs` BEFORE the existing GC step.
+- New `to_pandas()` methods on ParamAccessor, BufferAccessor, ModulePassLog.
+- Files: `torchlens/data_classes/{param_log,buffer_log,module_log,_summary}.py`, `torchlens/constants.py`, `torchlens/postprocess/finalization.py` (add summary capture before GC).
+- Tests: `tests/test_io_pandas.py` (NEW) — schema shape; empty accessor; summary correctness with mixed tensor/primitive/list/dict/kwargs args; summary survives GC; both `_args_summary` and `_kwargs_summary` present.
+- Size: **~280 LoC** (up from 240; adds kwargs summary + recursive formatter).
+
+### Group 2 — Exports + bundle (serial: S3 after S2; S4 after S1)
+
+**IO-S3. Export wrappers: to_csv / to_parquet / to_json on all seven DataFrame producers**
+- Wrappers on ModelLog, LayerAccessor, ModuleAccessor, ModuleLog, ModulePassLog, ParamAccessor, BufferAccessor.
+- `pyarrow` optional via `pip install torchlens[io]`; clear `ImportError` if missing.
+- Files: `torchlens/data_classes/{interface,layer_log,module_log,param_log,buffer_log}.py`, `pyproject.toml`.
+- Tests: `tests/test_io_export.py` — round-trip + schema stability + ImportError on parquet.
+- Size: **~220 LoC**.
+
+**IO-S4. Bundle save/load (eager post-hoc) + manifest v1 + integrity + exception contract**
+- `torchlens/_io/bundle.py`: `save` (post-hoc) and `load`. Integrates scrub (S1), tensor_policy (below), and manifest.
+- `torchlens/_io/manifest.py`: schema class, sha256 hashing, PEP 440 version parsing, policy enforcement.
+- `torchlens/_io/tensor_policy.py`: implements supported-tensor matrix; returns `(Ok | SkipReason | Error)` per tensor; respects `strict` flag.
+- All bundle errors wrap in `TorchLensIOError` (Fork G).
+- ModelLog gets `.save()` / `.load()` sugar; `torchlens` exports `save`, `load`, `cleanup_tmp`.
+- Files: `torchlens/_io/{bundle,manifest,tensor_policy}.py` (NEW); `torchlens/data_classes/model_log.py`; `torchlens/__init__.py`; `torchlens/user_funcs.py`.
+- Tests: `tests/test_io_bundle.py` (NEW) — eager round-trip; strict default raises on sparse; `strict=False` skips + records; all 12 version-policy rows; corrupt manifest / missing blob / truncated safetensors / checksum tamper all raise `TorchLensIOError`; overwrite semantics; non-tensor postfunc rejected at save; include flags combos.
+- Size: **~480 LoC**.
+
+### Group 3 — Streaming + lazy (serial)
+
+**IO-S5. Streaming-save during forward pass + postprocess steps 19+20 + streaming-strict + cleanup_tmp + symlink rejection**
+- `torchlens/_io/streaming.py`: `BundleStreamWriter`. Open `<path>.tmp.<uuid>/blobs/` (reject if path exists as symlink), receive `(blob_id, tensor)` synchronously, consult `tensor_policy` per tensor (streaming is **always strict** — Round-3 finding #6), write safetensors. On `finalize()`: compute sha256 per blob, write manifest, write scrubbed `metadata.pkl`, rename temp dir → final path. Returns set of blob ids + final path for ref-patching.
+- Instrument `LayerPassLog.save_tensor_data()` with writer callout; gated to exhaustive-pass call site only (`capture/output_tensors.py:866-900`).
+- **Step 19 `_finalize_streamed_bundle`** registered in `postprocess/__init__.py`: always runs if writer present. Handles manifest write, scrubbed metadata.pkl write, atomic rename.
+- **Step 20 `_evict_streamed_activations`** registered after step 19: runs only if writer present AND `keep_activations_in_memory=False`. Patches `LazyActivationRef` with final (post-rename) path.
+- Non-tensor postfunc guard: writer verifies first received tensor is `torch.Tensor`; if not, abort, mark `.tmp.<uuid>/PARTIAL`, raise `TorchLensIOError` (Fork D rule).
+- Symlink rejection: writer refuses to open if `<path>` exists as a symlink; load side already covered by S4 + Fork J.
+- `torchlens.cleanup_tmp(path, force=False)` utility (rejects symlink temp dirs — Round-3 finding #7).
+- Files: `torchlens/_io/streaming.py` (NEW), `torchlens/_io/bundle.py`, `torchlens/data_classes/{layer_pass_log,model_log}.py`, `torchlens/user_funcs.py`, `torchlens/postprocess/{__init__,finalization}.py`.
+- Tests: `tests/test_io_streaming.py` (NEW) — blobs written during pass (verify timestamps); step 19 always runs and bundle is finalized on keep_activations_in_memory=True; step 20 gated correctly; mid-pass exception leaves PARTIAL; non-tensor postfunc aborts; sparse/meta/nested tensor mid-stream raises `TorchLensIOError` with PARTIAL preserved; lazy refs point to final path not temp; cleanup_tmp ignores symlinks; `activation_sink` callable path.
+- Size: **~440 LoC** (up from 400 due to step split + strictness + symlink rejection).
+
+**IO-S6. Lazy activation references + two-level drift guard + lazy-resave fast-copy + rehydrate_nested + no-shared-handles**
+- Flesh out `torchlens/_io/lazy.py`: `LazyActivationRef(blob_id, shape, dtype, device_at_save, source_bundle_path, kind, expected_sha256)`; `materialize(map_location="cpu")` opens safetensors fresh, reads, verifies sha256 against `expected_sha256`, closes, returns tensor (Fork K: no shared readers).
+- `LayerPassLog.materialize_activation(map_location="cpu") -> Tensor` (and `.materialize_gradient()`).
+- `torchlens.rehydrate_nested(model_log, map_location="cpu")`: power-user function for when user did `lazy=True, materialize_nested=False`. Walks nested containers, replaces any remaining `BlobRef` with real tensors.
+- ModelLog records `_source_bundle_manifest_sha256` at load time.
+- Lazy-resave fast-copy path in `torchlens/_io/bundle.py::save` (Fork H two-layer):
+  1. Verify `sha256(source/manifest.json) == _source_bundle_manifest_sha256`; else raise.
+  2. For each `LazyActivationRef` about to be copied: verify `sha256(source/blobs/<blob_id>.safetensors) == ref.expected_sha256`; else raise.
+  3. Only then `shutil.copy` to new bundle.
+- Cleanup: `ModelLog.cleanup()` documents "no long-lived handles to close" (Fork K).
+- Files: `torchlens/_io/lazy.py` (EXPAND), `torchlens/data_classes/{layer_pass_log,cleanup}.py`, `torchlens/_io/bundle.py`, `torchlens/_io/rehydrate.py`, `torchlens/validation/invariants.py` (clear-error path for lazy-only logs).
+- Tests: `tests/test_io_lazy.py` (NEW) — shape/dtype accessible without disk read; materialize bit-exact vs eager; map_location honored; manifest-level drift (mutate manifest) raises; **blob-level drift (mutate a single blob file, leave manifest intact) also raises** (Round-3 finding #4); fast-copy on clean source; validation API raises clearly on lazy-only; `rehydrate_nested` populates nested BlobRefs; no open file handles leak after materialize.
+- Size: **~400 LoC** (up from 360 due to per-blob drift + rehydrate_nested + expected_sha256 field).
+
+### Group 4 — Integration tests + docs (parallel)
+
+**IO-S7. Integration + corruption regression suite**
+- End-to-end: capture → stream-save → lazy-load → materialize → to_parquet → re-load.
+- Corruption battery: truncated safetensors, missing blob, corrupt pickle, tampered manifest, stale counts, unknown extra files, checksum mismatch. Each must raise `TorchLensIOError` with specific message.
+- Forged older-format pickle loads with `DeprecationWarning`.
+- DataParallel/DDP sanity skip (torchlens already `warn_parallel`; streaming inherits).
+- Scrub-policy lint test: iterate all `FIELD_ORDER` columns, assert each has explicit policy entry.
+- Files: `tests/test_io_integration.py` (NEW), `tests/test_io_plain_pickle.py` (NEW), minor updates to `test_save_new_activations.py`.
+- Size: **~380 LoC**.
+
+**IO-S8. Docs**
+- Docstrings on every new public API with copy-pasteable examples.
+- README "Save and Load" section.
+- `.project-context/knowledge/io_architecture.md` (NEW): bundle layout, manifest schema, tensor matrix, version policy, operational-shape note (Fork I).
+- Files: `torchlens/_io/__init__.py`, `torchlens/__init__.py`, `torchlens/data_classes/model_log.py`, `README.md`, `.project-context/knowledge/io_architecture.md` (NEW).
+- Size: **~160 LoC**.
+
+Total: ~2640 LoC (up from 2460 in v2).
+
+---
+
+## 5. Spec Dependency Graph
+
+```
+S1 ─┬─> S4 ─┬─> S5 ──> S6 ──> S7
+    │       │
+S2 ─┴─> S3 ─┘                S8 (docs, parallel with S7)
+```
+
+---
+
+## 6. Risk Register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Unsupported tensor layouts | strict=True default raises; strict=False opt-in records in manifest. |
+| R2 | Scrub misses a new field added in a future release | S7 lint test enumerates FIELD_ORDER; CI fails if new field lacks policy entry. |
+| R3 | Disk-full / crash mid-stream | `.tmp.<uuid>/PARTIAL` sentinel; `cleanup_tmp` utility. |
+| R4 | Lazy refs inside nested containers confuse validation | Nested containers eager-materialized by default (`materialize_nested=True`); expert `materialize_nested=False` mode requires `rehydrate_nested()` before resave (Fork M). |
+| R5 | Lazy cleanup vs live safetensors handles | No long-lived handles: `materialize()` opens/reads/closes per call (Fork K). `cleanup()` is trivial. |
+| R6 | Format drift in N+1 | `io_format_version` + migration helpers (S1). |
+| R7 | CUDA bundle on CPU host | `map_location="cpu"` default; safetensors handles it. |
+| R8 | Streaming writer blocks | Synchronous by design; documented. |
+| R9 | pyarrow install weight | Optional via extras. |
+| R10 | Many small files (directory format) | Documented tradeoff (Fork I); deferred to future sprint. |
+| R11 | NFS/Windows rename edge cases | Documented: local-same-fs best-effort. |
+| R12 | Source bundle mutated between lazy load and resave | Manifest sha256 check on resave; raise clearly. |
+| R13 | DataParallel/DDP multiple capture | Torchlens is single-process; inherit existing warning. |
+| R14 | Exception handling ambiguity | All bundle errors wrap `TorchLensIOError` (Fork G). |
+| R15 | User expects `validate_forward_pass` on portable-loaded ModelLog | Hard-raise `TorchLensIOError` on portable-loaded logs (Fork L); docstring + README + tests. |
+| R16 | Resave with nested BlobRefs silently corrupts | Hard-raise `TorchLensIOError` telling user to call `rehydrate_nested()` first (Fork M). |
+
+---
+
+## 7. Execution Plan
+
+| Round | Specs | Gate |
+|-------|-------|------|
+| 1 | S1 ‖ S2 | Pickle scrub round-trip green; new pandas schemas green. |
+| 2 | S3 (after S2) ‖ S4 (after S1) | All export formats green; bundle round-trip green; version policy table tested. |
+| 3 | S5 (after S4) | Streaming + step 19 green; postprocess sees tensors; lazy refs point at final path. |
+| 4 | S6 (after S5) | Lazy load + materialize bit-exact; source drift detected; resave fast-copy. |
+| 5 | S7 ‖ S8 | Integration corruption battery green; docs complete. |
+| 6 | Phase 5 dual review (me + `/codex:review`). |
+
+---
+
+## 8. Stop-and-Ask Triggers
+
+- End of this plan revision — **NOW**
+- Any public API signature change beyond additions
+- Any bump of `io_format_version` in the future
+- End of Phase 5 (which review findings to fix)
+
+---
+
+## 9. Success Criteria (binary)
+
+- [ ] `torchlens.save(model_log, path)` + `torchlens.load(path)` round-trip everything on the supported-tensor matrix
+- [ ] Six log-level DataFrames + `.to_csv/.to_parquet/.to_json` on all seven producers
+- [ ] `log_forward_pass(..., save_activations_to=path)` streams during pass; postprocess unaffected
+- [ ] `keep_activations_in_memory=False` evicts post-pass; lazy refs point to final (post-rename) path
+- [ ] Lazy load preserves metadata access without disk read; `materialize_activation()` bit-exact
+- [ ] Source-drift detection works
+- [ ] All 14 version-policy rows tested
+- [ ] All bundle errors raise `TorchLensIOError`
+- [ ] Scrub-policy lint passes
+- [ ] Plain pickle still works with deprecation warning on pre-sprint pickles only
+- [ ] `pytest tests/ -m "not slow"` green
+- [ ] `ruff check . && mypy torchlens/` green
+
+---
+
+## 10. Change Log vs Round 4 (addresses all 4 findings)
+
+| Finding | Severity | Resolution |
+|---------|----------|-----------|
+| R4-1 Validation broken on portable bundles because func_applied is dropped | HIGH | New Fork L: explicitly declare `validate_forward_pass` / `validate_saved_activations` unsupported on portable-loaded ModelLogs. `_loaded_from_bundle` flag + hard-raise with actionable message. Removed all "validation-ready bundle" language. Users who need replay keep logs in memory or use plain pickle. |
+| R4-2 No resave contract for `materialize_nested=False` mode | MEDIUM | New Fork M: `torchlens.save()` pre-scans for nested `BlobRef`; raises `TorchLensIOError` with a "call `rehydrate_nested()` first" hint if any found. |
+| R4-3 Step-19/20 split left keep-in-memory path un-disk-backed | MEDIUM | Fork D rewritten: step 19 ALWAYS attaches `.activation_ref` (independent of `keep_activations_in_memory`). Step 20 only nulls `.activation`. Returned log is genuinely disk-backed in both modes. |
+| R4-4 Public API sketch + risk register lagged v4 design | LOW | Synced `LazyActivationRef` sketch to include `expected_sha256`. Risk register R4/R5 updated to reflect Fork K/M. Added R15/R16 for new Fork L/M behaviors. |
+
+## Change Log vs Round 3 (see plan_v4.md for detailed Round-3 resolutions)
+
+All 9 Round-3 findings were resolved in v4 and verified by the Round-4 reviewer. Summary retained in `review_round_4.md`.

--- a/.project-context/plans/io-sprint/review_round_1.md
+++ b/.project-context/plans/io-sprint/review_round_1.md
@@ -1,0 +1,124 @@
+# Adversarial Review — I/O Sprint Plan Round 1
+
+## Findings
+
+1. **CRITICAL — The primary format still depends on pickling objects that do not round-trip today.**
+Location: Fork A lines 13-18, Fork E lines 53-60, IO-S1 lines 145-154, IO-S4 lines 172-180.
+Failure scenario: A user logs a normal `nn.Sequential(nn.Linear(...), nn.ReLU(), nn.Linear(...))` model and calls `torchlens.save()`. `metadata.pkl` still contains `func_applied` callables and other live Python objects. The current tree already throws `PicklingError` on common built-in ops like `linear`; the bundle dies before tensor sidecars matter. The plan claims "Pickle handles nested Python" when the audits already showed the opposite.
+Recommendation: Rewrite IO-S1 and IO-S4. Stop treating raw pickle of live `ModelLog` state as the archival contract. Either strip/normalize every non-stable callable/object field before pickling, or replace `metadata.pkl` with a schema-owned state dict. Edit Fork A lines 13-18 and IO-S1 lines 148-153 to name the exact fields that must be scrubbed: `func_applied`, `activation_postfunc`, `_param_ref`, `FuncCallLocation` runtime objects, arbitrary `extra_attributes`, and any nested tensors in captured args/kwargs.
+
+2. **CRITICAL — S5 breaks the capture pipeline by replacing activations with lazy refs too early.**
+Location: Fork D lines 46-51, IO-S5 lines 184-190.
+Failure scenario: User runs `log_forward_pass(..., save_activations_to=..., keep_activations_in_memory=False)`. `save_tensor_data()` swaps `self.activation` to `LazyActivationRef` during the forward pass. Postprocess immediately runs after forward and still expects real tensors for undecoration, output-node copying, buffer deduplication, equality checks, and validation-related metadata. The log crashes before it is returned.
+Recommendation: Edit IO-S5 lines 187-190. Do not evict inside `save_tensor_data()`. Keep real tensors through postprocess, then evict in a postprocess step after all tensor-consuming logic is done. This needs either a new spec or an explicit S5/S6 hook point after `_set_pass_finished`.
+
+3. **CRITICAL — Gradients are promised in the format, but the sprint never designs gradient streaming or backward-failure semantics.**
+Location: Bundle layout lines 24-27, public API lines 68-70, IO-S4 lines 172-180, IO-S5 lines 184-190.
+Failure scenario: User calls `torchlens.save(..., include_gradients=True)` or expects `<layer>.grad.safetensors` from streaming. Gradients do not exist until backward hooks fire. S5 only instruments `save_tensor_data()` in forward, not `log_tensor_grad()`. If backward fails halfway through, the plan has no temp-dir lifecycle, completeness rule, or manifest state for partial gradient capture.
+Recommendation: Edit IO-S4 and IO-S5. Either cut gradient sidecars from Phase 4 entirely or add a separate gradient-write path in `log_tensor_grad()` with explicit bundle states for "forward complete / backward incomplete / gradients absent". The current text is lying.
+
+4. **CRITICAL — `.tlens` as `.tar.gz` is incompatible with the plan’s lazy-load story.**
+Location: Fork A line 31, Fork B lines 33-39, public API lines 68-78, IO-S4 lines 177-180.
+Failure scenario: User saves `model.tlens` and later calls `torchlens.load("model.tlens", lazy=True)`. A gzipped tarball is not random-access friendly for thousands of tensor sidecars. Either the loader silently extracts the whole archive somewhere, defeating lazy loading, or it materializes everything eagerly, contradicting the default-lazy decision.
+Recommendation: Edit Fork A line 31 and IO-S4 lines 177-180. Either drop `.tar.gz` from this sprint, or define hard semantics now: `.tlens` loads eagerly only, or `.tlens` is an uncompressed archive with a real index. Do not keep the current hand-wave.
+
+5. **CRITICAL — The filename scheme is broken on Windows and fragile everywhere else.**
+Location: Bundle layout lines 24-27, Fork D line 49, IO-S5 line 188.
+Failure scenario: Pass-qualified labels use `:` today (`conv2d_1_1:2`). The plan literally names files `<layer_label_pass>.safetensors`. That is an invalid filename on Windows. Long labels, mixed casing, and any future non-filesystem-safe characters also create collisions or path-length failures.
+Recommendation: Edit Fork A lines 20-29 and IO-S5 line 188. Manifest must own a stable opaque blob id per tensor. Filenames cannot be raw layer labels. Put the human-readable label in the manifest, not in the path.
+
+6. **CRITICAL — `activation_postfunc` and other non-tensor activation payloads are ignored, but they blow up this design.**
+Location: Fork D lines 49-51, IO-S5 line 188, IO-S6 lines 193-199, Risk R1 lines 226-226.
+Failure scenario: User passes `activation_postfunc=lambda t: t.cpu().numpy()` or any custom object transform. Current TorchLens already allows this path to reach postprocess in dangerous ways. The proposed writer assumes `self.activation` is still a tensor after postfunc and tries to sidecar it. `LazyActivationRef.materialize()` also assumes tensor-only storage. Non-tensor activations become unsaveable, unloadable garbage.
+Recommendation: Edit Fork D and IO-S5/IO-S6. Either explicitly forbid non-tensor `activation_postfunc` when save/load/streaming is enabled and enforce it early, or add a second serialization lane for non-tensor activation payloads. Right now the spec pretends this problem does not exist.
+
+7. **HIGH — The lazy API is contradictory and will be miserable in real user code.**
+Location: LazyActivationRef lines 113-128, LayerPassLog helpers lines 130-135, IO-S6 lines 193-199.
+Failure scenario: The plan says `.activation` returns a `LazyActivationRef`, then says accessing `.activation` materializes on read, then says users must call `materialize()`. Pick one. Common workflows like `layer.activation.cpu().numpy()`, `plt.imshow(layer.activation[0])`, `torch.equal(layer.activation, other)`, and loops over activation values either break or materialize implicitly in invisible, expensive ways. Existing validation code also directly assumes `.activation` is a tensor.
+Recommendation: Edit lines 121-125, 132-135, and IO-S6 lines 195-197. Make the API honest: `.activation` remains a tensor-or-None field, and lazy loads use a separate accessor like `.activation_ref` plus `.materialize_activation()`. Do not hide I/O behind magic attribute behavior.
+
+8. **HIGH — Default-lazy loaded logs will break existing TorchLens methods that assume tensor activations.**
+Location: Fork B lines 33-39, LayerPassLog helpers lines 130-135, IO-S6 lines 193-199.
+Failure scenario: User loads a bundle and then calls `validate_saved_activations`, `validate_forward_pass`, string repr helpers, or anything else that reads `layer.activation.shape`, `.dtype`, `.numel()`, `.detach()`, or `torch.equal(...)`. Those call sites currently assume actual tensors. The plan does not audit or gate any of those methods against lazy refs.
+Recommendation: Edit Fork B and IO-S6. Either make lazy loading opt-in for Phase 4 or add an explicit compatibility audit spec that enumerates which existing APIs still work on lazy-loaded logs and which raise structured errors. The default cannot change silently while the rest of the object graph still expects eager tensors.
+
+9. **HIGH — The safetensors fallback story destroys the stated guarantees and creates a mixed-format mess the loader cannot reason about.**
+Location: Fork A lines 13-18, public API lines 68-77, IO-S4 lines 172-180, Risk R1 lines 226-226, Risk R7 lines 232-232.
+Failure scenario: Lean-install user without `safetensors` saves a bundle. Some blobs are written with `torch.save`, others maybe with safetensors, and `LazyActivationRef.materialize()` in S6 is specified only for safetensors. Device mapping semantics now differ by backend. Safety claims differ by backend. Version stability differs by backend. The manifest schema has nowhere to record this cleanly.
+Recommendation: Edit IO-S4 and IO-S6. Either make `safetensors` required for the archival bundle path, or explicitly define a per-blob backend field plus load semantics for each backend. "Warn once and fall back" is not a format design.
+
+10. **HIGH — The manifest is too weak to support integrity, lazy loading, or mixed backends.**
+Location: Fork A lines 17-18 and 20-29, IO-S4 lines 175-180.
+Failure scenario: One sidecar is truncated, another is missing, a third was written with `torch.save`, and the bundle was produced on a different torch build. The manifest only stores counts and versions. There is no per-blob index, checksum, storage backend, shape, dtype, layout, or byte-size entry. The loader cannot verify anything and lazy refs have no authoritative source of truth.
+Recommendation: Rewrite IO-S4 line 175. Manifest v1 needs a `tensors` table keyed by stable blob id with label, kind, backend, relative path, shape, dtype, device-at-save, layout, checksum, and maybe storage size. Without that, corruption handling is fiction.
+
+11. **HIGH — Atomicity is overstated and concurrent-writer hazards are unaddressed.**
+Location: Fork D lines 51-51, IO-S5 lines 186-190, Risk R3 lines 228-228.
+Failure scenario: Two processes save to the same path. Both use `<path>.tmp`. They stomp each other. On NFS or SMB the final rename is not the nice local-rename guarantee the plan assumes. On Windows, directory renames can fail if another process has a handle open. A crash after writing files but before manifest fsync exposes a "successful" rename with a corrupt bundle.
+Recommendation: Edit Fork D and IO-S5. Use unique temp dirs per writer, lock or fail fast on existing final path, and stop calling the operation atomic across filesystems. If you keep the rename story, scope it to local same-filesystem best-effort semantics and add fsync requirements.
+
+12. **HIGH — Selective-layer streaming inherits a known-bad fast path, and the plan pretends that is fine.**
+Location: Fork D lines 47-49, IO-S5 lines 184-190, Execution Plan lines 243-246.
+Failure scenario: User streams only selected layers on AlexNet or ResNet-like models. TorchLens already has tests documenting `save_new_activations()` failures on real models due to identity-op counter misalignment. The plan routes selective saves through exactly that machinery and calls it "single instrumentation point" as if the reliability issue vanished.
+Recommendation: Edit Fork D and IO-S5. Either mark selective-layer streaming out of scope for this sprint or add a prerequisite spec to retire the known `save_new_activations()` failures before relying on that path for I/O.
+
+13. **HIGH — The unsupported-tensor story is hand-waving, not design.**
+Location: Risk R1 line 226, Risk R7 line 232, IO-S4 lines 174-180, IO-S6 lines 194-199.
+Failure scenario: User captures sparse COO, sparse CSR, quantized, meta, nested tensor, tensor subclass, DTensor, FSDP-local shard, complex dtype, `bfloat16`, `float16`, or a non-contiguous tensor. Safetensors only handles dense contiguous tensors. `torch.save` fallback for a DTensor or shard preserves a local implementation detail, not a portable activation. Meta tensors have no data to store. CPU-only reload of CUDA-origin half/bfloat sidecars is not even specified for the mixed-backend case.
+Recommendation: Edit Risk R1, IO-S4, and IO-S6. Add an explicit supported-tensor matrix now. For unsupported layouts, either fail fast with a precise error or define a portable coercion policy. "Fallback to torch.save" is not enough for distributed or layout-rich tensors.
+
+14. **HIGH — Backward compatibility for existing `pickle.dump(model_log)` users is not actually planned.**
+Location: Fork E lines 53-60, public API lines 68-85, IO-S1 lines 145-154.
+Failure scenario: Existing users directly `pickle.dump(model_log)` and later `pickle.load(...)`. After this sprint, the canonical save path becomes a bundle, lazy refs enter the object graph, and `__setstate__` starts default-filling versioned fields. The plan never states whether raw pickle remains supported, deprecated, or explicitly limited. Users get silent behavior drift instead of a migration path.
+Recommendation: Edit Fork E and IO-S1. State the compatibility contract for plain pickle in one sentence that is not evasive. Either keep it supported and test it, or deprecate it with warnings and a concrete migration note in S8.
+
+15. **HIGH — Version skew is only recorded, not handled.**
+Location: Fork E lines 53-60, IO-S4 line 175, Risk R6 lines 231-231.
+Failure scenario: Bundle saved on Python 3.13 / torch 2.x / TorchLens N, then loaded on Python 3.10 / torch 1.x / TorchLens N+1. The manifest stores version strings, but the plan only promises a warning for newer TorchLens. There is no rule for incompatible torch majors, missing dtypes, changed RNG state formats, or Python pickle opcode incompatibility.
+Recommendation: Edit Fork E and IO-S4. Define load policy: which version mismatches warn, which hard-fail before opening `metadata.pkl`, and which are unsupported. Without this, the manifest is decorative.
+
+16. **HIGH — The default directory bundle is going to feel absurd for tiny models and punishing for large ones.**
+Location: Bundle layout lines 20-31, Fork D lines 49-51, Risk R10 lines 235-235.
+Failure scenario: Tiny model with three saved tensors produces a directory tree, manifest, pickle, and activation folder instead of one obvious file. Large model with tens of thousands of passes produces tens of thousands of tiny files and murders inode counts, stat overhead, backup tooling, and network filesystems. The plan chooses the worst operational shape at both ends.
+Recommendation: Edit Fork A lines 20-31 and public API lines 68-72. Either make single-file the default for post-hoc save and directory mode opt-in for streaming, or shard activations into chunk files instead of one file per tensor.
+
+17. **HIGH — Corruption handling is almost entirely missing from the specs.**
+Location: IO-S4 tests line 179, IO-S7 lines 204-210, Risk R3 lines 228-228.
+Failure scenario: `metadata.pkl` is corrupt, one activation file is missing, tar extraction is truncated, manifest counts do not match actual files, checksum mismatches, or disk fills after 70% of files are written. The test plan only mentions manifest mismatch and a monkeypatched disk-full case. That is nowhere near enough for a format that claims symmetric loading.
+Recommendation: Expand IO-S4 and IO-S7. Add tests for missing blob files, truncated safetensors, corrupted pickle, stale manifest counts, unexpected extra files, and partial tar archives. Also specify the exact exception types.
+
+18. **HIGH — `frames/` is in the bundle layout but nowhere in the sprint specs.**
+Location: Bundle layout lines 28-29, IO-S4 lines 172-180, IO-S8 lines 212-218.
+Failure scenario: User enables `save_source_context=True` and saves a bundle. The directory format advertises `frames/`, but no spec defines what goes there, how it maps back to `FuncCallLocation`, what gets redacted, or how it is loaded. This is a format boundary leak disguised as a comment.
+Recommendation: Edit Fork A lines 20-29 and add a dedicated subtask under IO-S4 or a new spec. Either define `frames/` concretely or remove it from the layout until it exists.
+
+19. **MEDIUM — The sprint goal says “comprehensive, frictionless I/O for ModelLog and its children,” but module-pass I/O is still missing.**
+Location: Goal line 4, Fork C lines 41-44, accessors lines 100-110, IO-S2 lines 156-161.
+Failure scenario: User wants one row per module pass, including `forward_args`/`forward_kwargs` or pass-level nesting structure. The plan only covers pass-level layer logs, aggregate layers, modules, params, and buffers. `ModulePassLog` remains a blind spot even though it is a first-class child object.
+Recommendation: Edit Fork C and either explicitly exclude `ModulePassLog` from the sprint goal or add a spec for module-pass export. The current wording overpromises.
+
+20. **MEDIUM — Several specs are not actually independent, and the LoC estimates are fantasy.**
+Location: Group notes lines 141-141, IO-S1 lines 145-154, IO-S4 lines 172-180, IO-S5 lines 184-191, Execution Plan lines 243-246.
+Failure scenario: S1 needs schema decisions from S4. S5 depends on lazy object semantics from S6 and on bundle manifest/index design from S4. S7 depends on real corruption semantics not defined anywhere else. Meanwhile the LoC estimates for fixing pickle hardening, designing a manifest, supporting tar, streaming, fallback backends, and tests are far below the actual blast radius.
+Recommendation: Edit Section 3 and Section 5. Merge S4/S6 design-wise, split corruption/integrity into its own spec, and stop calling S1/S2 "parallel-safe" without acknowledging shared constants, accessors, and loader helpers.
+
+21. **MEDIUM — The plan invents `compression=\"zstd\"` without a real backend contract.**
+Location: public API lines 68-73.
+Failure scenario: User sets `compression="zstd"` expecting tensor compression. Safetensors does not expose a tensor-compression knob in the documented torch API. Either the argument is ignored, silently reinterpreted as tar compression, or causes a backend-specific branch that is nowhere specified.
+Recommendation: Edit public API lines 68-73. Remove `compression` from Phase 4 unless there is a concrete implementation and backend contract. Fake knobs are worse than no knobs.
+
+22. **MEDIUM — The risk register mentions `torchlens.cleanup_tmp(path)`, but no spec adds it.**
+Location: Risk R3 line 228, IO-S5 lines 184-190, IO-S8 lines 212-218.
+Failure scenario: Disk fills mid-stream, user gets told to run `torchlens.cleanup_tmp(path)`, and that function does not exist because no spec owns it. This is sloppy plan leakage.
+Recommendation: Edit IO-S5 or IO-S8 to add the utility explicitly, or delete it from Risk R3.
+
+23. **MEDIUM — Re-saving a lazily loaded bundle is undefined and likely pathological.**
+Location: public API lines 68-85, IO-S4 lines 172-180, IO-S6 lines 193-199.
+Failure scenario: User loads a lazy bundle and immediately calls `model_log.save(new_path)`. Does TorchLens copy existing sidecars, materialize everything, or write new blobs only for materialized activations while silently dropping the rest? The plan does not say. That is not an obscure workflow; it is a standard archive-copy/edit/archive flow.
+Recommendation: Edit IO-S4 and IO-S6. Define save-from-lazy semantics now, or reject it explicitly with a hard error in Phase 4.
+
+## Verdict
+
+**RED**
+
+This plan is not ready. The core design still relies on broken pickle assumptions, the streaming eviction point is wrong, the gradient story is incomplete, the archive form contradicts lazy loading, and the manifest is too weak to support integrity or mixed backends. This is not a punch-list cleanup. It needs structural redesign before Phase 4.

--- a/.project-context/plans/io-sprint/review_round_2.md
+++ b/.project-context/plans/io-sprint/review_round_2.md
@@ -1,0 +1,127 @@
+# Adversarial Review — I/O Sprint Plan Round 2
+
+## Verdict
+
+**RED**
+
+Round 2 is materially better than Round 1, but it does **not** actually resolve all 23 prior findings. The largest remaining gap is the bundle contract for **non-activation tensor fields**: the plan now says it will scrub tensors out of `captured_args`, `children_tensor_versions`, RNG state, and module forward args, but it never defines how those blobs are rehydrated or eagerly materialized on load. That is still a format-design hole, not an implementation detail.
+
+Several revisions also introduced new ambiguity: the new eviction step has no exact placement in the current 18-step postprocess pipeline, lazy refs appear to be created before the temp-dir rename, the default save policy still silently drops unsupported tensors, and the new `pack_bundle` utility is underspecified.
+
+## Round 1 Verification
+
+| # | Orig Sev | Status | Assessment |
+|---|----------|--------|------------|
+| 1 | CRITICAL | **PARTIAL** | Scrubbing is broader, but the plan still lacks a rehydration/materialization contract for nested tensor fields and still omits some arbitrary-object fields. See Findings 1-2. |
+| 2 | CRITICAL | **PARTIAL** | Eviction no longer happens in `save_tensor_data()`, but the new postprocess hook still has no concrete step number or state-transition contract. See Finding 3. |
+| 3 | CRITICAL | **RESOLVED** | Gradient streaming was cut; post-hoc gradient bundling is now the stated scope. |
+| 4 | CRITICAL | **RESOLVED** | Tar/tar.gz was removed from the core save/load path. |
+| 5 | CRITICAL | **RESOLVED** | Opaque blob ids replace raw layer labels in filenames. |
+| 6 | CRITICAL | **PARTIAL** | Non-tensor `activation_postfunc` is only addressed for streaming, and even there the enforcement point is internally inconsistent. See Finding 4. |
+| 7 | HIGH | **RESOLVED** | `.activation` vs `.activation_ref` split is now coherent. |
+| 8 | HIGH | **PARTIAL** | Default-lazy load still changes the default behavior of loaded logs while the compatibility audit is narrow. See Findings 1 and 5. |
+| 9 | HIGH | **RESOLVED** | `safetensors` is now required for the bundle path. |
+| 10 | HIGH | **PARTIAL** | The manifest is much stronger, but checksum scope and some index semantics are still underspecified. See Finding 7. |
+| 11 | HIGH | **RESOLVED** | Temp-dir uniqueness and local-filesystem atomicity scope are now stated. |
+| 12 | HIGH | **RESOLVED** | Streaming is restricted to the exhaustive pass; the known-bad fast path is no longer reused. |
+| 13 | HIGH | **PARTIAL** | The supported-tensor matrix exists, but the default policy still silently emits partial bundles. See Finding 6. |
+| 14 | HIGH | **PARTIAL** | Plain-pickle support is more explicit, but line 42 says it is "not deprecated" while line 420 promises a deprecation warning for old plain pickles. The compatibility contract is still fuzzy. |
+| 15 | HIGH | **PARTIAL** | A version-policy table exists, but nightly/pre-1.0/interpreter edge cases are still unspecified. See Finding 7. |
+| 16 | HIGH | **UNRESOLVED** | The operational-shape problem remains: directory bundle plus one blob per tensor is still the default. `pack_bundle` only papers over it after the fact. See Finding 11. |
+| 17 | HIGH | **PARTIAL** | Corruption coverage is broader, but exact exception contracts are still not specified. See Finding 12. |
+| 18 | HIGH | **RESOLVED** | `frames/` was removed from the bundle layout. |
+| 19 | MEDIUM | **PARTIAL** | `ModulePassLog.to_pandas()` was added to scope, but the plan still does not say how it preserves forward-arg summaries after current GC clears them. See Finding 9. |
+| 20 | MEDIUM | **RESOLVED** | Dependencies and LoC expectations are more realistic than v1. |
+| 21 | MEDIUM | **RESOLVED** | `compression="zstd"` was removed. |
+| 22 | MEDIUM | **RESOLVED** | `cleanup_tmp` now has an owner spec. |
+| 23 | MEDIUM | **PARTIAL** | Lazy-bundle re-save semantics are defined for deletion, but not for source-bundle drift or mutation. See Finding 8. |
+
+## Findings
+
+### 1. CRITICAL — The bundle contract still does not define how nested tensor fields are rehydrated or eagerly materialized.
+**Location:** `plan.md` lines 31-32, 39, 49-55, 280-281, 326-333.
+
+**Failure scenario:** A user saves a log with `include_captured_args=True` and `save_rng_states=True`, then loads it with `torchlens.load(path, lazy=False)` and calls `validate_forward_pass()`. The plan says tensors inside `captured_args`, `captured_kwargs`, `forward_args`, `forward_kwargs`, `func_rng_states`, and `children_tensor_versions` become `BlobRef` stubs, and `__setstate__` restores those stubs as `LazyActivationRef`. But the only eager-materialization contract in the plan is `LayerPassLog.materialize_activation()`, which touches `.activation` only. Validation and replay code need real tensors inside those nested containers, not activation refs embedded in lists/dicts.
+
+**Recommendation:** Define a real blob-field schema now. At minimum:
+- distinguish activation, gradient, captured-arg, child-version, RNG-state, and module-arg blobs;
+- store a path-aware stub that can be reinserted into nested containers;
+- specify eager-load behavior for **all** tensor-bearing fields, not just `.activation`;
+- or, if bundle v1 is activation-only, explicitly exclude validation-state fields from the archival contract.
+
+### 2. HIGH — The scrub contract still leaves arbitrary-object holes.
+**Location:** `plan.md` lines 31-37, 68, 280-281.
+
+**Failure scenario:** A layer's `func_config` contains a tensor subclass or user object, or a module's `extra_attributes` contains arbitrary data from module introspection. The scrub contract only names `func_applied`, `activation_postfunc`, `_param_ref`, `FuncCallLocation._frame_func_obj`, and "extra_attributes on ModelLog". It never covers `func_config`, `ModuleLog.extra_attributes`, or other arbitrary-object fields already present in the current object graph. `metadata.pkl` can still fail to serialize or can round-trip inconsistently.
+
+**Recommendation:** Expand the scrub contract from a few named fields to a full allow-list/deny-list over the actual `FIELD_ORDER` surfaces. `func_config` and module `extra_attributes` need an explicit policy: either recursively scrub/normalize them or reject them for portable bundle save.
+
+### 3. HIGH — The new eviction step is still not placed concretely in the pipeline, and the ref path likely races the final rename.
+**Location:** `plan.md` lines 80-81, 249-251, 319, 327, 396-397.
+
+**Failure scenario:** During streaming, `_evict_streamed_activations` creates `LazyActivationRef` objects while the writer is still targeting `<path>.tmp.<uuid>`. Step 6 then renames the temp dir to `<path>`. Unless the ref stores the final destination path rather than the live temp path, the returned `ModelLog` now holds stale bundle paths. Separately, the text keeps calling this the "18-step pipeline" while also saying the new step is "appended last", without stating whether it runs before or after `_set_pass_finished`.
+
+**Recommendation:** Name the exact order in the plan. Example: "Step 18 = `_evict_streamed_activations`; Step 19 = `_set_pass_finished`." Also define whether refs are created with the final bundle path or patched after rename.
+
+### 4. HIGH — Non-tensor `activation_postfunc` is still only half-specified.
+**Location:** `plan.md` lines 92-100, 303-311, 316-323.
+
+**Failure scenario:** A user saves a log post hoc with `torchlens.save(model_log, path)` after running `activation_postfunc=lambda t: t.cpu().numpy()`. The streaming path has a proposed guard, but the ordinary bundle save path does not. Even within streaming, the text says the error is raised "at forward start" and then immediately switches to a runtime-first-layer check. Those are materially different behaviors for temp-dir cleanup and user surprise.
+
+**Recommendation:** Pick one rule and apply it to both save paths. If bundle v1 is tensor-only, reject non-tensor postfunc output **before any blob is written** in both streaming and post-hoc save.
+
+### 5. HIGH — Default-lazy load is still too aggressive for the audited compatibility surface.
+**Location:** `plan.md` lines 45-57, 59-63, 205, 326-333.
+
+**Failure scenario:** A user loads a normal activation bundle with the default `lazy=True` and then uses an existing TorchLens method outside the short audit list. The plan only audits validation, reprs, `to_pandas()`, and cleanup. Any other public or semi-public method that expects tensors still sees `.activation is None` or nested refs and breaks on the new default path.
+
+**Recommendation:** For Phase 4, make `lazy=False` the default unless the compatibility audit is exhaustive and explicit. Lazy load is a useful feature; it should not become the surprising default while the object graph is still tensor-centric.
+
+### 6. HIGH — The supported-tensor matrix still defaults to silent partial bundles.
+**Location:** `plan.md` lines 169-183, 191-200, 308-311, 373.
+
+**Failure scenario:** A model produces a sparse, quantized, nested, or DTensor activation. `torchlens.save()` succeeds by default, emits a warning, and silently drops that activation. The user now has a bundle that looks valid but is incomplete by default. That is especially risky for validation, regression testing, and CI artifacts.
+
+**Recommendation:** Flip the default. `strict=True` should be the default for bundle save; lenient skip behavior should be an explicit opt-in for power users who knowingly accept partial archives.
+
+### 7. MEDIUM — Manifest integrity and version semantics still have undefined edge cases.
+**Location:** `plan.md` lines 107-122, 128-158, 308-309.
+
+**Failure scenario:** A bundle is produced on a nightly PyTorch build (`2.x.dev...`), by a pre-1.0 TorchLens release, or under a different Python implementation. The version-policy table only sketches major/minor behavior and does not say how these version strings are parsed. Likewise, `sha256` is recorded, but the plan never states whether it hashes the exact safetensors file bytes, a logical tensor payload, or something else.
+
+**Recommendation:** Specify normalized version parsing and checksum scope explicitly. The simplest workable rule is: "sha256 is computed over the exact blob file bytes on disk after write, and version comparisons use normalized PEP 440 parsing where available, else string fallback with warning."
+
+### 8. HIGH — Lazy-bundle re-save still does not protect against sidecar drift.
+**Location:** `plan.md` lines 253-268, 311, 331-333, 385.
+
+**Failure scenario:** A user lazy-loads `a/`, another process mutates one sidecar or rewrites the source bundle, and then the user calls `model_log.save("b/")`. The plan's fast path just `shutil.copy`s blobs from the current source bundle if it "exists and is intact". That can yield a new bundle whose copied sidecars no longer match the in-memory metadata originally loaded from `a/`.
+
+**Recommendation:** Record source-manifest digests or mtimes at load time and re-verify them before fast-copy. If the source drifted, either materialize and re-write or fail hard.
+
+### 9. MEDIUM — `ModulePassLog.to_pandas()` still has no concrete data-preservation point.
+**Location:** `plan.md` lines 66-68, 287-291.
+
+**Failure scenario:** The current code clears `ModulePassLog.forward_args` and `.forward_kwargs` after `_build_module_logs` to release tensor references. The plan promises pandas rows with forward-arg shape metadata, but never states where that summary is captured before those fields are nulled.
+
+**Recommendation:** Add an explicit summary field to `ModulePassLog` during module-log construction, or compute/export that summary inside `_build_module_logs` before the existing GC step. As written, the plan promises data that the current lifecycle discards.
+
+### 10. MEDIUM — `pack_bundle` reintroduces a new archive surface without a contract.
+**Location:** `plan.md` lines 346-352, 382.
+
+**Failure scenario:** Users rely on `torchlens.pack_bundle()` for single-file archival, but tar behavior for symlinks, permissions, zero-length files, sparse files, and overwrite/unpack conflicts is unspecified. The plan removed tar from the core path, then added it back as a utility without defining its semantics.
+
+**Recommendation:** Either cut `pack_bundle` from Phase 4 or specify the tar contract and tests explicitly. Do not smuggle a second archive format back into scope via S8.
+
+### 11. MEDIUM — Round 1 finding #16 is still not actually resolved.
+**Location:** `plan.md` lines 14-25, 348, 382-383.
+
+**Failure scenario:** Tiny models still save as multi-file directories, and large models still create one file per tensor by default. `pack_bundle` only helps after the directory already exists; it does nothing for inode pressure or directory-walk cost during save/load.
+
+**Recommendation:** Stop claiming this finding is resolved. Either defer it explicitly or change the default operational shape. Documentation is not the same as resolution.
+
+### 12. MEDIUM — Corruption handling is broader than v1, but the exception boundary is still unspecified.
+**Location:** `plan.md` lines 119-121, 338-340, 421, 446.
+
+**Failure scenario:** A truncated safetensors blob raises one backend exception, a corrupted `metadata.pkl` raises another, and a checksum mismatch raises `TorchLensIOError`. Callers now have to guess which exceptions to catch, even though the change log claims exact exception types are part of the spec.
+
+**Recommendation:** Specify the exception contract in the plan: either all bundle-corruption cases are wrapped in `TorchLensIOError`, or the plan lists which backend exceptions intentionally leak through.

--- a/.project-context/plans/io-sprint/review_round_3.md
+++ b/.project-context/plans/io-sprint/review_round_3.md
@@ -1,0 +1,132 @@
+# Adversarial Review — I/O Sprint Plan Round 3
+
+## Verdict
+
+**RED**
+
+Round 3 is materially tighter than Round 2. Several prior red items are genuinely fixed. The plan is not converged, though: four high-severity design gaps remain in the scrub/reload/streaming contracts, and a few new medium-severity issues were introduced by the v3 revisions.
+
+## Round 2 Verification
+
+| Finding | Status | Assessment |
+| --- | --- | --- |
+| R2-1 Nested tensor rehydration | **PARTIAL** | v3 finally defines a nested-tensor contract, but it still has a correctness hole around `map_location` and an unbounded RAM blow-up risk because nested tensors are always eager-loaded, even in `lazy=True`. See Finding 1. |
+| R2-2 Scrub allow-list holes | **PARTIAL** | Fork A is broader, but the policy/lint still misses real non-`FIELD_ORDER` state and live callables on aggregate objects. See Finding 2. |
+| R2-3 Eviction pipeline position | **PARTIAL** | The plan now names "step 19" and final-path refs, but the step gate contradicts the finalize semantics for the default `keep_activations_in_memory=True` workflow. See Finding 3. |
+| R2-4 Non-tensor postfunc inconsistency | **RESOLVED** | v3 now states one rule for both streaming and post-hoc save, with explicit pre-write rejection on the post-hoc path. |
+| R2-5 Lazy default too aggressive | **RESOLVED** | Flipping `lazy=False` to the default is the conservative choice for the current tensor-centric object model. |
+| R2-6 Silent partial bundles | **PARTIAL** | `torchlens.save()` now defaults to `strict=True`, which fixes the original concern for post-hoc bundle save. The streaming path still does not say how unsupported tensors behave. See Finding 6. |
+| R2-7 Version parsing + checksum scope | **RESOLVED** | PEP 440 parsing and "sha256 over exact blob file bytes" are now explicit. |
+| R2-8 Lazy-resave drift | **PARTIAL** | Manifest-hash drift detection is better than nothing, but it still misses mutated blob bytes when `manifest.json` is unchanged. See Finding 4. |
+| R2-9 ModulePassLog summary capture | **PARTIAL** | A preservation point now exists, but it only covers the positional-arg happy path and does not preserve kwargs or nested dict-style inputs coherently. See Finding 5. |
+| R2-10 pack_bundle semantics | **RESOLVED** | `pack_bundle` was cut from scope. |
+| R2-11 Operational shape | **RESOLVED** | v3 correctly marks the one-file-per-tensor shape as deferred instead of claiming it is solved. |
+| R2-12 Exception contract | **RESOLVED** | The plan now clearly states that bundle-layer errors are wrapped in `TorchLensIOError`. |
+
+## Findings
+
+### 1. HIGH — Nested-tensor eager rehydration is still underspecified for `map_location`, and the new default can explode RAM.
+**Location:** `plan.md` lines 53-61, 248-253, 332-333, 379-385.
+
+**Failure scenario:** A user loads a large bundle with `torchlens.load(path, lazy=True, map_location="cpu")` where `include_captured_args=True` and many operations captured tensor args, RNG states, or `children_tensor_versions`. Fork A says every nested `BlobRef` is eagerly materialized during `__setstate__`, but `__setstate__` has no `map_location` parameter. S1 simultaneously says `rehydrate.py` does the inverse load work. Those are two different designs. Even if the implementation routes around `__setstate__`, v3 still forces eager load of every nested tensor in both lazy and eager modes, so "lazy" bundles with tens of thousands of captured-arg tensors can still blow RAM immediately.
+
+**Recommendation:** Move all blob materialization out of `__setstate__` and into a loader/rehydrator entrypoint that receives `map_location`. Then either:
+- add a separate flag for nested tensor materialization, or
+- make bundle-save defaults less aggressive for captured args/RNG state,
+
+so `lazy=True` is not defeated by auxiliary tensor payloads.
+
+### 2. HIGH — The scrub policy is still not actually exhaustive, and the proposed lint is not strong enough to prove it.
+**Location:** `plan.md` lines 31-49, 331, 395; `torchlens/data_classes/model_log.py` lines 166-166, 230-230, 246-246, 270-283; `torchlens/data_classes/cleanup.py` lines 58-82; `.project-context/research/io-audit-codex.md` lines 62-62, 90-92, 123-145.
+
+**Failure scenario:** The plan claims an exhaustive scrub policy guarded by `FIELD_ORDER` enumeration, but the current object graph already contains important state outside `FIELD_ORDER`: `ModelLog` internals such as `_optimizer`, `_saved_gradients_set`, `_module_metadata`, `_module_forward_args`, `_module_logs`, `_buffer_accessor`, `_mod_*`; `LayerPassLog.parent_layer_log`; and `LayerLog` extras not listed in `LAYER_LOG_FIELD_ORDER`. On top of that, Fork A only deny-lists `activation_postfunc` and `func_applied` on some classes. `LayerLog` still carries both callables today, copied from the first pass. The result is a portable-bundle scrub pass that can still serialize live callables or transient backrefs, or silently rely on raw pickle success for state that should have been normalized.
+
+**Recommendation:** Stop using `FIELD_ORDER` enumeration as the proof of scrub completeness. Define an explicit serialized-state schema per class, including out-of-band/transient attributes, and deny-list all callables/backrefs/transient build state across:
+- `ModelLog`,
+- `LayerPassLog`,
+- `LayerLog`,
+- `ModuleLog`,
+- `ParamLog`,
+- helper objects such as `FuncCallLocation`.
+
+At minimum, `LayerLog.func_applied`, `LayerLog.activation_postfunc`, `LayerPassLog.parent_layer_log`, and the current non-`FIELD_ORDER` `ModelLog` internals need explicit policy.
+
+### 3. HIGH — Step 19 is internally contradictory for the default streaming workflow.
+**Location:** `plan.md` lines 97-106, 368-375, 447.
+
+**Failure scenario:** Fork D says Step 19 is gated on `keep_activations_in_memory=False`, but the same section also says that when `keep_activations_in_memory=True` Step 19 still writes `manifest.json`, writes `metadata.pkl`, and renames the temp dir, only skipping activation eviction. S5 repeats the gated-only-when-false version. Those cannot both be true. If the gate is implemented literally, the default streaming path never finalizes the bundle. If the gate is ignored, the named "eviction" step is doing two unrelated jobs: bundle finalization and optional in-memory eviction.
+
+**Recommendation:** Split the current Step 19 into:
+- an always-run bundle-finalization step, and
+- a conditional activation-eviction substep.
+
+If you want to keep one step number, the gate must be rewritten so finalization always happens and only the null-out/`LazyActivationRef` patching is conditional.
+
+### 4. HIGH — Manifest-only source-drift detection still misses tampered blob files.
+**Location:** `plan.md` lines 174-180, 311-318, 381-385, 435.
+
+**Failure scenario:** A user does `model_log = torchlens.load("a/", lazy=True)`. Another process later overwrites `a/blobs/0000000042.safetensors` with bad bytes but leaves `a/manifest.json` untouched. `model_log.save("b/")` re-hashes only `manifest.json`, sees the same digest, and fast-copies the corrupted blob into `b/`. The v3 defense catches manifest edits, not bundle-content drift.
+
+**Recommendation:** Record and re-verify content, not just manifest bytes. Practical options:
+- capture a root digest over manifest + referenced blob checksums at load time, or
+- re-hash every source blob named in the manifest before fast-copy, or
+- require materialization/rewrite instead of raw copy for lazy resave.
+
+### 5. MEDIUM — `forward_args_summary` does not fully preserve the data that current GC deletes.
+**Location:** `plan.md` lines 83-86, 341-344; `torchlens/postprocess/finalization.py` lines 418-424, 691-695.
+
+**Failure scenario:** A module is called with tensor kwargs only, or with a dict/list structure in `forward_args`. `_build_module_logs()` currently clears both `forward_args` and `forward_kwargs`. v3 adds a single `forward_args_summary: str`, but the described format only summarizes positional args. A kwargs-heavy module can end up with a misleadingly empty or incomplete pandas row after GC.
+
+**Recommendation:** Preserve both sides explicitly:
+- add `forward_kwargs_summary`, or
+- define `forward_args_summary` as a recursive summary over the full `(args, kwargs)` call surface.
+
+The summary format also needs to say how dict/list nesting is represented.
+
+### 6. MEDIUM — The new `strict=True` default fixes post-hoc save, but streaming still has no unsupported-tensor contract.
+**Location:** `plan.md` lines 119-135, 236-245, 368-375, 424.
+
+**Failure scenario:** A model is captured with `log_forward_pass(..., save_activations_to=path)`, and one activation is sparse, meta, nested, or a tensor subclass. Fork E clearly defines `strict` behavior for `torchlens.save()`, but the streaming API has no `strict` parameter and S5 never says whether `tensor_policy.py` is consulted mid-pass. One implementation will abort on first unsupported tensor; another will silently skip; a third may write a partial bundle and keep going. v3 claims this finding is fixed, but only the post-hoc save path has an explicit contract.
+
+**Recommendation:** Extend the strict/lenient policy to streaming explicitly. Either:
+- add a streaming `strict` flag, or
+- state that streaming always behaves as `strict=True`,
+
+and cover it in S5/S7 tests.
+
+### 7. MEDIUM — Symlink handling is still undefined for bundle load and temp-dir cleanup.
+**Location:** `plan.md` lines 19-24, 115, 156-160, 255-259, 369-375.
+
+**Failure scenario:** A bundle directory contains symlinked `metadata.pkl` or `blobs/*.safetensors`, or a sibling `<path>.tmp.*` entry is a symlink. The loader and `cleanup_tmp()` are both filesystem-facing operations, but the plan never says whether symlinks are rejected, followed, or cleaned. A symlinked blob escapes the "bundle root only" assumption; a symlinked temp dir can turn cleanup into deletion outside the intended scope.
+
+**Recommendation:** State and test a hard rule: reject symlinks anywhere in bundle roots and in discovered temp dirs. `cleanup_tmp()` should only recurse into real directories directly owned under the expected parent.
+
+### 8. MEDIUM — The promised scrub-policy guard lands too late to protect the scrub work.
+**Location:** `plan.md` lines 49, 331, 395, 445-449.
+
+**Failure scenario:** S1 introduces the scrubber; S4 depends on it for bundle save/load; the scrub-policy lint is not scheduled until S7. That means the guard advertised in Fork A is absent during the actual design/build rounds where scrub completeness can regress. If the sprint is implemented incrementally, the "lint-protected" claim is false until the end.
+
+**Recommendation:** Move a minimal scrub completeness test into S1, and keep only cross-feature integration coverage in S7.
+
+### 9. MEDIUM — The plan acknowledges open safetensors handles, but not their thread-safety or ownership model.
+**Location:** `plan.md` lines 379-383, 428.
+
+**Failure scenario:** `LazyActivationRef.materialize()` is implemented with cached `safetensors` readers or mmaps, and another thread calls `ModelLog.cleanup()` while materialization is in flight or while another ref still depends on a shared handle. v3 says cleanup closes handles before nulling refs, but does not say whether readers are per-ref, shared, locked, or thread-safe.
+
+**Recommendation:** Pick one concrete model:
+- no long-lived shared readers at all, or
+- shared readers guarded by locks/refcounts,
+
+and document whether lazy materialization is thread-safe.
+
+## Checks With No Substantive Finding
+
+- **`lazy=False` default itself:** conservative and acceptable for this sprint. The real issue is the unconditional eager load of nested tensor blobs, not the top-level default.
+- **Manifest `relative_path` when a bundle directory is moved:** no blocker found if load resolves `relative_path` against the bundle root passed to `torchlens.load()`. A fresh load after moving the directory should still work. The remaining portability issue is only for long-lived in-memory refs after the bundle is moved post-load.
+- **"Step 19" numeric ordering:** the current pipeline is imperative code, not a name-based registry. The numbering itself is not the problem. The real issue is the contradictory gate/finalize contract in Finding 3.
+
+## Summary
+
+Round 3 fixed several real issues from Round 2: the lazy default flip, the strict default flip for post-hoc save, the tar/`pack_bundle` scope cut, the version/checksum clarifications, and the explicit exception contract. The plan is still not ready for implementation as written because the scrub surface, nested rehydration contract, streaming finalization gate, and lazy-resave drift protection are not yet sound.
+
+If Findings 1-4 are fixed cleanly, this plan is close enough that the next review could plausibly go GREEN.

--- a/.project-context/plans/io-sprint/review_round_4.md
+++ b/.project-context/plans/io-sprint/review_round_4.md
@@ -1,0 +1,63 @@
+# Adversarial Review — I/O Sprint Plan Round 4
+
+## Verdict
+
+**YELLOW**
+
+Round 4 genuinely resolves the 9 Round-3 findings. The Round-3 reviewer’s note was directionally right: Findings 1-4 were fixed cleanly, and I did not find a new RED-class architecture hole in the nested rehydration, scrub completeness, streaming finalization split, per-blob drift detection, symlink rejection, or no-shared-readers model.
+
+This is close. I still found one new high-severity contract break and two medium-severity gaps introduced by the v4 revisions, plus one low-severity document inconsistency.
+
+## Round 3 Verification
+
+| Finding | Status | Assessment |
+| --- | --- | --- |
+| R3-1 Nested tensor rehydration / `map_location` / RAM blow-up | **RESOLVED** | Materialization moved out of `__setstate__` into a loader that accepts `map_location`, and v4 added `materialize_nested` plus safer defaults for captured args / RNG state. |
+| R3-2 Scrub surface not exhaustive | **RESOLVED** | `PORTABLE_STATE_SPEC` is a materially stronger contract than the old FIELD_ORDER-based proof, and the completeness lint now lands in S1 instead of S7. |
+| R3-3 Step 19 gate contradictory | **RESOLVED** | Finalization and eviction are now split into step 19 / step 20 with distinct gates. |
+| R3-4 Manifest-only drift misses blob tampering | **RESOLVED** | v4 adds per-blob sha256 verification before fast-copy. |
+| R3-5 `forward_args_summary` misses kwargs | **RESOLVED** | v4 adds `forward_kwargs_summary` plus recursive formatting rules. |
+| R3-6 Streaming unsupported-tensor policy undefined | **RESOLVED** | Streaming is now explicitly always strict. |
+| R3-7 Symlink handling undefined | **RESOLVED** | v4 now states a reject-on-symlink policy for save/load/cleanup. |
+| R3-8 Scrub lint lands too late | **RESOLVED** | The completeness lint is now in S1. |
+| R3-9 Reader thread-safety / ownership model undefined | **RESOLVED** | The plan now picks a concrete no-shared-readers model. |
+
+## Findings
+
+### 1. HIGH — The new scrub contract makes “validation-ready bundles” impossible as written because layer callables are dropped with no restoration path.
+**Location:** `plan.md` lines 60-65, 95-101, 467-476; `torchlens/validation/invariants.py` lines 397-398; `torchlens/validation/core.py` line 468.
+
+**Failure scenario:** A user follows the v4 guidance and saves with `include_captured_args=True` because they want a validation-ready bundle, then loads it eagerly and calls `validate_forward_pass()`. The plan now explicitly drops `LayerPassLog.func_applied` and `LayerLog.func_applied`. Worse, line 65 says `LayerLog.func_applied` is recoverable from `LayerPassLog` records, but line 60 drops the LayerPassLog callable too. Current validation requires `callable(lpl.func_applied)` and replay executes `layer.func_applied(...)`. As written, a loaded portable bundle cannot satisfy that contract.
+
+**Recommendation:** Pick one explicit rule:
+- preserve a restorable callable identity and rebuild `func_applied` on load for supported ops, or
+- declare `validate_forward_pass()` unsupported on portable bundles and remove the “validation-ready bundles” claim tied to `include_captured_args=True`.
+
+### 2. MEDIUM — `lazy=True, materialize_nested=False` has no resave / drift contract for nested `BlobRef` payloads.
+**Location:** `plan.md` lines 96-101, 392-399, 468-473.
+
+**Failure scenario:** A user loads a bundle with `lazy=True, materialize_nested=False`, leaving nested tensor-bearing fields such as `captured_args`, `func_rng_states`, or `forward_kwargs` as `BlobRef`-like objects. They then call `model_log.save("b/")`. The v4 fast-copy/drift logic only specifies how `LazyActivationRef` blobs are verified and copied. It does not say how remaining nested `BlobRef`s are copied, re-manifested, or rejected. That leaves the expert-mode resave path underspecified for exactly the new mode v4 introduced.
+
+**Recommendation:** State one rule explicitly:
+- `torchlens.save()` rejects ModelLogs that still contain nested `BlobRef`s and requires `rehydrate_nested()` first, or
+- nested refs must also carry source-bundle + checksum metadata and participate in the same fast-copy / drift-check pipeline as `LazyActivationRef`.
+
+### 3. MEDIUM — The step-19/20 split still leaves the default streaming path internally inconsistent about whether the returned log is actually disk-backed.
+**Location:** `plan.md` lines 147-159, 456-457.
+
+**Failure scenario:** In v4, step 20 is the only step that explicitly sets `.activation_ref`, and it only runs when `keep_activations_in_memory=False`. But line 159 says that with the default `keep_activations_in_memory=True`, the returned ModelLog has activations in memory “AND disk-backed.” As written, the keep-in-memory path finalizes the bundle on disk but never says when any `LazyActivationRef` objects are attached to the in-memory log. That matters for later cleanup/materialization/resave semantics.
+
+**Recommendation:** Decide this explicitly:
+- step 19 should always attach `activation_ref` for streamed blobs, and step 20 should only null `.activation`, or
+- stop claiming the keep-in-memory return value is disk-backed and document that only the bundle on disk is durable.
+
+### 4. LOW — A few remaining sections still describe pre-v4 behavior.
+**Location:** `plan.md` lines 381-389 vs. 466-476; lines 516-519.
+
+**Failure scenario:** An implementer following the public `LazyActivationRef` sketch in §3 omits `expected_sha256`, even though S6 requires it for the new per-blob drift check. The risk register also still says nested containers are always eager-materialized and that `cleanup()` closes live handles, both of which v4 explicitly changed.
+
+**Recommendation:** Sync the public API sketch and risk register to the v4 design so the plan has one consistent source of truth.
+
+## Summary
+
+Round 4 did the important work. The Round-3 blockers are actually fixed, and the plan now looks implementable. I would not call it GREEN yet because the bundle-validation claim is still incompatible with the scrub contract, and the new expert nested-lazy path needs one more explicit save/resave rule. Once those are tightened, this plan is plausibly ready to go GREEN.

--- a/.project-context/plans/io-sprint/review_round_5.md
+++ b/.project-context/plans/io-sprint/review_round_5.md
@@ -1,0 +1,52 @@
+# Adversarial Review — I/O Sprint Plan Round 5
+
+## Verdict
+
+**YELLOW**
+
+Round 5 fixes the Round-4 issues at the design-fork level, and I did not find a new RED-class architecture hole in Fork L, Fork M, the unconditional step-19 `.activation_ref` attachment, or the `expected_sha256` addition. But the plan is still not fully GREEN because a few implementation-facing sections still contradict those new decisions.
+
+## Round 4 Verification
+
+| Finding | Status | Assessment |
+| --- | --- | --- |
+| R4-1 Validation broken on portable bundles because `func_applied` is dropped | **PARTIAL** | Fork L picks the right rule: portable bundles do not support validation/replay. But the plan still contains contradictory "validation-ready bundle" / "lazy-only" language. See Finding 1. |
+| R4-2 No resave contract for `materialize_nested=False` mode | **RESOLVED** | Fork M now explicitly rejects `torchlens.save()` when nested `BlobRef`s are still present and tells the user to run `rehydrate_nested()` first. |
+| R4-3 Step-19/20 split left keep-in-memory path un-disk-backed | **PARTIAL** | Fork D now says step 19 always attaches `.activation_ref`, which is the right fix. But IO-S5 still assigns ref patching to step 20. See Finding 2. |
+| R4-4 Public API sketch + risk register lagged v4 design | **PARTIAL** | `LazyActivationRef` now includes `expected_sha256`, which fixes the main API sketch gap. But a few bookkeeping sections still describe pre-v5 behavior. See Finding 3. |
+
+## Findings
+
+### 1. MEDIUM — Fork L is not propagated consistently; the plan still promises validation-oriented portable bundles in several places.
+**Location:** `plan.md` lines 65, 95, 100, 281-284, 510-511, 612.
+
+**Failure scenario:** An implementer follows the new Fork L section and adds a bundle-load guard, but then also follows the earlier guidance that `include_captured_args=True` is for "validation-ready bundles" and the S6 test text that says validation should raise only on "lazy-only" logs. That yields an implementation where eagerly loaded portable bundles still try to validate, or the docs still tell users bundle validation is supported if they include enough metadata. That directly contradicts Fork L's actual rule: portable-loaded ModelLogs never support `validate_forward_pass()` or `validate_saved_activations()`.
+
+**Recommendation:** Remove the stale validation language everywhere it still appears:
+- line 95 should stop saying `include_captured_args=True` is for validation-ready bundles;
+- line 100 should stop describing eager nested materialization as useful for validation on portable loads;
+- line 65 should stop implying dropped `LayerLog.func_applied` is recoverable for replay on portable bundles;
+- S6 should say validation raises on **portable-loaded** ModelLogs, not just "lazy-only" ones.
+
+### 2. MEDIUM — IO-S5 still gives step 20 responsibility that Fork D moved to step 19.
+**Location:** `plan.md` lines 147-149, 489-492, 614.
+
+**Failure scenario:** An implementer follows the spec decomposition rather than the higher-level fork prose. IO-S5 still says step 20 "Patches `LazyActivationRef` with final (post-rename) path." If implemented literally, `keep_activations_in_memory=True` logs will finalize the bundle but return without `.activation_ref`, which recreates the exact ambiguity Round 4 flagged.
+
+**Recommendation:** Make IO-S5 match Fork D exactly:
+- step 19 should explicitly attach `.activation_ref` with final path and `expected_sha256` for every streamed blob;
+- step 20 should only null `.activation` when `keep_activations_in_memory=False`.
+
+### 3. LOW — Several bookkeeping sections still lag the current spec.
+**Location:** `plan.md` lines 455, 483, 511, 551, 561, 599.
+
+**Failure scenario:** Test planning drifts because the plan disagrees with itself:
+- S1 owns the `PORTABLE_STATE_SPEC` completeness lint, but S7/R2 still describe an older `FIELD_ORDER`/S7 lint model.
+- Fork H is now two-layer drift protection, but R12 only mentions manifest-sha checking.
+- The version-policy table has 13 rows, while S4 says "all 12 version-policy rows" and the success criteria say "All 14 version-policy rows tested."
+
+**Recommendation:** Sync the bookkeeping sections to the actual v5 design before implementation starts so the tests are derived from one consistent source of truth.
+
+## Summary
+
+This is still close. The actual Round-4 fixes are now present, and I do not see a new structural blocker. But the plan is not GREEN yet because the implementation sections still contain contradictory instructions in two of the exact areas v5 was supposed to settle: validation on portable bundles and step-19/20 ownership. One cleanup pass should be enough.

--- a/.project-context/plans/io-sprint/review_round_6.md
+++ b/.project-context/plans/io-sprint/review_round_6.md
@@ -1,0 +1,28 @@
+# Adversarial Review — I/O Sprint Plan Round 6
+
+## Verdict
+
+**YELLOW**
+
+Round 6 fixes two of the three Round-5 bookkeeping inconsistencies:
+- IO-S5 now matches Fork D: step 19 owns `.activation_ref` attachment and step 20 only evicts `.activation`.
+- The version-policy table count is now consistent at 13 rows, and the `PORTABLE_STATE_SPEC` completeness lint is consistently owned by S1 rather than S7.
+
+I did not find a new architecture issue. But the plan is still not fully GREEN because one part of the Round-5 validation/replay cleanup is still not propagated everywhere.
+
+## Findings
+
+### 1. MEDIUM — Fork L is still contradicted by two stale validation/replay phrases.
+**Location:** `plan.md` lines 65 and 100.
+
+**Why this still matters:** Fork L now makes a clear product decision: portable-loaded ModelLogs do not support `validate_forward_pass()` or replay-oriented recovery of live callables. But two earlier sections still describe the portable path as if validation/replay remains a meaningful target:
+- line 100 says `lazy=True, materialize_nested=True` is the common case when the user "needs real tensors for validation paths";
+- line 65 still says dropped `LayerLog.func_applied` is "recoverable from LayerPassLog records or repr string", which reintroduces the idea that replay-relevant callable state is recoverable from the portable artifact.
+
+**Recommendation:** Finish the Fork L scrub:
+- replace the "validation paths" rationale on line 100 with a non-validation use case;
+- reword line 65 so it no longer implies replay/callable recovery from portable bundle contents.
+
+## Summary
+
+This is close. The step-19/20 bookkeeping, version-policy row counts, and S1-vs-S7 ownership mismatch are now internally consistent. I did not find another substantive issue beyond the remaining stale validation/replay text above.

--- a/.project-context/plans/io-sprint/review_round_7.md
+++ b/.project-context/plans/io-sprint/review_round_7.md
@@ -1,0 +1,24 @@
+# Adversarial Review — I/O Sprint Plan Round 7
+
+## Verdict
+
+**YELLOW**
+
+The two Round-6 stale phrases are fixed. I did not find a new architecture problem, and the plan otherwise looks internally coherent and implementable. But there is still one remaining stale validation reference that contradicts Fork L, so this is not GREEN yet.
+
+## Findings
+
+### 1. LOW — Risk register R4 still uses pre-Fork-L validation language.
+**Location:** `plan.md` line 553.
+
+**Why this still matters:** Fork L makes portable-loaded ModelLogs explicitly non-validatable: `validate_forward_pass()` and `validate_saved_activations()` hard-raise on bundle-loaded logs. But R4 still says:
+
+> `Lazy refs inside nested containers confuse validation`
+
+That is no longer the actual risk. The mitigation text underneath is about `materialize_nested=False` requiring `rehydrate_nested()` before resave, which confirms this row is just stale wording left over from the earlier validation-capable model.
+
+**Recommendation:** Rewrite R4 to describe the real risk, e.g. nested `BlobRef` usability/resave semantics, not validation.
+
+## Summary
+
+This is very close, but not fully GREEN. Once the R4 risk-register wording is scrubbed to match Fork L, I do not see another substantive blocker.

--- a/.project-context/plans/io-sprint/review_round_8.md
+++ b/.project-context/plans/io-sprint/review_round_8.md
@@ -1,0 +1,24 @@
+# Adversarial Review — I/O Sprint Plan Round 8
+
+## Verdict
+
+**GREEN**
+
+I did not find a remaining validation/replay contradiction against Fork L, and I did not find other stale text from earlier design iterations that still changes implementation meaning.
+
+## Verification
+
+- Fork L is now propagated consistently:
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:65) drops live callables with no portable replay recovery claim.
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:95) and [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:100) no longer frame include flags or eager nested materialization as validation-oriented.
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:269) explicitly says portable-loaded ModelLogs do not support `validate_forward_pass()` or `validate_saved_activations()`.
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:553) rewrites R4 around lingering nested `BlobRef`s rather than validation confusion.
+
+- Earlier bookkeeping mismatches also remain cleaned up:
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:147) keeps `.activation_ref` attachment in step 19, with [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:149) limiting step 20 to eviction only.
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:483) and [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:597) are consistent on the 13-row version-policy table.
+  - [plan.md](/home/jtaylor/projects/torchlens/.project-context/plans/io-sprint/plan.md:449) keeps `PORTABLE_STATE_SPEC` completeness lint ownership in S1, matching the rest of the plan.
+
+## Summary
+
+At this point the plan reads as internally coherent and implementable. I do not see a real remaining blocker from the prior review chain.

--- a/.project-context/research/adversarial.md
+++ b/.project-context/research/adversarial.md
@@ -1,0 +1,455 @@
+# AST Branch Attribution Adversarial Report
+
+## Scope
+
+This is a red-team inventory for an AST-based `if` / `elif` / `else` attribution scheme layered onto TorchLens forward-pass introspection.
+
+Codebase-grounded baseline observed during survey:
+
+- Current Step 5 starts from `internally_terminated_bool_layers`, not from a dedicated "`Tensor.__bool__` happened here" event.
+- Current THEN detection is source-driven, requires `save_source_context=True`, parses the file with `ast.parse()`, and matches `ast.If` by line number proximity.
+- `FuncCallLocation` source context is lazily loaded through `linecache`, so source text can drift after capture.
+- Aggregate `LayerLog` merge rules only merge 3 fields; `cond_branch_then_children` is first-pass-only today.
+- Validation currently has no invariant enforcing `cond_branch_then_children <-> conditional_then_edges` consistency.
+- Visualization already has conditional-edge limitations: ELK ignores IF/THEN labeling and Graphviz can dedupe away labels.
+
+Assumption used in this report: the proposed design is "attribute subsequent captured ops to THEN / ELIF / ELSE branches using Python AST + source line numbers", and should work on ordinary eager `forward()` execution unless explicitly documented as unsupported.
+
+## 1. Source-Code Availability Failures
+
+### 1.1 Notebook and REPL cells have unstable or synthetic filenames
+- Severity: blocker
+- Description: `inspect` and frame metadata often report `<ipython-input-...>` or `<stdin>`. The text may exist only in notebook machinery, not as a stable `.py` path. AST lookup by filesystem path fails or resolves stale cell contents after re-execution.
+- Mitigation: support notebook cell source providers explicitly, or document notebooks / REPL as unsupported for AST branch attribution.
+- Test sketch: `NotebookCellIfModel` defined and redefined across Jupyter cell executions; verify branch attribution after re-run.
+
+### 1.2 `exec()` / `eval()` / dynamically generated functions have no durable source file
+- Severity: blocker
+- Description: `forward` or helper predicates built from strings often carry filenames like `<string>`. There may be no recoverable source, or the source text used at runtime is different from anything reachable later.
+- Mitigation: document limitation; optionally allow caller-supplied source text or content hash.
+- Test sketch: `ExecForwardModel` where `forward` is attached via `exec`.
+
+### 1.3 Lambdas and nested closures collapse attribution context
+- Severity: high
+- Description: lambdas, local helper functions, and nested closures often share line numbers with surrounding code or point at enclosing blocks. The AST range may identify the outer function body while the actual branch lives in an inner scope.
+- Mitigation: require branch attribution only for real `FunctionDef` / `AsyncFunctionDef` bodies with stable qualnames, or add scope-aware AST resolution.
+- Test sketch: `ClosurePredicateModel` with nested helper returning a tensor bool used by outer `if`.
+
+### 1.4 Decorated `forward()` methods shift apparent source ownership
+- Severity: high
+- Description: decorators can replace `forward` with a wrapper whose file and line numbers belong to decorator code, not model code. Class `source_line` from `inspect.getsourcelines(module_class)` can also point at decorators rather than the class body.
+- Mitigation: unwrap only when safe, record both wrapped and unwrapped metadata, or document decorated `forward` as best-effort only.
+- Test sketch: `DecoratedForwardModel` with a logging decorator that wraps `forward`.
+
+### 1.5 Monkey-patched `forward` methods break class-level source assumptions
+- Severity: high
+- Description: instance-level or class-level monkey patching means the executed `forward` may not match the class source file, line, or AST. A design anchored on module class metadata will silently read the wrong file.
+- Mitigation: resolve source from the executing callable object, not from module class metadata alone.
+- Test sketch: `MonkeyPatchedForwardModel` where `model.forward = patched_forward.__get__(model, type(model))`.
+
+### 1.6 `.pyc`-only deployments and native extensions expose no parseable Python source
+- Severity: blocker
+- Description: packaged or frozen environments may retain bytecode only, or implement `forward` in C++ / pybind / `.so`. AST branch attribution cannot recover the source structure.
+- Mitigation: document limitation and fail closed.
+- Test sketch: synthetic test skipped in normal CI but covered in docs / explicit unsupported-case tests.
+
+### 1.7 `torch.compile`, TorchDynamo, tracing, and scripting can erase Python-level branch structure
+- Severity: blocker
+- Description: `torch.compile`, `torch.jit.trace`, and `torch.jit.script` can inline, specialize, trace once, or replace Python control flow with graph IR. The runtime path may no longer correspond to the original Python AST, or may execute generated wrapper code instead.
+- Mitigation: detect compiled / scripted / traced models and disable AST branch attribution, or clearly scope support to eager Python execution only.
+- Test sketch: `CompiledIfModel`, `ScriptedIfModel`, `TracedIfModel`.
+
+### 1.8 Encoding, BOM, and newline normalization can skew line mapping
+- Severity: medium
+- Description: AST parsing and line-number arithmetic can go wrong when source contains UTF-8 BOM, CRLF normalization changes, or encoding declarations. A captured frame line may still be correct while re-read file offsets drift after normalization.
+- Mitigation: open files with the same decoding strategy Python used to compile them, preserve newline handling, and test BOM / CRLF explicitly.
+- Test sketch: `CRLFEncodedIfModel` stored with BOM and CRLF.
+
+## 2. AST vs Runtime Misalignment
+
+### 2.1 Multi-line predicates break naive "nearest line" `ast.If` matching
+- Severity: blocker
+- Description: predicates can span many lines across parentheses, helper calls, and boolean operators. Matching the bool-producing op to the nearest `ast.If` on `lineno` can select the wrong statement or a parent / sibling conditional.
+- Mitigation: resolve the exact AST node whose test span contains the runtime event and verify structural ancestry.
+- Test sketch: `MultilinePredicateModel` with a 6-line `if (...)` test.
+
+### 2.2 `elif` is represented as nested `If` inside `orelse`
+- Severity: blocker
+- Description: Python AST does not have a distinct `Elif` node. A line-based scheme can confuse the top-level `if`, inner `elif`, and final `else`, especially when several tests share nearby lines.
+- Mitigation: normalize `if` / `elif` ladders into explicit branch arms before attribution.
+- Test sketch: `ElifLadderModel` with tensor conditions in `if`, `elif`, and `else`.
+
+### 2.3 Hot reload changes file contents after call-stack capture
+- Severity: high
+- Description: the frame line number is captured during execution, but AST is parsed later from disk and source context is loaded lazily through `linecache`. If the file changes in between, the recorded line now points at different code.
+- Mitigation: capture source snapshot or file content hash at logging time; reject mismatched hashes.
+- Test sketch: `HotReloadIfModel` where the file is rewritten between execution and postprocess.
+
+### 2.4 `linecache` invalidation is not automatic enough for live-edit workflows
+- Severity: high
+- Description: even if disk contents change, `linecache` may continue serving old lines until explicitly invalidated. AST may parse new text while `FuncCallLocation` shows old text, producing self-contradictory attribution evidence.
+- Mitigation: call `linecache.checkcache(path)` or cache explicit source snapshots.
+- Test sketch: modify source after first access to `code_context` and compare with AST parse.
+
+### 2.5 AST spans are ranges; runtime evidence is point samples
+- Severity: high
+- Description: a branch body can cover a large line interval containing nested `if`, `with`, `try`, helper calls, and comprehensions. "Child op line falls in body range" is necessary but not sufficient to prove direct branch membership.
+- Mitigation: use AST parent chains and statement ownership, not body start/end ranges alone.
+- Test sketch: `NestedBodySameRangeModel` with nested `if` inside outer `if`.
+
+### 2.6 Python 3.9 -> 3.13 AST metadata differences alter edge cases
+- Severity: medium
+- Description: `end_lineno` support, pattern-matching nodes, parser details, and exact spans differ across versions. A design tuned on one Python minor version can silently misattribute on another.
+- Mitigation: version-gated parsing logic and a cross-version regression matrix.
+- Test sketch: same conditional corpus run under 3.9, 3.10, 3.11, 3.12, 3.13.
+
+### 2.7 Semicolon-packed statements and one-line branches collapse multiple events onto one line
+- Severity: medium
+- Description: `if cond: a = f(x); b = g(x)` makes two branch-local ops share one physical line. Line-only attribution cannot distinguish them from adjacent same-line statements.
+- Mitigation: document limitation or move to column offsets / bytecode events if exactness is required.
+- Test sketch: `OneLineBranchModel`.
+
+## 3. Attribution Ambiguity
+
+### 3.1 Multiple ops on one line cannot be uniquely assigned
+- Severity: blocker
+- Description: chained calls, tuple unpacking, helper calls, or semicolon-separated ops produce several captured layers at the same source line. A line-number scheme can only say "some branch-local work happened here".
+- Mitigation: document limitation or enrich attribution with column offsets / AST expression mapping.
+- Test sketch: `MultiOpSameLineModel`.
+
+### 3.2 List / set / dict comprehensions and generator expressions create hidden scopes
+- Severity: high
+- Description: comprehension filters (`[f(x) for x in xs if pred(x)]`) are AST control-flow nodes but not ordinary statement blocks. Runtime ops often execute in an implicit nested scope with confusing line ownership.
+- Mitigation: either explicitly support comprehension scopes or document them as unsupported.
+- Test sketch: `ComprehensionIfModel`.
+
+### 3.3 Ternary expressions (`ast.IfExp`) put both arms on the same line
+- Severity: high
+- Description: `y = a(x) if cond else b(x)` has THEN and ELSE on one expression line. Simple line-range checks cannot tell which captured op belongs to which arm, especially if both calls share the same source line.
+- Mitigation: support `ast.IfExp` explicitly or document limitation.
+- Test sketch: `TernaryIfExpModel`.
+
+### 3.4 `torch.where` and masked tensor ops look like conditionals but are not Python branching
+- Severity: medium
+- Description: users may expect them to appear as THEN / ELSE branches, but both arms can execute eagerly and the condition is tensorized, not a Python `if`. Mislabeling these as branch edges would be wrong.
+- Mitigation: document as non-Python control flow; never infer branch edges from tensorized selection ops.
+- Test sketch: `TorchWhereModel`.
+
+### 3.5 The same `if` can execute multiple times inside one forward
+- Severity: blocker
+- Description: when an `if` lives in a loop, branch-local ops from different iterations share source lines but correspond to different runtime decisions. A no-pass or no-iteration attribution will merge contradictory outcomes.
+- Mitigation: store per-execution-instance branch records keyed by pass / iteration.
+- Test sketch: `LoopedIfModel` iterating over timesteps with alternating branch outcomes.
+
+### 3.6 Cross-pass aggregation can collapse contradictory branch histories
+- Severity: blocker
+- Description: aggregate `LayerLog` fields represent only first-pass values for most fields today. If pass 1 took THEN and pass 2 took ELSE, a LayerLog-level branch view will be stale or outright false.
+- Mitigation: keep branch attribution on `LayerPassLog` only, or add merge semantics for branch metadata.
+- Test sketch: `RecurrentElifModel` with different branch outcome on pass 2.
+
+### 3.7 ELSE attribution is fundamentally harder than THEN attribution
+- Severity: high
+- Description: THEN can be approximated by body membership after finding an `If`. ELSE requires distinguishing `elif`, explicit `else`, and "no branch-local op executed". Missing ELSE edges can be misread as "condition false and no else", which is not the same thing.
+- Mitigation: explicitly model branch arms, including empty arms and `elif` desugaring.
+- Test sketch: `ExplicitElseModel` and `NoElseModel`.
+
+## 4. Dynamic Dispatch and Hooks
+
+### 4.1 Forward pre/post hooks can emit ops outside the lexical branch body
+- Severity: high
+- Description: hooks run because a branch-local module was invoked, but the hook code lives elsewhere. Captured ops from the hook may be semantically branch-caused yet source-located outside the branch body.
+- Mitigation: document lexical-only attribution, or separately tag hook-originated ops.
+- Test sketch: `ForwardHookIfModel`.
+
+### 4.2 Backward hooks and autograd callbacks muddy branch provenance
+- Severity: medium
+- Description: if branch metadata is later surfaced on backward or gradient-related artifacts, hook-created ops will not correspond cleanly to forward lexical structure.
+- Mitigation: scope branch attribution to forward graph only; document that backward hooks are out of scope.
+- Test sketch: `BackwardHookIfModel`.
+
+### 4.3 `nn.Module.apply` and helper traversals can execute conditionals outside `forward`
+- Severity: medium
+- Description: code may call utility methods that traverse submodules or mutate state before / during forward. A branch event observed in helper code may not map to the module's `forward` source.
+- Mitigation: restrict attribution to frames inside the active `forward` stack root.
+- Test sketch: `ApplyInsideForwardModel`.
+
+### 4.4 `custom autograd.Function.forward` hides user logic behind a different callable boundary
+- Severity: high
+- Description: branching can happen inside `autograd.Function.forward`, not the enclosing module `forward`. If attribution assumes all relevant source is in module `forward`, it misses or misattributes those ops.
+- Mitigation: support arbitrary user frames, not just module-forward frames.
+- Test sketch: `AutogradFunctionIfModel`.
+
+### 4.5 `DataParallel` / `DistributedDataParallel` replicate execution context
+- Severity: blocker
+- Description: TorchLens is already documented as effectively single-threaded. Replica threads / processes can produce duplicated or interleaved branch events, differing branch outcomes per device, and non-deterministic frame ordering.
+- Mitigation: fail closed for DP / DDP branch attribution, or explicitly implement replica-aware logging.
+- Test sketch: `DataParallelIfModel`.
+
+## 5. Control-Flow Subtleties
+
+### 5.1 Early `return` inside a branch truncates the graph
+- Severity: high
+- Description: a THEN arm may end the forward pass before any "post-branch" reconvergence exists. Graph-based heuristics that expect a merge point can misidentify branch starts or over-assign downstream ops.
+- Mitigation: handle branch arms with no reconvergence as first-class cases.
+- Test sketch: `EarlyReturnIfModel`.
+
+### 5.2 `raise` inside a branch prevents postprocess assumptions from holding
+- Severity: high
+- Description: the forward pass aborts before normal cleanup, so branch metadata may be partial or internally inconsistent. Any design assuming a completed graph is brittle here.
+- Mitigation: document unsupported for exception-raising forwards, or add partial-pass semantics.
+- Test sketch: `RaiseInIfModel`.
+
+### 5.3 `try/except/else/finally` nested in branches creates overlapping lexical regions
+- Severity: high
+- Description: an op may be inside an outer THEN arm and also inside an `except` or `finally` block. Line-range-only ownership cannot express which control-flow decision actually caused it.
+- Mitigation: treat `try` constructs as separate control-flow nodes or document limitation.
+- Test sketch: `TryExceptInsideIfModel`.
+
+### 5.4 `with` blocks inside branches can trigger hidden enter/exit work
+- Severity: medium
+- Description: context-manager `__enter__` / `__exit__` code executes because of the branch, but source lines belong to the context manager implementation, not the body.
+- Mitigation: document lexical-only attribution.
+- Test sketch: `WithInsideIfModel`.
+
+### 5.5 `continue` / `break` inside loop-local `if` statements change future control flow
+- Severity: high
+- Description: the branch does not only own local ops; it changes whether later loop-body ops run. A naive scheme that attributes only direct body lines misses these control effects.
+- Mitigation: either document "lexical body only" semantics or model control-transfer consequences explicitly.
+- Test sketch: `BreakContinueIfModel`.
+
+### 5.6 Re-entrant or nested conditionals can share the same predicate-producing line
+- Severity: high
+- Description: helper functions may compute a bool once, then consume it in nested or repeated `if` statements. A single terminal bool event can map to multiple branch consumers.
+- Mitigation: tie attribution to the exact bool-consumption site, not just the bool-producing tensor.
+- Test sketch: `ReentrantBoolUseModel`.
+
+### 5.7 Pattern matching guards (`match` / `case ... if`) are control flow too
+- Severity: high
+- Description: Python 3.10+ introduces guarded `case` arms whose semantics are branch-like but not expressed as `ast.If`. A design focused on `ast.If` / `IfExp` will miss them.
+- Mitigation: either support `ast.Match` guards or document unsupported syntax.
+- Test sketch: `MatchGuardModel`.
+
+## 6. False Positives: Bool Used Non-Branchingly
+
+### 6.1 `assert tensor_cond` is not a THEN / ELSE branch
+- Severity: blocker
+- Description: it consumes a truthy value but does not create ordinary branch arms. Treating it as IF/THEN would invent edges that never existed.
+- Mitigation: whitelist only actual branching constructs; document asserts separately.
+- Test sketch: `AssertTensorCondModel`.
+
+### 6.2 `bool(tensor)` cast for logging / storage is not branch control
+- Severity: blocker
+- Description: users may cast to Python bool to stash a flag, emit debug text, or pass into a helper. The bool conversion happened, but no model ops should be attributed to THEN / ELSE.
+- Mitigation: require evidence of a control-flow consumer, not bool conversion alone.
+- Test sketch: `BoolCastOnlyModel`.
+
+### 6.3 `any()` / `all()` over tensor-derived Python bools is reduction, not branch ownership
+- Severity: high
+- Description: these calls may consume scalarized tensor predicates while remaining outside any branching statement.
+- Mitigation: classify them as scalar reductions, not branch sites.
+- Test sketch: `AnyAllReductionModel`.
+
+### 6.4 Short-circuit expressions in assignments and returns are not statement branches
+- Severity: high
+- Description: `x = tensor_bool and helper()` or `return a if cond else b` can use truthiness without creating the same graph semantics as a statement-level `if`.
+- Mitigation: support them explicitly or document them as unsupported; do not silently fold them into ordinary IF/ELSE semantics.
+- Test sketch: `ShortCircuitAssignModel`.
+
+### 6.5 Test scaffolding and debug guards inside helper code can contaminate model attribution
+- Severity: medium
+- Description: branching used only for logging, asserts, or test instrumentation inside helpers can appear in captured call stacks and be mistaken for model-semantic control flow.
+- Mitigation: optionally filter frames by module / source root, or document that attribution is purely lexical.
+- Test sketch: `DebugGuardHelperModel`.
+
+### 6.6 Walrus expressions inside comprehensions are especially easy to misclassify
+- Severity: medium
+- Description: `[(y := f(x)) for x in xs if bool(pred(x))]` combines hidden scopes, implicit control flow, and bool conversion. The branchy-looking bool use may have no meaningful THEN / ELSE edges in the forward graph.
+- Mitigation: document unsupported syntax surface.
+- Test sketch: `WalrusComprehensionModel`.
+
+## 7. False Negatives: Branches Without Atomic Bool Capture
+
+### 7.1 Pure Python predicates create real branches with no tensor bool event
+- Severity: blocker
+- Description: `if training:`, `if self.flag:`, and shape / mode guards produce genuine branch-local ops but never touch `Tensor.__bool__`.
+- Mitigation: document that the feature covers tensor-driven Python control flow only, not all branches.
+- Test sketch: `PythonBoolIfModel`.
+
+### 7.2 `tensor.item()` / `int(tensor)` / `float(tensor)` scalarize before branching
+- Severity: blocker
+- Description: `if tensor.item() > 0:` creates a real branch but bypasses `Tensor.__bool__`. The captured tensor may terminate internally, but the actual control decision happened after scalarization.
+- Mitigation: detect scalarization APIs explicitly, or document them as unsupported.
+- Test sketch: `ItemScalarizationIfModel`.
+
+### 7.3 Metadata-derived predicates (`len(tensor)`, `tensor.shape[0]`, `tensor.device`) bypass bool wrappers
+- Severity: high
+- Description: these are semantically data-dependent branches in user code, but no tensor-bool op exists to anchor attribution.
+- Mitigation: document limitation; do not imply full branch coverage.
+- Test sketch: `ShapePredicateModel`.
+
+### 7.4 Functional conditionals (`torch.where`, masked blending, `torch.cond`) have no Python branch edge
+- Severity: medium
+- Description: users may interpret these as branches, but they are dataflow constructs or alternate control-flow APIs. A Python-AST scheme will miss them entirely.
+- Mitigation: document them as out of scope.
+- Test sketch: `TorchCondModel`.
+
+### 7.5 Predicates cached before the branch site can hide provenance
+- Severity: high
+- Description: `flag = (x.sum() > 0).item(); ...; if flag:` separates tensor creation from bool consumption. The branch exists, but the nearest tensor op line may be far away or in another helper.
+- Mitigation: track scalarization / bool-consumption events, not just tensor creation sites.
+- Test sketch: `CachedFlagModel`.
+
+## 8. Data-Model and Multi-Pass Failure Modes
+
+### 8.1 Same source `if` can take different arms on different passes
+- Severity: blocker
+- Description: recurrent or looped layers can execute the same source line many times with different outcomes. A single aggregate THEN / ELSE annotation on the logical layer is under-specified and can be wrong.
+- Mitigation: keep branch history per `LayerPassLog` and expose aggregate summaries explicitly as sets / counts, not scalars.
+- Test sketch: `AlternatingRecurrentIfModel`.
+
+### 8.2 `LayerLog` first-pass-wins semantics make branch metadata stale by construction
+- Severity: blocker
+- Description: today only 3 fields merge across passes. Any new aggregate branch field added to `LayerLog` without explicit merge rules will silently report pass-1 truth for a multi-pass layer.
+- Mitigation: either never aggregate branch-arm membership onto `LayerLog`, or define merge semantics up front.
+- Test sketch: `FirstPassThenSecondPassElseModel`.
+
+### 8.3 `recurrent_group` and `equivalent_operations` can hide branch divergence
+- Severity: high
+- Description: loop detection groups structurally equivalent ops across passes. If the same op appears in different branch arms across iterations, equivalence grouping can imply sameness where control provenance differs.
+- Mitigation: keep branch attribution orthogonal to equivalence grouping.
+- Test sketch: `EquivalentOpDifferentBranchModel`.
+
+### 8.4 Cross-run reuse of a model object can change branch behavior while keeping old structural assumptions
+- Severity: high
+- Description: a second logged pass on new inputs may take different branches. Any cached or reused branch intervals from a prior run can be wrong even if source text is unchanged.
+- Mitigation: scope branch-attribution caches to a single `ModelLog`.
+- Test sketch: same model instance logged twice with opposite branch outcomes.
+
+### 8.5 Selective saving / cleanup can leave partial branch metadata
+- Severity: medium
+- Description: if future APIs allow dropping unsaved layers or bool nodes before visualization / export, branch edges can dangle or become uninterpretable.
+- Mitigation: either require all layers for branch attribution or aggressively validate and prune metadata during cleanup.
+- Test sketch: `SelectiveSaveIfModel`.
+
+## 9. Performance at Scale
+
+### 9.1 Large `forward()` files make repeated AST search expensive
+- Severity: medium
+- Description: a 1000-line `forward` with many nested conditionals can turn naive `ast.walk` per bool event into noticeable postprocess overhead.
+- Mitigation: parse each file once and pre-index control-flow nodes by span.
+- Test sketch: `HugeNestedIfModel`.
+
+### 9.2 100k-op graphs with many scalar bools amplify backtracking and interval membership checks
+- Severity: high
+- Description: every bool-to-branch-start traversal plus every op-to-branch-interval lookup compounds memory and CPU. Worst case is a highly recurrent model with frequent branch decisions.
+- Mitigation: bound metadata, store compact branch IDs, and benchmark before shipping.
+- Test sketch: synthetic `DeepLoopBranchModel` generating many passes and bool nodes.
+
+### 9.3 Source-context capture already adds memory; branch indexing adds more
+- Severity: medium
+- Description: `save_source_context=True` stores call stacks on every op. Adding per-op branch-arm sets or interval trees can push large-model memory up sharply.
+- Mitigation: make branch attribution opt-in and measure memory overhead.
+- Test sketch: compare `save_source_context=False` vs `True` vs branch mode on a large model.
+
+### 9.4 Degenerate interval trees can become almost as large as the graph
+- Severity: medium
+- Description: if every branch arm is small, nested, and repeated, an interval-tree or arm-map representation can approach O(number of ops + number of branch instances) memory.
+- Mitigation: deduplicate by source span and branch instance only where semantics allow.
+- Test sketch: `ManyTinyNestedIfsModel`.
+
+## 10. Visualization Risks
+
+### 10.1 Deep nesting will create unreadable IF / THEN / ELSE overlays
+- Severity: medium
+- Description: multiple nested arms across modules can produce dense colored edge bundles and labels that obscure the core dataflow graph.
+- Mitigation: add opt-in layers, collapse modes, and hover / detail views; document that deep conditional graphs may need filtered rendering.
+- Test sketch: `DeepNestedVisualizationModel`.
+
+### 10.2 Ops outside any `if` need clear semantics relative to branch-local ops
+- Severity: medium
+- Description: users will ask whether unlabeled edges mean "outside control flow", "unknown", or "unsupported syntax". Ambiguity here becomes a correctness problem in interpretation.
+- Mitigation: distinguish explicit "outside any attributed branch" from "source unavailable / unsupported".
+- Test sketch: mixed branch / non-branch forward with unsupported constructs.
+
+### 10.3 Edge routing for IF / THEN / ELSE can be ambiguous at reconvergence points
+- Severity: high
+- Description: once branches merge, a single downstream op may have parents from multiple arms. Edge labels alone may not reveal whether the op executed unconditionally after merge or belongs to one arm.
+- Mitigation: render arm nodes / branch blocks, not just edge labels.
+- Test sketch: `ReconvergingBranchesModel`.
+
+### 10.4 Legend complexity scales poorly once ELSE, ELIF, unknown, and unsupported states appear
+- Severity: medium
+- Description: the more states the system admits, the easier it is for users to misread the visualization. Visual semantics can become more confusing than helpful.
+- Mitigation: keep a minimal, explicit legend and surface unsupported cases as warnings.
+- Test sketch: combined `if` / `elif` / `else` / unsupported construct demo model.
+
+### 10.5 Existing renderer limitations will already undercut new branch semantics
+- Severity: high
+- Description: ELK currently drops IF/THEN logic entirely, and Graphviz can dedupe away conditional labels. Adding richer branch attribution without fixing renderer semantics will create inconsistent outputs across backends.
+- Mitigation: either keep conditional rendering Graphviz-only and document it, or close renderer parity gaps first.
+- Test sketch: same model rendered with Graphviz and ELK; compare branch labels.
+
+## 11. Backward-Compatibility Traps
+
+### 11.1 Existing `cond_branch_then_children` users may assume THEN-only semantics forever
+- Severity: high
+- Description: repurposing current fields to mean generic branch attribution, or adding ELSE into the same containers, will break downstream code that interprets them as current THEN-only edges.
+- Mitigation: add new fields for new semantics; preserve old fields and document them as legacy THEN-only.
+- Test sketch: compatibility test reading older THEN-only outputs.
+
+### 11.2 `FIELD_ORDER` mismatches will raise hard initialization errors
+- Severity: blocker
+- Description: `LayerPassLog` enforces exact field-set equality with `LAYER_PASS_LOG_FIELD_ORDER`. Adding branch metadata without updating constants, renaming, cleanup, and constructors yields immediate crashes or missing-attribute breakage.
+- Mitigation: update class definitions and all canonical field-order registries together.
+- Test sketch: serialization / construction round-trip with new fields present.
+
+### 11.3 Pickled / serialized `ModelLog`s from older versions will miss new branch fields
+- Severity: blocker
+- Description: unpickling older artifacts into newer classes can fail, or succeed with partially missing branch metadata that downstream code assumes exists.
+- Mitigation: version gates, defaults on load, or explicit non-compatibility documentation.
+- Test sketch: load old fixture pickle into new code and inspect branch fields.
+
+### 11.4 `to_pandas`, exporters, cleanup, and rename steps can silently drop new metadata
+- Severity: high
+- Description: current project notes already flag missing `cond_branch_then_children` coverage in `to_pandas`. Any new fields will need matching updates across exporters, cleanup filters, and label-renaming steps.
+- Mitigation: audit every branch-metadata consumer before release.
+- Test sketch: pandas export and cleanup round-trip preserve branch columns / edges.
+
+### 11.5 Validation currently will not catch internal branch-edge inconsistency
+- Severity: high
+- Description: there is no invariant checking `cond_branch_then_children <-> conditional_then_edges` consistency today. New fields increase the chance of silently inconsistent logs.
+- Mitigation: add invariants for every new branch container before shipping.
+- Test sketch: deliberately corrupt metadata in a unit test and assert validation failure.
+
+## 12. Regression Coverage Proposal
+
+Recommended concrete test models for long-term coverage:
+
+- `NotebookCellIfModel`: defined in notebook-style synthetic source; verifies unsupported or supported-notebook behavior is explicit.
+- `ExecForwardModel`: `forward` injected via `exec`; verifies fail-closed behavior.
+- `DecoratedForwardModel`: wrapped `forward`; verifies wrapper vs user source handling.
+- `MultilinePredicateModel`: multi-line `if` test; verifies exact `If` selection.
+- `ElifLadderModel`: `if` / `elif` / `else`; verifies arm separation.
+- `TernaryIfExpModel`: ternary expression; verifies explicit unsupported or correct handling.
+- `ComprehensionIfModel`: comprehension filter; verifies unsupported or scope-aware behavior.
+- `LoopedIfModel`: same `if` executed repeatedly in one forward with alternating outcomes.
+- `AlternatingRecurrentIfModel`: same logical layer across passes with different branch outcomes; verifies `LayerPassLog` vs `LayerLog` semantics.
+- `ForwardHookIfModel`: hook-created ops around a branch-local module call.
+- `AutogradFunctionIfModel`: conditional inside `autograd.Function.forward`.
+- `DataParallelIfModel`: verifies explicit disablement or replica-aware behavior.
+- `EarlyReturnIfModel`: branch ends forward before merge.
+- `TryExceptInsideIfModel`: nested exception flow inside an `if`.
+- `MatchGuardModel`: Python 3.10+ pattern-match guard.
+- `AssertTensorCondModel`: bool consumption without branch arms; verifies no false IF edge.
+- `BoolCastOnlyModel`: `flag = bool(tensor_cond)` with no branch; verifies no attribution.
+- `ItemScalarizationIfModel`: `if tensor.item() > 0:`; verifies documented false-negative or dedicated support.
+- `ShapePredicateModel`: branch on `x.shape[0]`; verifies non-tensor control flow is out of scope.
+- `TorchWhereModel`: tensorized conditional op; verifies not mislabeled as Python branching.
+- `ReconvergingBranchesModel`: explicit merge after THEN and ELSE; verifies visualization semantics.
+- `HugeNestedIfModel`: performance benchmark with deep nesting and many source intervals.
+- `CRLFEncodedIfModel`: BOM + CRLF source file; verifies stable parsing and line mapping.
+- `HotReloadIfModel`: file changed after execution; verifies snapshot/hash mismatch handling.
+
+## Bottom Line
+
+The dominant failure mode is not "AST parsing is hard"; it is "lexical source ranges are an incomplete proxy for runtime control-flow ownership". The scheme is viable only if it is explicitly scoped, aggressively validated, and honest about unsupported syntax and execution modes. Without that discipline, it will produce confident-looking wrong answers in exactly the cases users most need help understanding.

--- a/.project-context/research/ast-design.md
+++ b/.project-context/research/ast-design.md
@@ -1,0 +1,751 @@
+# AST Design for Full `if` / `elif` / `else` Attribution
+
+## Context
+
+TorchLens already has the raw ingredients for Python-level branch attribution:
+
+- scalar bool tensor ops are detectable (`is_scalar_bool`, `is_terminal_bool_layer`)
+- every relevant op can be associated with user source locations via `FuncCallLocation`
+- Step 5 already marks conditional subgraphs and has partial AST-based THEN detection
+- visualization already understands graph-level conditional edge metadata
+
+Current coverage is intentionally narrow:
+
+- `torchlens/postprocess/control_flow.py` backtracks from terminal bool tensors to mark `in_cond_branch`
+- AST use is limited to detecting whether a child edge lands in the root `if` body
+- only THEN is modeled explicitly (`cond_branch_then_children`, `conditional_then_edges`)
+- false positives are cleaned up after the fact by clearing IF markings when no `ast.If` is found
+- `LayerLog` currently inherits branch metadata from the first pass only, which is insufficient for rolled graphs
+
+This document proposes a full attribution layer for `if` / `elif` / `else`, designed to sit on top of the existing Step 5 flow without changing the rest of TorchLens's graph semantics.
+
+## 1. Core Algorithm For AST Branch Discovery
+
+### Goal
+
+Given `(source_file, bool_line_number)`, locate the enclosing `ast.If` whose `test` expression contains `bool_line_number`, flatten any `elif` chain, and emit a normalized conditional record with explicit THEN / ELIF / ELSE branch ranges.
+
+### Key Design Choice
+
+Treat one Python `if` / `elif` / `else` chain as one logical conditional event.
+
+Example:
+
+```python
+if a:
+    ...
+elif b:
+    ...
+elif c:
+    ...
+else:
+    ...
+```
+
+This becomes one `conditional_id` with branch kinds:
+
+- `then`
+- `elif_1`
+- `elif_2`
+- `else`
+
+The nested `ast.If` nodes used by CPython to represent `elif` are flattened into one record. A true nested `if` inside a branch body remains a separate conditional event.
+
+### Source Index Built Per File
+
+For each parsed file, build:
+
+1. A parent map for AST nodes.
+2. A function-scope index:
+   - `FunctionDef`
+   - `AsyncFunctionDef`
+   - `Lambda` when it has usable line spans
+3. A normalized conditional table for every root `if` chain in each function scope.
+4. A bool-consumer index for all AST contexts that may consume a bool result:
+   - `If.test`
+   - `Assert.test`
+   - `While.test`
+   - `IfExp.test`
+   - comprehension `if` filters
+   - `match case ... if guard`
+   - `bool(...)` casts
+
+### Conditional Record
+
+Recommended normalized record:
+
+```python
+ConditionalRecord = {
+    "id": int,
+    "source_file": str,
+    "function_span": (int, int),
+    "if_stmt_span": (int, int),
+    "test_span": (int, int),
+    "nesting_depth": int,
+    "branch_ranges": {
+        "then": (int, int),
+        "elif_1": (int, int),
+        "elif_2": (int, int),
+        "else": (int, int),
+    },
+    "branch_test_spans": {
+        "then": (int, int),
+        "elif_1": (int, int),
+        "elif_2": (int, int),
+    },
+    "parent_conditional_id": Optional[int],
+    "parent_branch_kind": Optional[str],
+}
+```
+
+Notes:
+
+- `id` can be assigned densely per `ModelLog`, but the cache should internally key records by structural identity: `(source_file, function_start, if_lineno, if_col_offset)`.
+- `branch_ranges` are inclusive line intervals covering the executed body for that branch.
+- `else` is present only for a terminal non-`If` `orelse`.
+
+### Branch Range Extraction
+
+For a root `ast.If`:
+
+1. `then` range = from `body[0].lineno` to `end_lineno(body[-1])`
+2. If `orelse` starts with a single `ast.If`, flatten it as `elif_n`
+3. For each flattened `elif_n`:
+   - test span = nested `If.test`
+   - branch range = nested `If.body`
+4. If the terminal `orelse` is not a single `ast.If`, record one `else` range
+
+### Nested-If Containment Stack
+
+Every conditional record stores its parent relation if it sits inside another branch body:
+
+```python
+(conditional_id, branch_kind, line_range)
+```
+
+That tuple is the unit carried in the nested branch stack.
+
+### Matching A Bool Line To A Conditional
+
+Given `(source_file, bool_line_number)`:
+
+1. Find the smallest function scope containing `bool_line_number`.
+2. Within that scope, find the deepest normalized conditional whose root `test_span` or any `elif_n` test span contains `bool_line_number`.
+3. Return that `ConditionalRecord` and the matching branch-test kind:
+   - root test => `then`
+   - first flattened `elif` test => `elif_1`
+   - second flattened `elif` test => `elif_2`
+   - etc.
+
+This lets multiple atomic bool ops inside `if a and b:` or `if not cond:` resolve to the same conditional record.
+
+### Pseudocode
+
+```text
+function build_file_index(filename):
+    source = read(filename)
+    tree = ast.parse(source)
+    annotate_parents(tree)
+
+    scopes = collect_function_scopes(tree)
+    conditionals = []
+
+    for scope in scopes:
+        for if_node in direct_and_nested_if_nodes(scope):
+            if is_elif_synthetic_child(if_node):
+                continue
+            record = flatten_if_chain(if_node, scope)
+            conditionals.append(record)
+
+    assign_parent_conditionals(conditionals)
+    bool_consumers = collect_bool_consumers(tree, conditionals)
+
+    return FileIndex(scopes, conditionals, bool_consumers)
+
+
+function flatten_if_chain(if_node, scope):
+    record = new ConditionalRecord(...)
+    record.test_span = span(if_node.test)
+    record.branch_ranges["then"] = body_span(if_node.body)
+
+    cursor = if_node
+    elif_index = 0
+    while len(cursor.orelse) == 1 and isinstance(cursor.orelse[0], ast.If):
+        cursor = cursor.orelse[0]
+        elif_index += 1
+        kind = "elif_" + str(elif_index)
+        record.branch_test_spans[kind] = span(cursor.test)
+        record.branch_ranges[kind] = body_span(cursor.body)
+
+    if cursor.orelse is not empty:
+        record.branch_ranges["else"] = body_span(cursor.orelse)
+
+    return record
+
+
+function resolve_bool_line(filename, bool_line_number):
+    index = get_cached_file_index(filename)
+    scope = smallest_scope_containing(index.scopes, bool_line_number)
+    if scope is None:
+        return None
+
+    matches = []
+    for record in scope.conditionals:
+        for kind, test_span in record.branch_test_spans.items():
+            if test_span.start <= bool_line_number <= test_span.end:
+                matches.append((record.depth, record, kind))
+
+    if matches is empty:
+        return None
+
+    return deepest_match(matches).record, deepest_match(matches).kind
+```
+
+## 2. Op Attribution Algorithm
+
+### Goal
+
+For each captured op source line `L`, compute:
+
+```python
+[(conditional_id, branch_kind), ...]
+```
+
+ordered from outermost to innermost active branch.
+
+### Important Distinction
+
+Attribution is based on branch body intervals, not the line span of the entire `if` statement.
+
+That means:
+
+- an op on a line inside `if` / `elif` / `else` body is attributed
+- an op on a line after the conditional, in the same function and same forward pass, is not attributed
+
+This is the core rule that distinguishes "inside the branch" from "after the branch."
+
+### Recommended Attribution Unit
+
+Use the full `func_call_stack`, not just one frame.
+
+Reason:
+
+- the current stack is ordered shallow-to-deep
+- an op inside a helper called from a branch should still inherit the caller's active branch
+- relying on only the first frame is brittle and under-attributes nested user calls
+
+### Per-Frame Attribution
+
+For each `FuncCallLocation(file, line_number, func_name)` in an op's call stack:
+
+1. Load the cached file index.
+2. Find the smallest function scope containing `line_number`.
+3. Query that function's branch interval tree with `line_number`.
+4. Return the matching stack of `(conditional_id, branch_kind)` for that frame.
+
+### Cross-Frame Aggregation
+
+Concatenate per-frame stacks shallow-to-deep, deduplicating adjacent repeats.
+
+Example:
+
+- caller frame line is inside `if outer_cond:`
+- callee frame line is inside `elif inner_cond:`
+
+Result:
+
+```python
+[(outer_id, "then"), (inner_id, "elif_1")]
+```
+
+### Direct Child Edge Attribution
+
+For visualization edge lists, direct branch-entry children of a branch-start node are identified by comparing stacks:
+
+1. Attribute the parent op and each child op.
+2. The first `(conditional_id, branch_kind)` present on the child but not on the parent is the branch entered by that edge.
+3. Emit:
+   - `conditional_then_edges`
+   - `conditional_elif_edges`
+   - `conditional_else_edges`
+
+This avoids hard-coding THEN-only logic in Step 5.
+
+### Proposed `LayerPassLog` Data Structure
+
+Per pass, store the executed branch stack directly:
+
+```python
+conditional_branch_stack: List[Tuple[int, str]]
+```
+
+Semantics:
+
+- empty list => op is not inside an attributed branch body
+- ordered outermost-to-innermost
+- values use normalized branch kinds: `then`, `elif_1`, `elif_2`, `else`
+
+Recommended convenience fields:
+
+```python
+conditional_branch_depth: int
+in_cond_branch: bool  # keep for compatibility; derived from stack length > 0
+```
+
+### Pseudocode
+
+```text
+function attribute_op(op):
+    aggregate_stack = []
+
+    for frame in op.func_call_stack:  # shallow -> deep
+        index = get_cached_file_index(frame.file)
+        if index is None:
+            continue
+
+        scope = smallest_scope_containing(index.scopes, frame.line_number)
+        if scope is None:
+            continue
+
+        frame_stack = query_branch_interval_tree(scope.branch_tree, frame.line_number)
+        aggregate_stack = merge_outer_to_inner(aggregate_stack, frame_stack)
+
+    return aggregate_stack
+
+
+function query_branch_interval_tree(branch_tree, line_number):
+    intervals = branch_tree.query(line_number)  # all branch-body intervals containing line
+    sort intervals by nesting depth ascending
+    return [(interval.conditional_id, interval.branch_kind) for interval in intervals]
+```
+
+## 3. Caching Strategy
+
+### Per-File Parse Cache
+
+Cache key:
+
+```python
+(filename, stat(filename).st_mtime_ns)
+```
+
+Cached value:
+
+- parsed AST module
+- function-scope index
+- normalized conditional records
+- bool-consumer index
+- per-function branch interval trees
+
+This matches the task requirement and is sufficient for interactive model debugging where source files may change between runs.
+
+### Per-Function Branch Interval Tree
+
+For each function scope, pre-build an interval tree over branch body ranges.
+
+Each interval stores:
+
+- `conditional_id`
+- `branch_kind`
+- `line_range`
+- `nesting_depth`
+
+Query complexity is `O(log k + d)` where:
+
+- `k` = number of branch intervals in the function
+- `d` = nesting depth of matches returned
+
+`d` is expected to be small.
+
+### Implementation Shape
+
+No third-party dependency is required. A small centered interval tree or equivalent balanced interval index is enough.
+
+The important contract is:
+
+- build once per function
+- query by source line
+- return all containing branch intervals in nesting order
+
+### Invalidation Policy
+
+1. On any lookup, recompute the cache key from current file mtime.
+2. If the mtime changed, discard the whole file entry.
+3. Rebuild AST, conditional records, bool-consumer index, and all function trees.
+4. No partial invalidation inside a file.
+
+This is conservative and low-risk.
+
+### Lifetime
+
+Keep the cache process-local and reuse it across `log_forward_pass()` calls. Clear only on process exit or explicit manual purge.
+
+## 4. Edge Cases And Handling
+
+### Ternary (`ast.IfExp`)
+
+Handling for v1:
+
+- detect it
+- classify the bool conversion as `ifexp`
+- do not attribute it to branch stacks
+
+Reason:
+
+- it is real Python control flow, but it does not map cleanly onto the current graph-edge visualization model
+- supporting it now would broaden scope beyond the sprint's explicit `if` / `elif` / `else` target
+
+### Comprehension With `if` Filter
+
+Handling for v1:
+
+- detect `comprehension.ifs`
+- classify as `comprehension_filter`
+- do not mark conditional branches
+
+### `assert cond`
+
+Handling:
+
+- detect `ast.Assert.test`
+- classify as `assert`
+- do not mark conditional branches
+
+This is a bool consumer, not a branch body selector.
+
+### `while cond`
+
+Handling for v1:
+
+- detect `ast.While.test`
+- classify as `while`
+- do not attribute branch stacks
+
+Reason:
+
+- loop-body attribution needs different semantics from one-shot branch attribution
+- the user explicitly called out `ast.While` as a v1 scope decision
+
+### `if (x := expr):` Walrus
+
+Handling:
+
+- support it
+- the walrus expression lives inside `If.test`
+- the enclosing `ast.If` still resolves normally by line-span matching
+
+### `if not cond:` And `if a and b:`
+
+Handling:
+
+- support them
+- any atomic bool layer whose source line falls inside the root test span or an `elif` test span maps to the owning conditional record
+- all such bool layers share the same `conditional_id`
+
+For `and` / `or`, short-circuiting means not all sub-bools will fire on every pass. That is acceptable; the conditional record is still the same.
+
+### Match-Case Guards
+
+Handling for v1:
+
+- detect `match_case.guard`
+- classify as `match_guard`
+- do not attribute branch stacks
+
+Documented skip, not a silent miss.
+
+### Multi-Line If-Test
+
+Handling:
+
+- use `node.test.lineno` through `node.test.end_lineno`
+- do not rely on `node.lineno` alone
+
+This is required for correct matching of wrapped conditions such as:
+
+```python
+if (
+    torch.mean(x) > 0
+    and torch.sum(y) > 0
+):
+    ...
+```
+
+### Nested Conditionals
+
+Handling:
+
+- fully supported
+- nested `if` statements inside any branch body become child conditional records
+- branch interval query returns all containing intervals, producing the stack naturally
+
+### Early `return` / `raise` Inside A Branch Body
+
+Handling:
+
+- no special-case change to attribution
+- ops before the `return` / `raise` remain attributed to the branch body
+- ops after the enclosing `if` do not exist on that execution path, so there is nothing extra to mark
+
+## 5. False Positive Filtering
+
+### Problem
+
+Current Step 5 starts from every internally terminated scalar bool and only later clears some false positives if no `ast.If` is found. That is too broad for full branch attribution.
+
+### Proposed Rule
+
+Only scalar bool events classified as `If.test` or flattened `elif` test should participate in branch marking.
+
+Everything else is excluded before graph-level branch metadata is emitted.
+
+### Classification Pipeline
+
+For each internally terminated scalar bool layer:
+
+1. Resolve its best user frame.
+2. Look up all bool-consuming AST contexts whose span contains `bool_line_number`.
+3. Choose the most specific matching context.
+4. Set:
+   - `bool_is_branch = True` only for `if_test` or `elif_test`
+   - `bool_is_branch = False` otherwise
+
+### Non-Branch Bool Contexts To Detect Explicitly
+
+- no enclosing AST bool consumer
+- `assert`
+- `bool(...)` cast
+- comprehension filter
+- `while`
+- `ifexp`
+- `match_guard`
+
+### Recommended Field On Atomic Bool Event
+
+Until a dedicated bool-event class exists, store classification on the bool-producing `LayerPassLog`:
+
+```python
+bool_is_branch: bool
+bool_context_kind: Optional[str]
+bool_conditional_id: Optional[int]
+```
+
+Recommended `bool_context_kind` values:
+
+- `if_test`
+- `elif_test`
+- `assert`
+- `bool_cast`
+- `comprehension_filter`
+- `while`
+- `ifexp`
+- `match_guard`
+- `unknown`
+
+### Step-5 Impact
+
+The Step 5 flood should start only from bool layers with `bool_is_branch=True`.
+
+That is better than the current "mark first, clear later" pattern because it:
+
+- reduces false graph labels
+- reduces unnecessary AST post-validation work
+- gives a reusable explanation for every excluded bool event
+
+## 6. False Negatives (Document, Do Not Fix)
+
+### `if python_bool:`
+
+Invisible to TorchLens.
+
+Reason:
+
+- no tensor bool conversion occurs
+- no tensor operation terminates in a Python truthiness check
+
+### `if tensor.item() > 0:`
+
+Also effectively invisible to the proposed mechanism.
+
+Reason:
+
+- `tensor.item()` converts to a Python scalar first
+- `> 0` yields a Python `bool`
+- `Tensor.__bool__` does not run on the branch decision
+
+So this should be documented as a false negative, not treated as a bug in the AST layer.
+
+### `torch.compile` / `torch.jit`
+
+Degrade gracefully.
+
+Expected failure modes:
+
+- synthetic or rewritten frames
+- source files unavailable
+- line numbers pointing into generated code
+- user frames absent from `func_call_stack`
+
+Handling:
+
+- if branch attribution cannot be resolved from real user source, leave conditional metadata empty
+- keep the rest of TorchLens logging intact
+- do not raise from postprocess
+
+## 7. Data Model Proposal
+
+### `LayerPassLog` Additions
+
+Concrete additions:
+
+```python
+conditional_branch_stack: List[Tuple[int, str]]
+conditional_branch_depth: int
+bool_is_branch: bool
+bool_context_kind: Optional[str]
+bool_conditional_id: Optional[int]
+cond_branch_else_children: List[str]
+cond_branch_elif_children: Dict[int, List[str]]
+```
+
+Notes:
+
+- `in_cond_branch` stays for compatibility and becomes derivable from `conditional_branch_stack`
+- `cond_branch_then_children` stays
+- `cond_branch_elif_children` maps `elif_index -> child layer labels`
+- `cond_branch_else_children` mirrors the current THEN child convention
+
+### `ModelLog` Additions
+
+Concrete additions:
+
+```python
+conditional_events: List[Dict[str, Any]]
+conditional_elif_edges: List[Tuple[int, int, str, str]]
+conditional_else_edges: List[Tuple[int, str, str]]
+```
+
+Recommended `conditional_events` entry shape:
+
+```python
+{
+    "id": int,
+    "kind": "if_chain",
+    "source_file": str,
+    "function_span": (int, int),
+    "if_stmt_span": (int, int),
+    "test_span": (int, int),
+    "nesting_depth": int,
+    "branch_ranges": Dict[str, Tuple[int, int]],
+    "branch_test_spans": Dict[str, Tuple[int, int]],
+    "parent_conditional_id": Optional[int],
+    "parent_branch_kind": Optional[str],
+    "bool_layers": List[str],
+}
+```
+
+Edge tuple semantics:
+
+- `conditional_then_edges` can remain as-is for compatibility or be widened to include `conditional_id`
+- `conditional_elif_edges`: `(conditional_id, elif_index, parent_label, child_label)`
+- `conditional_else_edges`: `(conditional_id, parent_label, child_label)`
+
+### Multi-Pass Merge Semantics On `LayerLog`
+
+This is the important rolled-graph design point.
+
+Current behavior copies conditional metadata from the first pass only. That is not acceptable once full branch stacks exist.
+
+Recommended aggregate semantics:
+
+```python
+conditional_branch_stacks: List[List[Tuple[int, str]]]
+conditional_branch_stack_passes: Dict[Tuple[Tuple[int, str], ...], List[int]]
+in_cond_branch: bool  # OR across passes
+cond_branch_then_children: List[str]  # union across passes, no-pass labels
+cond_branch_else_children: List[str]  # union across passes, no-pass labels
+cond_branch_elif_children: Dict[int, List[str]]  # union across passes, no-pass labels
+```
+
+Rules:
+
+1. `in_cond_branch` = OR across passes
+2. `conditional_branch_stacks` = unique stack signatures in first-seen order
+3. `conditional_branch_stack_passes` = which passes used each signature
+4. branch-entry child lists are unions across passes after stripping pass suffixes
+
+Why this matters:
+
+- the same rolled layer may execute in THEN on one pass and ELSE on another
+- preserving only first-pass metadata would silently mislabel the rolled graph
+
+## 8. Algorithmic Complexity Analysis
+
+Let:
+
+- `F` = number of source files touched by a run
+- `N_f` = AST size of file `f`
+- `C_f` = number of normalized conditionals in file `f`
+- `K_s` = number of branch intervals in function scope `s`
+- `M` = number of captured ops
+- `S` = average user-visible call-stack depth per op
+- `B` = number of internally terminated scalar bool layers
+
+### Preprocessing
+
+Per file:
+
+- parse AST: `O(N_f)`
+- normalize all conditionals: `O(C_f)`
+- build per-function interval trees: `O(sum(K_s log K_s))`
+
+Across all files:
+
+- `O(sum_f N_f + sum_f C_f + sum_s K_s log K_s)`
+
+### Bool Classification
+
+Per scalar bool event:
+
+- file cache lookup: `O(1)`
+- scope lookup: `O(log number_of_scopes_in_file)` if scopes are indexed
+- conditional / bool-consumer lookup: `O(log C_f + d)` with interval indexes
+
+Total:
+
+- `O(B log C)` in the indexed case
+
+### Op Attribution
+
+Per op:
+
+- one branch query per call-stack frame
+- `O(S * (log K + d))`
+
+Total:
+
+- `O(M * S * (log K + d))`
+
+In practice:
+
+- `S` is small
+- `d` is small
+- AST work only happens when source-context-driven branch attribution is needed
+
+### Memory
+
+Per cached file:
+
+- AST tree: `O(N_f)`
+- normalized conditionals and indexes: `O(C_f + sum K_s)`
+
+This is acceptable because branch attribution runs only when atomic bools are present.
+
+## 9. Open Questions Requiring Architect Decision
+
+1. Should full branch attribution require `save_source_context=True`, or should TorchLens always capture minimal `(file, line)` call-location data even when full source snippets are disabled?
+2. Should `conditional_id` be a dense per-`ModelLog` integer or a structural key derived from `(file, function_start, if_lineno, col_offset)`?
+3. Should `conditional_then_edges` be widened to include `conditional_id`, or should compatibility with the current two-tuple shape be preserved and only new edge lists carry IDs?
+4. In rolled graphs, should visualization show unioned branch labels, pass-number-qualified branch labels, or both when one `LayerLog` appears in different branches across passes?
+5. Is line-level attribution precise enough, or should TorchLens capture column offsets for bool ops and regular ops to disambiguate multiple bool consumers on the same line?
+6. Should `ast.IfExp` and `ast.While` stay explicitly out of v1 scope, or should they be promoted into the same conditional-event model now to avoid a second data-model expansion later?

--- a/.project-context/research/io-audit-claude.md
+++ b/.project-context/research/io-audit-claude.md
@@ -1,0 +1,633 @@
+# TorchLens I/O Audit Report
+
+**Audit Date**: 2026-04-23
+**Scope**: Save/load/export functionality, pickle behavior, data class structure
+**Status**: READ-ONLY audit (no modifications made)
+
+---
+
+## 1. INVENTORY
+
+### Existing I/O Methods
+
+| Location | Signature | Behavior |
+|----------|-----------|----------|
+| `user_funcs.py:695` | `validate_batch_of_models_and_inputs(...) -> pd.DataFrame` | Reads/writes validation results to CSV via `pd.read_csv()` and `to_csv()` |
+| `data_classes/interface.py:421` | `to_pandas(self) -> pd.DataFrame` | Exports 59 fields from all LayerPassLog entries to single-level pandas DataFrame |
+| `data_classes/layer_pass_log.py:455` | `save_tensor_data(t, t_args, t_kwargs, ...)` | Stores tensor via `safe_copy()`, optionally moves device, applies `activation_postfunc` |
+| `data_classes/layer_pass_log.py:503` | `log_tensor_grad(grad: torch.Tensor)` | Stores gradient via `detach().clone()` (bare clone, not deep-copy) |
+| `data_classes/model_log.py:337` | `__getstate__(self) -> Dict` | Pickle serialization: strips `_module_logs`, `_buffer_accessor`, `_module_build_data` weakrefs |
+| `data_classes/model_log.py:346` | `__setstate__(self, state)` | Pickle deserialization: rebuilds accessors, restores `source_model_log` refs on all LayerPassLog/LayerLog/ModuleLog objects |
+| `data_classes/layer_pass_log.py:390` | `__getstate__(self) -> Dict` | Pickle: strips `_source_model_log_ref` (weakref) |
+| `data_classes/layer_pass_log.py:396` | `__setstate__(self, state)` | Pickle: restores `__dict__` from state |
+| `data_classes/layer_log.py:216` | `__getstate__(self) -> Dict` | Pickle: strips `_source_model_log_ref` weakref |
+| `data_classes/layer_log.py:222` | `__setstate__(self, state)` | Pickle: restores `__dict__` from state |
+| `data_classes/layer_pass_log.py:417` | `copy(self)` | Selective-depth copy: deep-copies most fields except tensors, funcs, RNG states (documented) |
+| `capture/trace.py:55` | `save_new_activations(model_log, model, input_args, ...)` | Re-runs model in fast mode, saves only requested layers; clears prior activations in place |
+| `data_classes/cleanup.py:42` | `cleanup(self)` | Full teardown: deletes all attributes from ModelLog and LayerPassLog entries, breaks circular refs, calls `torch.cuda.empty_cache()` |
+| `data_classes/cleanup.py:31` | `release_param_refs(self)` | Releases nn.Parameter references from all ParamLogs to allow model GC |
+
+### No Explicit I/O Functions Found
+
+- **No `save()` / `load()` / `export()` methods** on ModelLog or data classes
+- **No torch.save / torch.load** calls in the codebase
+- **No JSON, CSV, Parquet, HDF5, or SafeTensors serialization** beyond `to_pandas()` + manual CSV
+- **No streaming-to-disk** during forward pass
+- **No activation-to-disk** utilities
+- **No format versioning** infrastructure
+
+---
+
+## 2. DATA CLASS SHAPE TABLE
+
+### ModelLog
+
+| Attribute | Type | Tensor? | Location | Notes |
+|-----------|------|---------|----------|-------|
+| `model_name` | str | No | model_log.py:164 | Model class name |
+| `layer_list` | List[LayerPassLog] | Cross-ref | model_log.py:197 | Ordered list of all layer passes (post-processing) |
+| `layer_dict_all_keys` | OrderedDict[str, LayerPassLog] | Cross-ref | model_log.py:199 | All lookup keys → entry |
+| `layer_logs` | OrderedDict[str, LayerLog] | Cross-ref | model_log.py:202 | No-pass label → aggregate |
+| `param_logs` | ParamAccessor | Cross-ref | model_log.py:258 | ParamLog objects for each parameter |
+| `_module_logs` | ModuleAccessor | Cross-ref | model_log.py:279 | ModuleLog objects |
+| `_buffer_accessor` | BufferAccessor | Cross-ref | model_log.py:230 | BufferLog objects |
+| `total_activation_memory` | int | No | model_log.py:253 | Sum of all saved tensor sizes |
+| `num_tensors_saved` | int | No | model_log.py:254 | Count of layers with saved activations |
+
+### LayerPassLog
+
+| Attribute | Type | Tensor? | Location | Notes |
+|-----------|------|---------|----------|-------|
+| `activation` | torch.Tensor | **Tensor** | layer_pass_log.py:135 | Actual output tensor (or None). Device/grad controlled by `output_device`, `detach_saved_tensor`. May be postprocessed via `activation_postfunc`. |
+| `gradient` | torch.Tensor | **Tensor** | layer_pass_log.py:155 | Backward gradient (bare clone, not autograd-linked) |
+| `has_saved_activations` | bool | No | layer_pass_log.py:136 | Whether `activation` is not None |
+| `has_gradient` | bool | No | layer_pass_log.py:157 | Whether `gradient` is not None |
+| `captured_args` | List[Any] | Mixed | layer_pass_log.py:141 | May contain cloned tensors + primitives |
+| `captured_kwargs` | Dict[str, Any] | Mixed | layer_pass_log.py:142 | Same as above |
+| `tensor_shape` | Tuple[int,...] | No | layer_pass_log.py:143 | Metadata only |
+| `tensor_dtype` | torch.dtype | No | layer_pass_log.py:144 | Metadata only |
+| `tensor_memory` | int | No | layer_pass_log.py:145 | Size in bytes |
+| `func_name` | str | No | layer_pass_log.py:164 | Operation name (e.g., 'conv2d') |
+| `func_applied` | Callable | No | layer_pass_log.py:163 | Direct reference to torch function (not pickled by default Python rules) |
+| `parent_layers` | List[str] | No | layer_pass_log.py:205 | Layer labels (cross-references) |
+| `child_layers` | List[str] | No | layer_pass_log.py:208 | Layer labels (cross-references) |
+| `parent_param_logs` | List[ParamLog] | Cross-ref | layer_pass_log.py:187 | References to ParamLog objects |
+| `func_rng_states` | Dict[str, torch.Tensor] | Mixed | layer_pass_log.py:169 | RNG state dicts (large, not mutated) |
+| `func_autocast_state` | Dict | No | layer_pass_log.py:170 | Autocast context metadata |
+| `children_tensor_versions` | Dict | Mixed | layer_pass_log.py:151 | RAW (not postprocessed) child tensor values for validation |
+| `func_config` | Dict | No | layer_pass_log.py:267 | Hyperparameters (stride, padding, etc.) |
+
+### LayerLog
+
+| Attribute | Type | Tensor? | Location | Notes |
+|-----------|------|---------|----------|-------|
+| `layer_label` | str | No | layer_log.py:68 | Human-readable no-pass label |
+| `func_applied` | Callable | No | layer_log.py:81 | Shared reference (not deep-copied) |
+| `passes` | Dict[int, LayerPassLog] | Cross-ref | layer_log.py (implied) | Per-pass details |
+| `_source_model_log_ref` | weakref | Cross-ref | layer_log.py:76 | Weakref to owning ModelLog |
+
+### ParamLog
+
+| Attribute | Type | Tensor? | Location | Notes |
+|-----------|------|---------|----------|-------|
+| `address` | str | No | param_log.py:51 | Full address (e.g., 'features.0.weight') |
+| `name` | str | No | param_log.py:52 | Short name (e.g., 'weight') |
+| `shape` | Tuple[int,...] | No | param_log.py:53 | Parameter shape |
+| `dtype` | torch.dtype | No | param_log.py:54 | Parameter dtype |
+| `num_params` | int | No | param_log.py:55 | Total # of scalar values |
+| `memory` | int | No | param_log.py:56 | Size in bytes |
+| `trainable` | bool | No | param_log.py:57 | Requires grad? |
+| `_param_ref` | Optional[nn.Parameter] | **Tensor** (indirect) | param_log.py:66 | Direct reference to actual parameter (prevents GC, used for lazy grad access) |
+| `_grad_shape`, `_grad_dtype`, `_grad_memory` | Metadata | No | param_log.py:73-75 | Lazy gradient metadata |
+
+### ModuleLog / ModulePassLog
+
+| Attribute | Type | Tensor? | Location | Notes |
+|-----------|------|---------|----------|-------|
+| `address` | str | No | module_log.py:123 | Module address in hierarchy |
+| `layers` / `all_layers` | List[str] | No | module_log.py (MultiPass/Aggregate) | Layer label references |
+| `forward_args` | Optional[tuple] | Mixed | module_log.py:147 | Captured module forward inputs (may contain tensors) |
+| `forward_kwargs` | Optional[dict] | Mixed | module_log.py:148 | Captured module forward keyword inputs |
+
+### BufferLog
+
+| Attribute | Type | Tensor? | Location | Notes |
+|-----------|------|---------|----------|-------|
+| (extends LayerPassLog) | | | buffer_log.py:22 | Inherits all LayerPassLog fields; `buffer_address` field identifies the buffer |
+| `buffer_address` | str (inherited) | No | layer_pass_log.py:224 | Full address (e.g., 'features.0.running_mean') |
+| `name` (computed) | str | No | buffer_log.py:36 | Last segment of buffer_address |
+| `module_address` (computed) | str | No | buffer_log.py:44 | Everything before last dot in buffer_address |
+
+---
+
+## 3. GAPS
+
+### a. Round-trip Pickling ModelLog
+
+**Status**: ✅ **PARTIAL SUPPORT** (basic pickle works, but with caveats)
+
+**What exists**:
+- `ModelLog.__getstate__()` strips `_module_logs`, `_buffer_accessor`, `_module_build_data` (weakref-backed accessors)
+- `ModelLog.__setstate__()` rebuilds accessors and restores `source_model_log` refs on all child entries
+- `LayerPassLog.__getstate__()` strips `_source_model_log_ref` weakref
+- `LayerPassLog.__setstate__()` restores `__dict__`
+- `LayerLog.__getstate__()` / `__setstate__()` follow same pattern
+
+**Limitations**:
+- `func_applied` (direct reference to torch function) may or may not pickle depending on PyTorch version/build
+- `func_rng_states` contains torch RNG state dicts (pickle-able but version-brittle)
+- `gradient` is stored as bare clone; after unpickling, gradients are stale (no connection to live parameters)
+- `_param_ref` pins model parameters (prevents GC); unpickling does NOT restore live refs to nn.Parameters
+- `children_tensor_versions` stores raw tensor data for validation; on round-trip, these are disconnected from the model
+- **No test coverage for pickle round-trip in visible codebase**
+- **No documentation** on pickle compatibility or version stability
+
+**Risk**: High. Pickling works for metadata but activations/parameters become stale on load. Suitable for post-mortem inspection, not for resuming training.
+
+---
+
+### b. Pandas DataFrame Export
+
+**Status**: ✅ **SINGLE-LEVEL ONLY**
+
+**What exists**:
+- `model_log.to_pandas()` (interface.py:421) exports 59 fields from all LayerPassLog entries
+- One row per layer pass (not per module, not per parameter)
+- Fields include metadata (shape, dtype, func_name), graph edges (parent_layers, child_layers), module/param metadata
+- Automatic type conversion (int, bool, etc.)
+
+**Missing**:
+- No parameter-level export (one row per ParamLog)
+- No module-level export (one row per ModuleLog)
+- No buffer-level export (one row per BufferLog)
+- No activation tensor values in DataFrame (only metadata)
+- No hierarchical/multi-level index support
+- **No `to_csv()` / `to_parquet()` / `to_json()` on ModelLog** (user must call `to_pandas().to_csv()` manually)
+
+---
+
+### c. CSV / Parquet / JSON Export
+
+**Status**: ❌ **NOT IMPLEMENTED (except CSV via to_pandas().to_csv())**
+
+**What exists**:
+- `validate_batch_of_models_and_inputs()` writes results CSV via `pd.to_csv()`
+- User can call `model_log.to_pandas().to_csv()` manually
+
+**Missing**:
+- No native `model_log.to_csv()` method
+- No `to_parquet()` support
+- No `to_json()` support
+- No schema versioning for exported formats
+- No round-trip deserialization
+
+**Note**: numpy arrays (parent_layers, parent_param_shapes, etc.) in DataFrame require custom encoding for JSON/Parquet.
+
+---
+
+### d. Activation-to-Disk
+
+**Status**: ❌ **NOT IMPLEMENTED**
+
+**Current behavior**:
+- All saved activations live in RAM in `layer_pass_log.activation` as torch.Tensor
+- No checkpointing to disk during or after forward pass
+- `save_new_activations()` re-runs model to refresh activations (expensive)
+- No selective/streaming save during forward pass
+
+**Missing**:
+- No eager save-to-disk hook
+- No streaming activation sink
+- No sparse/selective activation save (would require forward-pass hook system)
+- No memory-mapped tensor access post-save
+- No automatic offload to disk when RAM budget exceeded
+
+**Risk**: Large models with many layers hit memory limits. Users must manually implement activation offloading.
+
+---
+
+### e. Loading / Deserialization
+
+**Status**: ❌ **NOT IMPLEMENTED**
+
+**Current workflow**:
+- pickle: `pickle.load(f)` → ModelLog object (weakly supported, see section 3a)
+- CSV: No built-in loader; user must create ModelLog from scratch
+- Parquet/JSON: Not supported
+- **No lazy loading** of activations from disk
+- **No round-trip validation** (unpickle → verify = original)
+
+**Missing**:
+- No `ModelLog.load(path)` classmethod
+- No format detection / auto-parser
+- No lazy tensor loading
+- No dependency injection (binding activations to new model after unpickle)
+- No migration for schema changes (format versioning absent)
+
+---
+
+## 4. RISKS
+
+### Circular References & GC
+
+**Confirmed cycles**:
+1. `ModelLog.layer_list[i].source_model_log → ModelLog` (broken by `__getstate__`, requires explicit cleanup)
+2. `ModelLog.layer_logs[label].passes[1].source_model_log → ModelLog` (same)
+3. `ModelLog._module_logs[addr]._source_model_log_ref → ModelLog` (weakref, should be safe)
+4. `ParamLog._param_ref → nn.Parameter → model.parameters()` (pins model, OK for short-term use)
+
+**Mitigation**:
+- `cleanup()` method (cleanup.py:42) explicitly breaks all forward refs
+- No automatic cleanup; user must call `model_log.cleanup()` to free memory
+- Python's cyclic GC handles missed explicit cleanup, but slower
+
+**Risk for I/O**: After unpickling, circular refs may not be properly re-established. Calling `cleanup()` on unpickled ModelLog may delete still-needed objects.
+
+---
+
+### Tensor Device & Grad State on Round-Trip
+
+**Pickle behavior**:
+- `activation` tensor device is preserved (GPU/CPU tag stays)
+- Gradient tensors are stored as bare clones (no autograd links)
+- `gradient` on unpickle is a stale snapshot, not live with model
+
+**Risk**:
+- Loading a ModelLog from pickle on a different device (model on GPU, saved on CPU) → `activation` device mismatch
+- Trying to run `loss.backward()` using unpickled activations → no gradient flow (tensors are detached)
+- No automatic device transfer on load
+
+---
+
+### Memory Footprint on Large Models
+
+**Current strategy**: All activations in RAM
+- For ResNet-152 (152 layers) with batch_size=32: ~2-5 GB depending on layer depth
+- For Vision Transformers: even larger (many attention heads)
+- No tiered memory (RAM → disk → eviction)
+
+**Pickle overhead**:
+- `func_rng_states` stores full RNG state per layer (100-200 bytes × 1000 layers = 100-200 KB)
+- `captured_args` stores deep clones of input tensors to each function (can be large)
+- No compression
+
+**Risk**: Unpickling a large ModelLog may spike RAM usage (deserialize full graph + activations).
+
+---
+
+### Global Toggle State Interactions
+
+**Toggle mechanism** (_state._logging_enabled):
+- Single global boolean flag
+- Checked in ~2000 wrapped torch functions
+- `pause_logging()` context manager used during `activation_postfunc` to prevent logging postfunc ops
+
+**Pickle risk**:
+- `_logging_enabled` is not part of ModelLog (lives in module state)
+- Unpickling does not restore logging state
+- If user unpickles in an active logging session, cross-contamination possible (unlikely but plausible)
+
+**Risk**: LOW (logging state is global and user-managed, not tied to ModelLog serialization).
+
+---
+
+### PyTorch Version Brittleness
+
+**Observed version-sensitive code**:
+- `func_rng_states` stores `torch.get_rng_state()`, `torch.cuda.get_rng_state()` (format changes between PyTorch versions)
+- `torch.dtype` objects may not unpickle identically across versions
+- `func_applied` (function reference) may not pickle if torch functions are refactored
+
+**Risk**:
+- ModelLog pickled in PyTorch 2.0 may not unpickle in PyTorch 2.2
+- No version tag in pickle file
+- No migration path for schema changes
+
+---
+
+### Pickle Security
+
+**Current state**:
+- Default pickle protocol used (no explicit `protocol=5` seen)
+- `func_applied` stores direct references to torch callables (arbitrary code potential if attacker provides malicious torch module)
+- **No signature verification**
+
+**Risk**: Loading untrusted ModelLog pickles is unsafe (attacker can craft a pickle that calls arbitrary code via pickled function references). Best practice: only unpickle from trusted sources.
+
+---
+
+## 5. RECOMMENDATIONS
+
+### 5.1 Format Strategy
+
+**Recommended Approach: Parquet-primary + pickle fallback**
+
+**Rationale**:
+1. **Parquet** (columnar, typed, language-neutral, schema evolution):
+   - Native support for numpy arrays → list-of-lists conversion
+   - Handles 59-column DataFrame cleanly
+   - Version-safe schema (metadata in Parquet file)
+   - Can add parameter/module/buffer tables as separate files
+   - Suitable for data pipelines (dbt, pandas, polars, DuckDB)
+
+2. **Pickle** (backward compat only):
+   - Current code has `__getstate__/__setstate__` but untested
+   - Fine for temporary caches, not long-term archival
+   - Good for resume-training (activations must be regenerated anyway)
+
+3. **Reject JSON**:
+   - Poor for tensors (no native uint8, no compression)
+   - Verbose for large graphs
+   - Use Parquet + CSV instead
+
+4. **Reject HDF5/SafeTensors**:
+   - Overkill for metadata-heavy logs (not primarily tensor storage)
+   - Parquet is simpler, language-neutral
+
+**Tradeoff**: Parquet requires new dependency (pyarrow); pickle is built-in but unsafe + version-brittle.
+
+**Recommendation**:
+- Export: `model_log.to_parquet(path)` (saves metadata table + optional activation tensors in separate .pt files)
+- Load: `ModelLog.from_parquet(path)` (reconstructs from metadata, optionally lazy-loads activations)
+- Fallback: `pickle.dumps(model_log)` still works, but warn user about instability
+
+---
+
+### 5.2 Streaming-to-Disk Feasibility
+
+**Eager save during forward pass**: ✅ **Feasible, Medium Effort (2-3 sprints)**
+
+**Approach**:
+1. Add optional `activation_sink: Callable[[str, torch.Tensor], None]` parameter to `log_forward_pass()`
+2. In `log_function_output_tensors()`, after `save_tensor_data()`, call:
+   ```python
+   if self.source_model_log.activation_sink is not None:
+       activation_sink(layer_label, self.activation)
+   ```
+3. User provides sink (e.g., save to disk, write to shared memory, send to queue)
+
+**Example sink**:
+```python
+def disk_sink(label: str, tensor: torch.Tensor):
+    torch.save(tensor, f"/tmp/activations/{label}.pt")
+
+model_log = log_forward_pass(model, input, activation_sink=disk_sink)
+```
+
+**Streaming (selective save)**: ✅ **Also feasible, same infrastructure**
+- User passes `layers_to_save=['conv2d_1_1', 'conv2d_2_1']` → only those layers hit the sink
+- Reduces memory from O(L) to O(k) where k = # of saved layers
+
+**Effort**:
+- Modify `save_tensor_data()`: +10 lines
+- Add parameter to ModelLog.__init__: +1 line
+- Tests: +3 test cases
+- Docs: +1 example notebook
+- **Total: ~20-40 hours (1 week, one engineer)**
+
+**Tradeoff**: Eager sink requires user to implement; streaming isn't automatic. Consider lazy-load infrastructure (see below) as complement.
+
+---
+
+### 5.3 Lazy vs Eager Tensor Loading
+
+**Recommended: Hybrid**
+
+**Lazy loading (first-class support)**:
+1. On disk: activations stored as separate torch.pt files (one per layer)
+2. On unpickle: `ModelLog.from_parquet(path, lazy=True)` → metadata loaded, activations replaced with `_ActivationRef` proxy objects
+3. On access: `layer_log.activation` → if proxy, load from disk on-demand, cache in RAM
+
+**Benefits**:
+- Users can explore metadata (graph, FLOPs, module structure) without loading activations
+- Selective activation load: `layer_log.activation` vs `layer_log.activation_shape` (metadata only)
+- Suitable for very large models (VLM, LLM)
+
+**Implementation**:
+```python
+class _ActivationRef:
+    def __init__(self, path: str):
+        self.path = path
+        self._cached = None
+
+    def __getattr__(self, name):
+        if self._cached is None:
+            self._cached = torch.load(self.path)
+        return getattr(self._cached, name)
+
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        # Transparent in torch operations
+        return func(self._get_tensor(), **kwargs) if kwargs else func(self._get_tensor())
+
+    def _get_tensor(self):
+        if self._cached is None:
+            self._cached = torch.load(self.path)
+        return self._cached
+```
+
+**Eager (status quo)**:
+- `from_parquet(path, lazy=False)` loads all activations into RAM immediately
+- Suitable for small-to-medium models
+
+**Tradeoff**: Lazy adds ~200 lines, requires careful transparent tensor handling. Worth it for 1.0 release.
+
+---
+
+### 5.4 Concrete API Proposal
+
+```python
+# Export
+model_log.to_parquet(
+    path: str,
+    include_activations: bool = False,
+    include_gradients: bool = False,
+    compression: str = "snappy",
+)
+# Saves metadata table(s) to {path}/metadata.parquet
+# If include_activations: creates {path}/activations/ with one .pt per layer
+# If include_gradients: creates {path}/gradients/ with one .pt per layer
+
+# Load
+model_log = ModelLog.from_parquet(
+    path: str,
+    lazy_activations: bool = True,
+    lazy_gradients: bool = True,
+    device: str = "cpu",
+)
+# Reconstructs ModelLog from parquet metadata
+# If lazy: activations are _ActivationRef proxies; access triggers disk load + cache
+# device: move tensors to specified device on load
+
+# Backward compat (pickle)
+model_log = pickle.load(open("model_log.pkl", "rb"))
+# Still works, but deprecated. Warn user: "Pickle format is unstable across PyTorch versions. Use to_parquet() for archival."
+
+model_log.to_pickle(path: str)
+model_log = ModelLog.from_pickle(path: str)
+# Explicit wrappers (clearer intent than raw pickle.dump/load)
+
+# Parameter/Module/Buffer-level export (future, not in 1.0)
+model_log.params.to_csv("params.csv")
+model_log.modules.to_parquet("modules.parquet")
+model_log.buffers.to_csv("buffers.csv")
+```
+
+**Per-layer detail export** (also future):
+```python
+for layer_label, layer_log in model_log.layer_logs.items():
+    layer_log.to_dict()  # → {'layer_label': ..., 'activation': ..., ...}
+
+# Or bulk:
+model_log.to_dict_list()  # → [{'layer_label': 'conv2d_1_1', ...}, ...]
+```
+
+---
+
+### 5.5 Backward Compat & Format Versioning
+
+**Schema versioning**:
+1. Add `_io_format_version = 1` to ModelLog
+2. On export to parquet: embed version in file metadata (Parquet schema footer)
+3. On import: check version, migrate if needed
+   ```python
+   def _migrate_v0_to_v1(state: Dict) -> Dict:
+       # Example: add new fields with defaults
+       state['new_field'] = None
+       return state
+   ```
+
+**Backward compat strategy**:
+- Keep `__getstate__/__setstate__` working (pickle support) for ≥ 2 minor versions
+- Parquet format is primary going forward
+- No breaking changes to pickle unless major version bump
+- Document in CHANGELOG
+
+**Migration example**:
+```python
+@classmethod
+def from_parquet(cls, path, ...):
+    schema_version = _read_parquet_metadata(path)['io_format_version']
+    df = pd.read_parquet(path)
+    if schema_version == 0:
+        df = _migrate_v0_to_v1(df)
+    return cls._from_dataframe(df)
+```
+
+---
+
+## 6. IMPLEMENTATION OUTLINE
+
+### Phase 1: Parquet Export (1 sprint, 1 engineer)
+**Files touched**: `data_classes/interface.py`, `data_classes/model_log.py`
+
+1. Add `to_parquet(path, include_activations, ...)` method
+   - Reuse `to_pandas()` logic
+   - Optionally save activations as separate `.pt` files
+   - Write schema version to parquet metadata
+   - Tests: round-trip to_parquet → read_parquet
+
+**Deliverable**: Users can export metadata to parquet.
+
+---
+
+### Phase 2: Parquet Import + Lazy Loading (1.5 sprints, 1 engineer)
+**Files touched**: `data_classes/model_log.py`, `data_classes/interface.py`, new file `data_classes/lazy_activation.py`
+
+1. Create `_ActivationRef` proxy class (lazy_activation.py)
+   - `__getattr__`, `__torch_function__` for transparency
+   - Caching + device handling
+2. Add `from_parquet()` classmethod to ModelLog
+   - Deserialize metadata from parquet
+   - Reconstruct LayerLog, LayerPassLog, ModuleLog objects
+   - Optionally bind activations (eager or lazy)
+3. Tests: round-trip export → import, lazy load on access, device transfer
+
+**Deliverable**: Users can import metadata + lazy-load activations.
+
+---
+
+### Phase 3: Streaming Activation Sink (1 sprint, 1 engineer)
+**Files touched**: `user_funcs.py`, `data_classes/model_log.py`, `capture/output_tensors.py`
+
+1. Add `activation_sink: Optional[Callable]` parameter to `log_forward_pass()`
+2. Pass sink to ModelLog.__init__
+3. In `log_function_output_tensors()`, after `save_tensor_data()`:
+   ```python
+   if self.source_model_log.activation_sink is not None:
+       self.source_model_log.activation_sink(
+           self.layer_label_no_pass, self.activation
+       )
+   ```
+4. Tests: verify sink called with correct labels/tensors
+
+**Deliverable**: Users can stream activations to disk during forward pass.
+
+---
+
+### Phase 4: Pickle Hardening (0.5 sprint, 1 engineer)
+**Files touched**: `data_classes/model_log.py`, `data_classes/layer_pass_log.py`, `data_classes/layer_log.py`
+
+1. Add `_io_format_version` to ModelLog (set to 1)
+2. Enhance `__getstate__()` to include version info
+3. Add `from_pickle()` classmethod for clarity
+4. Add warning on `__setstate__()` if unpickling stale model
+
+**Deliverable**: Pickle still works; users aware it's not primary path.
+
+---
+
+### Phase 5: Per-Level Export Methods (1.5 sprints, 1 engineer)
+**Files touched**: `data_classes/param_log.py`, `data_classes/module_log.py`, `data_classes/buffer_log.py`
+
+1. Add `to_dict()` / `to_pandas()` / `to_csv()` to ParamAccessor
+2. Add `to_dict()` / `to_pandas()` / `to_parquet()` to ModuleAccessor
+3. Add `to_csv()` to BufferAccessor
+4. Tests: round-trip export for each
+
+**Deliverable**: Fine-grained export options (parameters, modules, buffers separately).
+
+---
+
+### Phase 6: Documentation + Examples (1 sprint, 1 engineer)
+**Files touched**: `docs/io.md`, example notebooks
+
+1. Write guide: "Saving & Loading ModelLogs"
+   - Best practices (parquet for archival, pickle for quick debugging)
+   - Device handling
+   - Memory management (lazy loading for large models)
+2. Example notebook: export layer graph to parquet → analyze in Pandas
+3. Example notebook: resume training with saved activations (for validation)
+4. Deprecation notice: pickle format instability
+
+**Deliverable**: Users understand all export options and tradeoffs.
+
+---
+
+## Summary Table
+
+| Feature | Status | Recommendation | Effort |
+|---------|--------|-----------------|--------|
+| Pickle round-trip | ✅ Partial | Harden + deprecation warning | 0.5 sprint |
+| Pandas export | ✅ Exists | No change (stays) | — |
+| Parquet export | ❌ Missing | Add in Phase 1 | 1 sprint |
+| Parquet import | ❌ Missing | Add in Phase 2 | 1.5 sprints |
+| Lazy loading | ❌ Missing | Add in Phase 2 | 1.5 sprints |
+| Streaming sink | ❌ Missing | Add in Phase 3 | 1 sprint |
+| Per-level export | ❌ Missing | Add in Phase 5 | 1.5 sprints |
+| Format versioning | ❌ Missing | Add in Phase 4 | 0.5 sprint |
+| **Total** | | | **7.5 sprints** (2.5 months, 1 FTE) |
+
+---
+
+## Conclusion
+
+TorchLens has **no production I/O system**. Pickle hooks exist but are untested and unstable. The single export pathway is `to_pandas().to_csv()`, which covers only metadata. Activations are RAM-resident only.
+
+**Recommended path forward**:
+1. **Parquet as primary format** (safer, version-stable, interoperable)
+2. **Lazy loading for large models** (metadata exploration without RAM spike)
+3. **Streaming sink for eager disk save** (opt-in, user-driven)
+4. **Deprecate pickle** except for debugging (too brittle for release code)
+5. **Per-level export** (parameters, modules, buffers) for fine-grained analysis
+
+**This is a **2.5-month effort** for a full solution (6–7 engineer-sprints). Prioritize Phases 1–2 (parquet import/export + lazy loading) as MVP, then add streaming and per-level exports as follow-ups.**

--- a/.project-context/research/io-audit-codex.md
+++ b/.project-context/research/io-audit-codex.md
@@ -1,0 +1,532 @@
+# TorchLens I/O Audit
+
+Date: 2026-04-23
+
+Scope notes:
+- Read-only audit of `torchlens/` plus relevant tests.
+- Visualization/rendering code was intentionally skipped per task.
+- All code-behavior claims below are backed by file:line citations. Runtime pickle experiments are called out explicitly as experiments, not code citations.
+
+## TOC
+- [1. Inventory](#1-inventory)
+- [2. Gaps vs user goals](#2-gaps-vs-user-goals)
+- [3. Risks and tricky spots](#3-risks-and-tricky-spots)
+- [4. Recommendations](#4-recommendations)
+- [5. Implementation outline](#5-implementation-outline)
+
+## 1. Inventory
+
+### 1.1 Existing serialization/export surfaces
+
+| Location | Signature | Behavior summary |
+| --- | --- | --- |
+| `torchlens/data_classes/model_log.py:337-345` | `ModelLog.__getstate__(self) -> Dict[str, Any]` | Pickle hook that copies `__dict__`, strips `_module_logs`, `_buffer_accessor`, `_module_build_data`, and normalizes `_raw_layer_type_counter` to a plain `dict`. |
+| `torchlens/data_classes/model_log.py:346-365` | `ModelLog.__setstate__(self, state: Dict[str, Any]) -> None` | Pickle restore hook that reinstalls an empty `ModuleAccessor`, reinitializes `_module_build_data`, and reconnects `LayerLog`/`LayerPassLog` backrefs to the owning `ModelLog`; it does not rebuild module/buffer accessors. |
+| `torchlens/data_classes/layer_pass_log.py:390-398` | `LayerPassLog.__getstate__(self) -> Dict` / `__setstate__(self, state: Dict) -> None` | Pickle hooks that only strip the weakref-backed `_source_model_log_ref` and then restore raw state. |
+| `torchlens/data_classes/layer_log.py:216-224` | `LayerLog.__getstate__(self) -> Dict` / `__setstate__(self, state: Dict) -> None` | Pickle hooks that only strip the weakref-backed `_source_model_log_ref` and then restore raw state. |
+| `torchlens/data_classes/layer_pass_log.py:417-453` | `LayerPassLog.copy(self)` | Selective-depth clone helper used internally for synthetic output nodes; this is not Python’s `__copy__` hook. |
+| `torchlens/data_classes/interface.py:421-541` | `to_pandas(self) -> pd.DataFrame` | Bound onto `ModelLog` as `model_log.to_pandas()`; exports one row per `LayerPassLog` with pass-level metadata columns. |
+| `torchlens/data_classes/layer_log.py:665-687` | `LayerAccessor.to_pandas(self) -> pd.DataFrame` | Exports one row per aggregate `LayerLog` with a smaller layer-level summary. |
+| `torchlens/data_classes/module_log.py:399-415` | `ModuleLog.to_pandas(self) -> pd.DataFrame` | Exports one row per layer inside one module, not one row per module pass. |
+| `torchlens/data_classes/module_log.py:496-510` | `ModuleAccessor.to_pandas(self) -> pd.DataFrame` | Exports one row per `ModuleLog` summary across the model. |
+| `torchlens/capture/trace.py:55-140` | `save_new_activations(self, model, input_args, input_kwargs=None, layers_to_save="all", random_seed=None)` | Re-runs the model in fast mode and refreshes saved activations in memory only; there is no disk output. |
+| `torchlens/user_funcs.py:153-382` | `log_forward_pass(...) -> ModelLog` | Main public API for in-memory activation capture; supports `layers_to_save="all"`, `"none"`, or selective layer keys, and uses a two-pass strategy for selective saves. |
+| `torchlens/user_funcs.py:385-411` | `get_model_metadata(...) -> ModelLog` | Public wrapper around `log_forward_pass(..., layers_to_save=None)` that returns metadata with no saved activations. |
+| `torchlens/user_funcs.py:508-632` | `validate_forward_pass(...) -> bool` / `validate_saved_activations(...) -> bool` | Public in-memory replay/validation path that depends on saved activations and function metadata; not a file format. |
+| `torchlens/user_funcs.py:635-697` | `validate_batch_of_models_and_inputs(...) -> pd.DataFrame` | Reads an existing CSV with `pd.read_csv()` and appends validation results back to CSV with `to_csv()`. |
+
+What is not present:
+- `ModelLog` only binds `to_pandas`, `save_new_activations`, validation, rendering, cleanup, and related helpers; it does not bind `save`, `load`, `to_csv`, `to_json`, `to_parquet`, or `to_dict` methods (`torchlens/data_classes/model_log.py:545-558`).
+- The package public API exports `log_forward_pass`, `show_model_graph`, `get_model_metadata`, validation helpers, decoration lifecycle helpers, and data classes, but no `load()` or serialization helper (`torchlens/__init__.py:14-34`).
+- `ParamAccessor` and `BufferAccessor` expose indexing/repr only; they do not define `to_pandas`, `to_csv`, `to_json`, or `to_parquet` (`torchlens/data_classes/param_log.py:191-248`, `torchlens/data_classes/buffer_log.py:72-132`).
+- `ModulePassLog` is a container with `__repr__`/`__len__` only; there is no pass-level export surface for it (`torchlens/data_classes/module_log.py:36-103`).
+
+### 1.2 Public API surface relevant to save/load/export
+
+| Public API | Relevance to I/O | Notes |
+| --- | --- | --- |
+| `log_forward_pass` | In-memory activation/metadata capture | Saves activations into `LayerPassLog.activation` according to `layers_to_save`; no file output path exists in this function (`torchlens/user_funcs.py:201-215`, `torchlens/user_funcs.py:289-346`). |
+| `get_model_metadata` | Metadata-only capture | Convenience wrapper for “no activations saved” (`torchlens/user_funcs.py:390-410`). |
+| `validate_forward_pass` | In-memory replay using saved activations | Forces `save_function_args=True` and `save_rng_states=True`, then replays from saved activations (`torchlens/user_funcs.py:520-532`, `torchlens/user_funcs.py:587-612`). |
+| `validate_batch_of_models_and_inputs` | Actual file I/O today | Only CSV read/write path in the audited scope (`torchlens/user_funcs.py:657-695`). |
+
+### 1.3 Data-class contents
+
+The canonical public field sets live in `torchlens/constants.py`:
+- `MODEL_LOG_FIELD_ORDER` (`torchlens/constants.py:33-119`)
+- `LAYER_PASS_LOG_FIELD_ORDER` (`torchlens/constants.py:121-261`)
+- `LAYER_LOG_FIELD_ORDER` (`torchlens/constants.py:266-339`)
+- `PARAM_LOG_FIELD_ORDER` (`torchlens/constants.py:361-382`)
+- `MODULE_LOG_FIELD_ORDER` (`torchlens/constants.py:402-447`)
+
+Important caveat: `ModelLog` also carries internal/transient attributes that are not in `MODEL_LOG_FIELD_ORDER`; `cleanup()` explicitly deletes those separately (`torchlens/data_classes/model_log.py:166-291`, `torchlens/data_classes/cleanup.py:58-82`).
+
+#### ModelLog
+
+Class definition: `torchlens/data_classes/model_log.py:113-292`
+Canonical field list: `torchlens/constants.py:33-119`
+
+| Attributes | Kind | Notes for pickle/export design |
+| --- | --- | --- |
+| `model_name`, `logging_mode`, `output_device` | primitive strings | Core identity/config. |
+| `_pass_finished`, `_all_layers_logged`, `_all_layers_saved`, `keep_unsaved_layers`, `detach_saved_tensors`, `save_function_args`, `save_gradients`, `save_source_context`, `save_rng_states`, `detect_loops`, `verbose`, `has_gradients`, `mark_input_output_distances` | primitive bool flags | Serialization-safe, but they change behavior on reload (`torchlens/data_classes/model_log.py:172-191`). |
+| `current_function_call_barcode`, `random_seed_used` | optional primitive | May be `None` before/during logging (`torchlens/data_classes/model_log.py:179-182`). |
+| `activation_postfunc` | callable or `None` | Can make saved activations non-tensor objects because `save_tensor_data()` stores its return value directly (`torchlens/data_classes/model_log.py:179`, `torchlens/data_classes/layer_pass_log.py:488-490`). |
+| `layer_list` | `list[LayerPassLog|BufferLog]` | Main ordered payload for pass-level export (`torchlens/data_classes/model_log.py:197-198`). |
+| `layer_dict_main_keys` | `dict[str, LayerPassLog|BufferLog]` | Primary final-label lookup (`torchlens/data_classes/model_log.py:198-201`). |
+| `layer_dict_all_keys` | `dict[mixed lookup key, LayerPassLog|BufferLog]` | Contains all lookup keys, not just canonical labels (`torchlens/data_classes/model_log.py:199-201`, `torchlens/data_classes/interface.py:77-123`). |
+| `layer_logs` | `dict[str, LayerLog]` | Aggregate no-pass layer view (`torchlens/data_classes/model_log.py:202`). |
+| `layer_labels`, `layer_labels_w_pass`, `layer_labels_no_pass` | `list[str]` | Final labels in various namespaces (`torchlens/data_classes/model_log.py:203-206`). |
+| `layer_num_passes`, `buffer_num_passes` | `dict[str, int]`-like | Pass counts per layer/buffer (`torchlens/data_classes/model_log.py:206`, `torchlens/data_classes/model_log.py:229`). |
+| `_raw_layer_dict`, `_raw_layer_labels_list`, `_raw_to_final_layer_labels`, `_final_to_raw_layer_labels` | raw-label dict/list structures | Raw-to-final mapping is critical to fast-path re-save and any future loader (`torchlens/data_classes/model_log.py:208-223`, `torchlens/capture/trace.py:124-140`). |
+| `_layer_nums_to_save` | `list[int]` or sentinel `"all"` | Selective-save resolution output, not a stable user object (`torchlens/data_classes/model_log.py:210`, `torchlens/capture/trace.py:161-192`). |
+| `_layer_counter`, `num_operations`, `total_activation_memory`, `num_tensors_saved`, `saved_activation_memory`, `total_param_*`, `pass_start_time`, `pass_end_time`, `time_*` | numeric primitives | Straightforward to tabularize. |
+| `_raw_layer_type_counter`, `_lookup_keys_to_layer_num_dict`, `_layer_num_to_lookup_keys_dict`, `layers_with_params`, `equivalent_operations`, `conditional_arm_edges`, `conditional_edge_passes` | dicts of labels/counts/sets/lists | Mixed nested containers; not table-ready without normalization (`torchlens/data_classes/model_log.py:213-250`). |
+| `_unsaved_layers_lookup_keys` | `set[str]` | Internal lookup helper (`torchlens/data_classes/model_log.py:214-217`). |
+| `input_layers`, `output_layers`, `buffer_layers`, `internally_initialized_layers`, `_layers_where_internal_branches_merge_with_input`, `internally_terminated_layers`, `internally_terminated_bool_layers`, `layers_with_saved_activations`, `unlogged_layers`, `layers_with_saved_gradients`, `orphan_layers` | `list[str]` | Label collections for derived summaries and future exports (`torchlens/data_classes/model_log.py:225-246`). |
+| `conditional_branch_edges`, `conditional_then_edges`, `conditional_elif_edges`, `conditional_else_edges` | edge lists of tuples | Nested, branch-specific graph metadata (`torchlens/data_classes/model_log.py:235-238`). |
+| `conditional_events` | `list[ConditionalEvent]` | Structured branch metadata objects (`torchlens/data_classes/model_log.py:94-111`, `torchlens/data_classes/model_log.py:239`). |
+| `param_logs` | `ParamAccessor` | Primary parameter accessor (`torchlens/data_classes/model_log.py:257-264`, `torchlens/data_classes/model_log.py:509-513`). |
+| Internal extras: `_module_logs`, `_buffer_accessor` | `ModuleAccessor`, `BufferAccessor|None` | Not in `MODEL_LOG_FIELD_ORDER`; both are stripped or left empty on pickle restore (`torchlens/data_classes/model_log.py:279-284`, `torchlens/data_classes/model_log.py:337-365`). |
+| Internal extras: `_module_build_data`, `_module_metadata`, `_module_forward_args`, `_param_logs_by_module` | transient dicts | Used to build `ModuleLog`/`BufferAccessor`, then cleared or rebuilt (`torchlens/data_classes/model_log.py:275-284`, `torchlens/postprocess/finalization.py:518-695`). |
+| Internal extras: `_optimizer`, `_pre_forward_rng_states`, `_saved_gradients_set`, `_mod_pass_num`, `_mod_pass_labels`, `_mod_entered`, `_mod_exited` | transient refs/counters/sets | Session-scoped state that complicates raw pickling and is not a clean archival schema (`torchlens/data_classes/model_log.py:166`, `torchlens/data_classes/model_log.py:246`, `torchlens/data_classes/model_log.py:270-276`, `torchlens/capture/trace.py:425-428`). |
+
+#### LayerPassLog
+
+Class definition: `torchlens/data_classes/layer_pass_log.py:68-273`
+Canonical field list: `torchlens/constants.py:121-261`
+
+| Attributes | Kind | Notes for pickle/export design |
+| --- | --- | --- |
+| `layer_label`, `tensor_label_raw`, `layer_label_raw`, `layer_label_short`, `layer_label_w_pass`, `layer_label_w_pass_short`, `layer_label_no_pass`, `layer_label_no_pass_short`, `layer_type`, `func_name`, `grad_fn_name`, `buffer_address`, `buffer_parent`, `containing_module`, `leaf_module_pass` | primitive strings or `None` | Mostly tabularizable scalar metadata (`torchlens/data_classes/layer_pass_log.py:111-145`, `torchlens/data_classes/layer_pass_log.py:223-267`). |
+| `operation_num`, `creation_order`, `layer_type_num`, `layer_total_num`, `pass_num`, `num_passes`, `tensor_memory`, `grad_memory`, `num_args`, `num_positional_args`, `num_keyword_args`, `num_params_total`, `num_params_trainable`, `num_params_frozen`, `params_memory`, `conditional_branch_depth` | primitive ints | Straightforward scalar columns (`torchlens/data_classes/layer_pass_log.py:111-145`, `torchlens/data_classes/layer_pass_log.py:153-192`, `torchlens/data_classes/layer_pass_log.py:235-267`). |
+| `func_time` | primitive float | Per-op timing (`torchlens/data_classes/layer_pass_log.py:166`). |
+| `_pass_finished`, `has_saved_activations`, `detach_saved_tensor`, `args_captured`, `has_child_tensor_variations`, `save_gradients`, `has_gradient`, `func_is_inplace`, `is_part_of_iterable_output`, `has_children`, `is_input_layer`, `has_input_ancestor`, `is_output_layer`, `feeds_output`, `is_final_output`, `is_output_ancestor`, `is_buffer_layer`, `is_internally_initialized`, `has_internally_initialized_ancestor`, `is_internally_terminated`, `is_terminal_bool_layer`, `bool_is_branch`, `is_scalar_bool`, `in_cond_branch`, `is_submodule_output`, `is_leaf_module_output` | primitive bools | Good DataFrame columns already exposed heavily by `ModelLog.to_pandas()` (`torchlens/data_classes/layer_pass_log.py:118`, `torchlens/data_classes/layer_pass_log.py:135-160`, `torchlens/data_classes/layer_pass_log.py:178-267`). |
+| `source_model_log` | weakref-backed ref to `ModelLog` | Stored internally as `_source_model_log_ref`; pickle strips the weakref only (`torchlens/data_classes/layer_pass_log.py:115-118`, `torchlens/data_classes/layer_pass_log.py:376-398`). |
+| `activation` | saved activation object, usually `torch.Tensor`, else `None` | Default path clones the tensor and optionally moves devices, but `activation_postfunc` can replace it with any object (`torchlens/data_classes/layer_pass_log.py:135`, `torchlens/data_classes/layer_pass_log.py:463-502`). |
+| `gradient` | `torch.Tensor|None` | Saved as `detach().clone()` snapshot, not a live autograd edge (`torchlens/data_classes/layer_pass_log.py:155`, `torchlens/data_classes/layer_pass_log.py:503-517`). |
+| `captured_args`, `captured_kwargs` | copied nested Python objects or `None` | May contain tensors and arbitrary Python containers when `save_function_args=True` (`torchlens/data_classes/layer_pass_log.py:141-142`, `torchlens/data_classes/layer_pass_log.py:495-501`). |
+| `tensor_shape`, `grad_shape` | tuple-like or `None` | Shape snapshots (`torchlens/data_classes/layer_pass_log.py:143`, `torchlens/data_classes/layer_pass_log.py:158`). |
+| `tensor_dtype`, `grad_dtype` | `torch.dtype|None` | PyTorch type objects, potentially version-sensitive (`torchlens/data_classes/layer_pass_log.py:144`, `torchlens/data_classes/layer_pass_log.py:159`). |
+| `activation_postfunc`, `func_applied` | callable or `None` | `func_applied` is the raw producing callable and is a major pickle-fragility point (`torchlens/data_classes/layer_pass_log.py:138`, `torchlens/data_classes/layer_pass_log.py:163`, `torchlens/capture/output_tensors.py:318`). |
+| `func_call_stack` | `list[FuncCallLocation]` | Nested lazy source objects; these carry `_frame_func_obj` until source is loaded when `save_source_context=True` (`torchlens/data_classes/layer_pass_log.py:165`, `torchlens/data_classes/func_call_location.py:109-123`, `torchlens/data_classes/func_call_location.py:140-198`). |
+| `func_rng_states`, `func_autocast_state` | nested dicts | Opaque RNG/autocast snapshots used by validation replay (`torchlens/data_classes/layer_pass_log.py:169-170`, `torchlens/utils/rng.py:49-111`, `torchlens/validation/core.py:470-477`). |
+| `func_argnames` | tuple of strings | Function signature names captured at decoration time (`torchlens/data_classes/layer_pass_log.py:171`). |
+| `func_positional_args_non_tensor`, `func_kwargs_non_tensor`, `func_non_tensor_args` | list/dict/list | Non-tensor function config fragments; already semi-tabular but nested (`torchlens/data_classes/layer_pass_log.py:175-177`). |
+| `parent_params` | `list[nn.Parameter]` during capture, later cleared to `[]` | Raw parameter refs are dropped during postprocessing to save memory (`torchlens/data_classes/layer_pass_log.py:184`, `torchlens/postprocess/finalization.py:115-118`). |
+| `parent_param_barcodes`, `parent_param_shapes`, `recurrent_group`, `parent_layers`, `child_layers`, `input_ancestors`, `output_descendants`, `internally_initialized_parents`, `internally_initialized_ancestors`, `conditional_branch_stack`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_else_children`, `containing_modules`, `modules_entered`, `module_passes_entered`, `modules_exited`, `module_passes_exited`, `module_entry_exit_thread_output` | lists/sets of labels or tuples | Nested graph/module metadata; exportable, but not flat without normalization (`torchlens/data_classes/layer_pass_log.py:183-267`). |
+| `parent_param_logs` | `list[ParamLog]` | Direct references to parameter metadata objects (`torchlens/data_classes/layer_pass_log.py:187`). |
+| `parent_param_passes`, `parent_layer_arg_locs`, `cond_branch_elif_children`, `cond_branch_children_by_cond`, `modules_entered_argnames`, `module_entry_exit_threads_inputs` | nested dicts | Not directly Parquet/CSV-friendly without schema design (`torchlens/data_classes/layer_pass_log.py:186`, `torchlens/data_classes/layer_pass_log.py:206`, `torchlens/data_classes/layer_pass_log.py:248-250`, `torchlens/data_classes/layer_pass_log.py:256-264`). |
+| `equivalent_operations`, `root_ancestors` | `set[str]` | Shared graph groupings; `equivalent_operations` is a direct reference to a `ModelLog`-owned set (`torchlens/data_classes/layer_pass_log.py:194-202`, `torchlens/capture/source_tensors.py:199-200`). |
+| `operation_equivalence_type`, `io_role`, `bool_context_kind`, `bool_wrapper_kind`, `scalar_bool_value`, `iterable_output_index`, `buffer_pass`, `min_distance_from_input`, `max_distance_from_input`, `min_distance_from_output`, `max_distance_from_output`, `flops_forward`, `flops_backward` | scalar primitives or `None` | Mostly flat metadata fields already used for summaries. |
+| `func_config` | `dict[str, Any]` | Lightweight op config extracted from args/kwargs (`torchlens/data_classes/layer_pass_log.py:266-267`, `torchlens/capture/output_tensors.py:340-349`). |
+| Extras: `parent_layer_log` | strong ref to aggregate `LayerLog` | Not in `LAYER_PASS_LOG_FIELD_ORDER`, restored by `ModelLog.__setstate__` when layer logs exist (`torchlens/data_classes/layer_pass_log.py:269-273`, `torchlens/data_classes/model_log.py:356-365`). |
+
+#### LayerLog
+
+Class definition: `torchlens/data_classes/layer_log.py:46-162`
+Canonical field list: `torchlens/constants.py:266-339`
+
+| Attributes | Kind | Notes for pickle/export design |
+| --- | --- | --- |
+| `layer_label`, `layer_label_short`, `layer_type`, `func_name`, `grad_fn_name`, `containing_module` | scalar strings or `None` | Aggregate layer identity (`torchlens/data_classes/layer_log.py:67-85`, `torchlens/data_classes/layer_log.py:140-142`). |
+| `layer_type_num`, `layer_total_num`, `num_passes`, `num_args`, `num_positional_args`, `num_keyword_args`, `tensor_memory`, `flops_forward`, `flops_backward`, `num_params_total`, `num_params_trainable`, `num_params_frozen`, `params_memory` | scalar ints | First-pass or merged numeric metadata (`torchlens/data_classes/layer_log.py:68-114`). |
+| `source_model_log` | weakref-backed ref to `ModelLog` | Pickle strips `_source_model_log_ref`, then `ModelLog.__setstate__` reconnects it (`torchlens/data_classes/layer_log.py:74-78`, `torchlens/data_classes/layer_log.py:202-224`, `torchlens/data_classes/model_log.py:356-365`). |
+| `func_applied`, `activation_postfunc` | callable or `None` | Same pickle concerns as `LayerPassLog` for `func_applied` (`torchlens/data_classes/layer_log.py:81`, `torchlens/data_classes/layer_log.py:98-100`). |
+| `tensor_shape`, `tensor_dtype`, `output_device`, `detach_saved_tensor`, `save_gradients` | scalar metadata | Representative values from first pass (`torchlens/data_classes/layer_log.py:92-101`). |
+| `parent_param_barcodes`, `parent_param_shapes`, `containing_modules`, `modules_exited`, `module_passes_exited`, `cond_branch_start_children`, `cond_branch_then_children`, `cond_branch_else_children`, `pass_labels` | lists | Mostly pass-stripped aggregate metadata (`torchlens/data_classes/layer_log.py:107-117`, `torchlens/data_classes/layer_log.py:148-162`). |
+| `parent_param_logs` | `list[ParamLog]` | Direct refs to parameter logs (`torchlens/data_classes/layer_log.py:108-114`). |
+| `conditional_branch_stacks` | `list[list[tuple[int, str]]]` | Aggregate branch-stack signatures across passes (`torchlens/data_classes/layer_log.py:136-139`). |
+| `conditional_branch_stack_passes`, `cond_branch_children_by_cond`, `cond_branch_elif_children` | nested dicts | Aggregated cross-pass conditional metadata (`torchlens/data_classes/layer_log.py:136-139`, `torchlens/postprocess/finalization.py:251-331`). |
+| `equivalent_operations` | `set[str]` | Shared layer-equivalence set (`torchlens/data_classes/layer_log.py:119-122`). |
+| `is_input_layer`, `is_output_layer`, `is_final_output`, `is_buffer_layer`, `is_internally_initialized`, `is_internally_terminated`, `is_terminal_bool_layer`, `is_scalar_bool`, `in_cond_branch`, `has_input_ancestor`, `is_leaf_module_output` | bool flags | Mixed first-pass and merged aggregate booleans (`torchlens/data_classes/layer_log.py:123-157`, `torchlens/postprocess/finalization.py:742-770`). |
+| `buffer_address`, `buffer_parent`, `buffer_pass`, `io_role`, `scalar_bool_value` | scalar or `None` | Special-case aggregate fields used for compatibility/visualization (`torchlens/data_classes/layer_log.py:127-157`). |
+| `passes` | `dict[int, LayerPassLog]` | Main route back to pass-level payloads (`torchlens/data_classes/layer_log.py:159-162`). |
+| Extras not in `LAYER_LOG_FIELD_ORDER`: `modules_exited`, `module_passes_exited`, `buffer_pass`, `has_input_ancestor`, `io_role`, `is_leaf_module_output`, `in_cond_branch` | additional aggregate compatibility fields | They are assigned in the class body and merged in `_build_layer_logs`, but not listed in the canonical field order (`torchlens/data_classes/layer_log.py:144-158`, `torchlens/postprocess/finalization.py:742-770`). |
+
+#### BufferLog
+
+Class definition: `torchlens/data_classes/buffer_log.py:22-69`
+
+`BufferLog` subclasses `LayerPassLog` and does not add new stored fields; it relies on the inherited `is_buffer_layer`, `buffer_address`, `buffer_pass`, and `buffer_parent` fields plus two computed properties:
+
+| Attributes | Kind | Notes |
+| --- | --- | --- |
+| all `LayerPassLog` fields | inherited | Buffer entries participate in the same graph/log schema as ordinary layer-pass entries (`torchlens/data_classes/buffer_log.py:22-33`). |
+| `name` | computed `str` | Last path component of `buffer_address` (`torchlens/data_classes/buffer_log.py:35-42`). |
+| `module_address` | computed `str` | Parent module address derived from `buffer_address` (`torchlens/data_classes/buffer_log.py:43-50`). |
+
+#### ModuleLog
+
+Class definition: `torchlens/data_classes/module_log.py:104-217`
+Canonical field list: `torchlens/constants.py:402-447`
+
+| Attributes | Kind | Notes for pickle/export design |
+| --- | --- | --- |
+| `address`, `name`, `module_class_name`, `source_file`, `class_docstring`, `init_signature`, `init_docstring`, `forward_signature`, `forward_docstring`, `address_parent`, `call_parent` | scalar strings or `None` | Module identity/source metadata (`torchlens/data_classes/module_log.py:167-187`). |
+| `source_line`, `address_depth`, `nesting_depth`, `num_passes`, `num_params`, `num_params_trainable`, `num_params_frozen`, `params_memory` | scalar ints | Mostly flat summary fields (`torchlens/data_classes/module_log.py:172-203`). |
+| `all_addresses`, `address_children`, `call_children`, `pass_labels`, `all_layers`, `buffer_layers`, `methods` | `list[str]` | Good candidates for normalized child tables rather than CSV columns (`torchlens/data_classes/module_log.py:168`, `torchlens/data_classes/module_log.py:180-205`, `torchlens/data_classes/module_log.py:212`). |
+| `passes` | `dict[int, ModulePassLog]` | Pass-level module execution objects; there is no export helper for them (`torchlens/data_classes/module_log.py:188-190`). |
+| `params` | `ParamAccessor` | Parameter metadata scoped to this module (`torchlens/data_classes/module_log.py:196-203`). |
+| `requires_grad`, `is_training`, `has_forward_hooks`, `has_backward_hooks` | bool flags | Flat summary fields (`torchlens/data_classes/module_log.py:203`, `torchlens/data_classes/module_log.py:208-210`). |
+| `extra_attributes` | `dict[str, Any]` | Potentially arbitrary Python objects, not inherently tabular (`torchlens/data_classes/module_log.py:211`). |
+| Extra `_source_model_log_ref` | weakref to `ModelLog` | There is no `ModuleLog.__getstate__`; instead the entire `_module_logs` accessor is stripped at `ModelLog.__getstate__` time (`torchlens/data_classes/module_log.py:214-243`, `torchlens/data_classes/model_log.py:337-345`). |
+| Extra `_buffer_accessor` | cached `BufferAccessor|None` | Lazily scoped buffer accessor for this module (`torchlens/data_classes/module_log.py:205-207`, `torchlens/data_classes/module_log.py:289-307`). |
+
+Related nested type: `ModulePassLog`
+- Definition: `torchlens/data_classes/module_log.py:36-103`
+- Contents: `module_address`, `all_module_addresses`, `pass_num`, `pass_label`, `layers`, `input_layers`, `output_layers`, `forward_args`, `forward_kwargs`, `call_parent`, `call_children`.
+- Important detail: `_build_module_logs()` nulls out `forward_args` and `forward_kwargs` after construction to release tensor references (`torchlens/postprocess/finalization.py:691-695`).
+
+#### ParamLog
+
+Class definition: `torchlens/data_classes/param_log.py:29-188`
+Canonical field list: `torchlens/constants.py:361-382`
+
+| Attributes | Kind | Notes for pickle/export design |
+| --- | --- | --- |
+| `address`, `name`, `module_address`, `module_type`, `barcode` | scalar strings | Stable parameter identity (`torchlens/data_classes/param_log.py:51-60`). |
+| `shape`, `grad_shape` | shape tuples or `None` | Flat metadata (`torchlens/data_classes/param_log.py:53`, `torchlens/data_classes/param_log.py:73`, `torchlens/data_classes/param_log.py:119-127`). |
+| `dtype`, `grad_dtype` | `torch.dtype|None` | PyTorch type objects (`torchlens/data_classes/param_log.py:54`, `torchlens/data_classes/param_log.py:74`, `torchlens/data_classes/param_log.py:129-137`). |
+| `num_params`, `memory`, `grad_memory`, `num_passes` | scalar ints | Flat numeric metadata (`torchlens/data_classes/param_log.py:55-56`, `torchlens/data_classes/param_log.py:69-76`, `torchlens/data_classes/param_log.py:139-147`). |
+| `trainable`, `is_quantized`, `has_grad`, `has_optimizer` | bool-like flags / optional bool | `has_grad` is lazy, computed from `_param_ref.grad` (`torchlens/data_classes/param_log.py:57`, `torchlens/data_classes/param_log.py:83-92`, `torchlens/data_classes/param_log.py:94-117`). |
+| `memory_str`, `grad_memory_str` | derived strings | Convenience display fields (`torchlens/data_classes/param_log.py:78-80`, `torchlens/data_classes/param_log.py:149-157`). |
+| `used_by_layers`, `linked_params` | `list[str]` | Reverse mappings populated during postprocessing (`torchlens/data_classes/param_log.py:70-71`, `torchlens/postprocess/finalization.py:78-118`). |
+| Extra `_param_ref` | strong ref to live `nn.Parameter` or `None` | This is intentionally retained until cleanup/release, and there is no custom pickle hook to strip it (`torchlens/data_classes/param_log.py:63-67`, `torchlens/data_classes/param_log.py:181-184`, `torchlens/data_classes/cleanup.py:31-40`). |
+| Extra `_has_grad`, `_grad_shape`, `_grad_dtype`, `_grad_memory`, `_grad_memory_str` | cached lazy-gradient state | Internal cache fields not listed in `PARAM_LOG_FIELD_ORDER` (`torchlens/data_classes/param_log.py:72-76`). |
+
+## 2. Gaps vs user goals
+
+### a. Pickling a ModelLog and round-tripping it cleanly
+
+Current state:
+- There are explicit pickle hooks on `ModelLog`, `LayerLog`, and `LayerPassLog` (`torchlens/data_classes/model_log.py:337-365`, `torchlens/data_classes/layer_log.py:216-224`, `torchlens/data_classes/layer_pass_log.py:390-398`).
+- `LayerPassLog.func_applied` stores the producing callable directly, and output/source logging populate that field from the original function object (`torchlens/data_classes/layer_pass_log.py:163`, `torchlens/capture/output_tensors.py:318`, `torchlens/capture/source_tensors.py:167-168`).
+- `ModelLog.__getstate__` strips `_module_logs` and `_buffer_accessor`, but `ModelLog.__setstate__` only recreates an empty `ModuleAccessor` and leaves `_buffer_accessor` unreconstructed; it only restores layer-related backrefs (`torchlens/data_classes/model_log.py:337-365`). The real builder for modules/buffers is `_build_module_logs()`, which is not called on unpickle (`torchlens/postprocess/finalization.py:518-695`).
+
+Runtime experiments (throwaway scripts, not checked in):
+- `nn.Sequential(nn.Linear(4, 4), nn.ReLU(), nn.Linear(4, 2))` failed at `pickle.dumps(log)` with `_pickle.PicklingError: Can't pickle <built-in function linear>...`.
+- A parameter-free `torch.sin(x) + 1` model did round-trip, but the restored object had `len(rt.modules) == 0`, `rt.buffers is None`, and `rt.root_module` failed because module/buffer accessors were not rebuilt.
+- A parameterized `x * self.scale` model also round-tripped, kept `ParamLog._param_ref`, and still came back with `len(rt.modules) == 0`.
+
+Existing test coverage is much narrower than “clean round-trip”:
+- `tests/test_metadata.py` and `tests/test_conditional_branches.py` only assert pickle round-trip behavior for logs captured with `save_source_context=False`, focusing on `FuncCallLocation` placeholder state, not full `ModelLog` usability after reload (`tests/test_metadata.py:980-1030`, `tests/test_conditional_branches.py:1900-1930`).
+- Those tests pass because `FuncCallLocation` explicitly zeros `_frame_func_obj` and fills no-source placeholders when source loading is disabled (`torchlens/data_classes/func_call_location.py:87-92`, `torchlens/data_classes/func_call_location.py:125-133`).
+
+Verdict:
+- Exists: partially.
+- Works: only for some logs; common `nn.Linear` logs fail outright, and successful round-trips still lose module/buffer access.
+- Missing: a stable callable-serialization strategy, module/buffer accessor rebuild, and explicit compatibility guarantees. The logical implementation points are `LayerPassLog.func_applied` capture and `ModelLog.__setstate__` rehydration (`torchlens/capture/output_tensors.py:318`, `torchlens/data_classes/model_log.py:346-365`).
+
+### b. Exporting layer-level metadata to a pandas DataFrame
+
+Current state:
+- `model_log.layers.to_pandas()` exists and returns one row per aggregate `LayerLog` (`torchlens/data_classes/model_log.py:515-519`, `torchlens/data_classes/layer_log.py:665-687`).
+- `model_log.to_pandas()` also exists, but it is pass-level, not aggregate layer-level (`torchlens/data_classes/interface.py:421-541`).
+
+Verdict:
+- Exists: yes.
+- Works: yes for pandas users.
+- Missing: explicit naming that distinguishes layer-level vs pass-level exports, and wrapper methods for CSV/Parquet/JSON.
+
+### c. Exporting pass-level / module-level / buffer-level / param-level metadata to DataFrames
+
+Current state:
+- Pass-level: `model_log.to_pandas()` exports one row per `LayerPassLog` (`torchlens/data_classes/interface.py:421-541`).
+- Layer-level: `model_log.layers.to_pandas()` exports one row per `LayerLog` (`torchlens/data_classes/layer_log.py:665-687`).
+- Module-level summary: `model_log.modules.to_pandas()` exports one row per `ModuleLog` (`torchlens/data_classes/module_log.py:496-510`).
+- Module-contained layers: `model_log.modules["addr"].to_pandas()` exports layers inside one module, not module passes (`torchlens/data_classes/module_log.py:399-415`).
+- Buffer-level: no DataFrame export surface on `BufferAccessor` (`torchlens/data_classes/buffer_log.py:72-132`).
+- Param-level: no DataFrame export surface on `ParamAccessor` (`torchlens/data_classes/param_log.py:191-248`).
+- Module-pass-level: `ModulePassLog` has no `to_pandas()` and its `forward_args`/`forward_kwargs` are nulled after module-log construction (`torchlens/data_classes/module_log.py:36-103`, `torchlens/postprocess/finalization.py:691-695`).
+
+Verdict:
+- Exists: pass-level yes, layer-level yes, module summary yes, module-contained-layers yes.
+- Works: limited but usable for those exact shapes.
+- Missing: first-class DataFrames for `ParamLog`, `BufferLog`, and `ModulePassLog`, plus a normalized schema for nested dict/list/set fields.
+
+### d. Exporting to CSV, Parquet, JSON
+
+Current state:
+- The only first-class CSV writer in scope is the batch-validation harness, which persists validation results to CSV (`torchlens/user_funcs.py:635-697`).
+- The layer/module DataFrame surfaces let a caller manually call pandas writers themselves, but TorchLens does not wrap those operations (`torchlens/data_classes/interface.py:421-541`, `torchlens/data_classes/layer_log.py:665-687`, `torchlens/data_classes/module_log.py:399-415`, `torchlens/data_classes/module_log.py:496-510`).
+- There are no native `to_csv`, `to_parquet`, `to_json`, `to_dict`, or `asdict` methods on the audited data classes or accessors (`torchlens/data_classes/model_log.py:545-558`, `torchlens/data_classes/param_log.py:191-248`, `torchlens/data_classes/buffer_log.py:72-132`).
+
+Verdict:
+- Exists: CSV only for validation results, not for `ModelLog`/`LayerLog`/`ParamLog` persistence.
+- Works: only if the user manually converts existing DataFrames.
+- Missing: native CSV/Parquet/JSON exporters, schema/version metadata, and importers.
+
+### e. Saving activations to disk (format, eager vs streaming, selective-layer vs all)
+
+Current state:
+- Activation capture is in memory. `save_tensor_data()` clones the tensor, optionally moves it to `output_device`, optionally applies `activation_postfunc`, and stores the result on `LayerPassLog.activation` (`torchlens/data_classes/layer_pass_log.py:463-502`).
+- `log_forward_pass()` supports saving activations for `"all"`, `"none"`, or selective layer keys; selective mode runs an exhaustive pass then a fast pass (`torchlens/user_funcs.py:201-215`, `torchlens/user_funcs.py:286-346`).
+- `save_new_activations()` replays the same graph and refreshes activations in memory only (`torchlens/capture/trace.py:55-140`, `torchlens/capture/output_tensors.py:608-644`, `torchlens/capture/source_tensors.py:286-338`).
+
+Verdict:
+- Exists: in-memory activation capture, including selective-layer refresh.
+- Works: yes in memory, subject to fast-path graph-stability checks.
+- Missing: any disk format, any streaming/spill-to-disk path, any tensor sharding, any lazy reload.
+
+### f. Loading any of the above back into usable ModelLog/LayerLog objects
+
+Current state:
+- There is no public loader API in `torchlens.__init__` or `torchlens/user_funcs.py` (`torchlens/__init__.py:14-34`, `torchlens/user_funcs.py:153-697`).
+- Python pickle is the only implicit “load” path, and it is incomplete for module/buffer accessors even when it succeeds (`torchlens/data_classes/model_log.py:337-365`, `torchlens/postprocess/finalization.py:518-695`).
+- No CSV/Parquet/JSON importers exist for any of the data classes or accessors (`torchlens/data_classes/model_log.py:545-558`, `torchlens/data_classes/param_log.py:191-248`, `torchlens/data_classes/buffer_log.py:72-132`).
+
+Verdict:
+- Exists: implicit `pickle.load()` only, and only partially.
+- Works: not cleanly enough to call this a supported load path.
+- Missing: a package-supported loader plus a format that can reconstruct usable `ModelLog`/`LayerLog`/`ModuleLog` objects deterministically.
+
+## 3. Risks and tricky spots
+
+### Circular references and object graphs
+
+- `LayerPassLog` stores a weakref-backed `source_model_log`, but also a strong `parent_layer_log` backref that is intentionally outside `FIELD_ORDER` (`torchlens/data_classes/layer_pass_log.py:80-85`, `torchlens/data_classes/layer_pass_log.py:115-118`, `torchlens/data_classes/layer_pass_log.py:269-273`).
+- `LayerLog` stores `passes: Dict[int, LayerPassLog]`, and each pass stores `parent_layer_log`, so the aggregate/pass layer view is cyclic by design (`torchlens/data_classes/layer_log.py:159-162`, `torchlens/postprocess/finalization.py:764-767`).
+- `ModuleLog` stores `passes: Dict[int, ModulePassLog]` plus a weakref-backed `_source_model_log_ref` (`torchlens/data_classes/module_log.py:188-217`).
+- `ParamLog` keeps a strong `_param_ref` to the actual `nn.Parameter` until cleanup or explicit release (`torchlens/data_classes/param_log.py:63-67`, `torchlens/data_classes/cleanup.py:31-40`).
+- Cleanup is aggressive because these graphs are cyclic and heavy; it deletes layer-entry attributes first, then `ModelLog` fields and internal containers (`torchlens/data_classes/cleanup.py:42-83`).
+
+### Weakrefs
+
+- Weakref-backed fields exist on `LayerPassLog.source_model_log`, `LayerLog.source_model_log`, `ModuleLog._source_model_log`, and accessor-side source refs (`torchlens/data_classes/layer_pass_log.py:376-389`, `torchlens/data_classes/layer_log.py:202-214`, `torchlens/data_classes/module_log.py:233-243`, `torchlens/data_classes/layer_log.py:611-619`, `torchlens/data_classes/buffer_log.py:83-92`).
+- The pickle hooks only strip/rebuild weakrefs for `LayerPassLog` and `LayerLog`; `ModuleLog` never gets a custom state hook because `_module_logs` is stripped wholesale at the `ModelLog` level (`torchlens/data_classes/model_log.py:337-365`).
+
+### Tensor device, grad, and post-processing state
+
+- Saved activations are cloned, optionally detached, and optionally moved to `output_device`; default behavior can preserve GPU residency (`torchlens/data_classes/layer_pass_log.py:481-490`, `torchlens/user_funcs.py:224-227`).
+- Saved gradients are detached/cloned snapshots (`torchlens/data_classes/layer_pass_log.py:503-517`).
+- `ParamLog` gradient metadata is lazy and tied to `_param_ref.grad`, so a successful pickle can carry a serialized parameter snapshot rather than a live link to the current model instance (`torchlens/data_classes/param_log.py:94-117`).
+- `activation_postfunc` can replace `activation` with any Python object, not necessarily a tensor (`torchlens/data_classes/layer_pass_log.py:488-490`).
+
+### Memory footprint
+
+- Every saved layer can hold an activation payload, optional copied args/kwargs, optional gradient, and optional child-version tensors used for validation replay (`torchlens/data_classes/layer_pass_log.py:135-160`, `torchlens/data_classes/layer_pass_log.py:495-501`, `torchlens/capture/output_tensors.py:392-405`).
+- `ModelLog` explicitly tracks aggregate activation memory and saved-activation memory, which reflects that activations are kept resident in memory today (`torchlens/data_classes/model_log.py:252-255`).
+- `save_new_activations()` clears and repopulates those in-memory payloads; it is not a spill mechanism (`torchlens/capture/trace.py:88-109`).
+
+### Thread safety and the global toggle
+
+- Logging is controlled by global mutable state in `torchlens/_state.py`; `active_logging()` is explicitly “NOT nestable” and assumes only one logged forward pass at a time (`torchlens/_state.py:183-209`).
+- There is no dedicated load path that fences itself from this global state. Unpickling itself does not flip the toggle, but the package has no designed concurrency story for “load while another thread is logging” because serialization/load APIs do not exist (`torchlens/_state.py:36-54`, `torchlens/__init__.py:14-34`).
+
+### Pickle security and PyTorch-version brittleness
+
+- The current implicit format is raw Python pickle; loading untrusted pickles is therefore arbitrary-code-execution unsafe in the general Python sense.
+- `func_applied` stores raw callables, and validation replay later calls them directly (`torchlens/capture/output_tensors.py:318`, `torchlens/validation/core.py:468-477`). That makes pickle compatibility sensitive to callable identity and refactors, and runtime experiments already show built-in-op failures.
+- RNG snapshots use opaque Python/NumPy/Torch state objects (`torchlens/utils/rng.py:49-89`), and dtypes/devices/autocast metadata are also framework-version-specific (`torchlens/data_classes/layer_pass_log.py:144`, `torchlens/data_classes/layer_pass_log.py:169-170`, `torchlens/utils/rng.py:92-141`).
+- `FuncCallLocation` only clears `_frame_func_obj` after lazy source loading when source loading is enabled; pickling before that can capture function objects unexpectedly (`torchlens/data_classes/func_call_location.py:109-123`, `torchlens/data_classes/func_call_location.py:140-198`).
+
+## 4. Recommendations
+
+### Format strategy
+
+Recommendation: make a directory-bundle format the primary path, with:
+- `manifest.json` for versioning and bundle metadata,
+- Parquet tables for flat metadata surfaces,
+- `safetensors` shards for activations and gradients,
+- explicit pickle wrappers only as a debug/escape-hatch path.
+
+Why this is the right tradeoff here:
+- Pickle-only is already broken for common built-in ops and incomplete even when it succeeds because module/buffer accessors are not rebuilt (`torchlens/capture/output_tensors.py:318`, `torchlens/data_classes/model_log.py:337-365`).
+- Metadata is already naturally splitting into flat summaries (`to_pandas()` surfaces) plus large tensor payloads, so Parquet + `safetensors` matches the real object shape better than one monolithic pickle (`torchlens/data_classes/interface.py:421-541`, `torchlens/data_classes/layer_log.py:665-687`, `torchlens/data_classes/module_log.py:399-415`, `torchlens/data_classes/module_log.py:496-510`).
+- `safetensors` avoids arbitrary code execution and gives deterministic tensor payloads; Parquet gives queryable tables.
+
+Tradeoff I would accept:
+- I would accept an extra dependency and a more explicit schema-normalization step in exchange for stability, safer loads, and large-model practicality.
+
+I would not ship “pickle-only” as the product story.
+
+### Should streaming-to-disk during forward pass be in scope?
+
+Recommendation: not for the first implementation.
+
+Why:
+- The current capture pipeline assumes `LayerPassLog.activation` is immediately available in memory for validation, output-node postprocessing, fast-path refresh, and some graph-replay logic (`torchlens/data_classes/layer_pass_log.py:463-502`, `torchlens/postprocess/__init__.py:200-247`, `torchlens/validation/core.py:450-500`).
+- Streaming would cut across `save_tensor_data()`, source/output fast paths, validation replay, and output-node copying. That is real surface area, not a small add-on (`torchlens/data_classes/layer_pass_log.py:463-502`, `torchlens/capture/output_tensors.py:608-644`, `torchlens/capture/source_tensors.py:286-338`).
+
+Effort estimate:
+- Basic bundle save/load without streaming: about 1 to 2 engineer-weeks.
+- Robust streaming capture with selective layers and replay compatibility: about 3 to 5 engineer-weeks.
+
+### Lazy vs eager tensor loading
+
+Recommendation: lazy by default, eager optional.
+
+Why:
+- Activations dominate size and current TorchLens already exposes useful metadata without needing every tensor resident (`torchlens/data_classes/model_log.py:252-255`, `torchlens/data_classes/interface.py:421-541`).
+- Large-model use cases are exactly where eager reload will hurt the most.
+
+Tradeoff I would accept:
+- Slightly more complicated access semantics and first-access latency on `layer.activation` are worth it to keep bundle loads cheap and predictable.
+
+Practical shape:
+- `tl.load(path, lazy_tensors=True)` should build the graph/metadata eagerly and materialize tensors on first access.
+- `tl.load(path, lazy_tensors=False)` should eagerly load tensor shards into memory.
+
+### Concrete API proposal
+
+I would build this API:
+
+```python
+model_log.save(
+    path,
+    format="auto",
+    include_activations=True,
+    include_gradients=False,
+    tensor_format="safetensors",
+    table_format="parquet",
+    overwrite=False,
+)
+
+tl.load(path, lazy_tensors=True, map_location="cpu") -> ModelLog
+
+model_log.passes_df() -> pd.DataFrame
+model_log.layers_df() -> pd.DataFrame
+model_log.modules_df() -> pd.DataFrame
+model_log.params_df() -> pd.DataFrame
+model_log.buffers_df() -> pd.DataFrame
+
+model_log.to_csv(path, table="passes")
+model_log.to_parquet(path, table="passes")
+model_log.to_json(path, table="passes")
+
+model_log.to_pickle(path)
+tl.load_pickle(path) -> ModelLog
+```
+
+Reasoning:
+- The current `to_pandas()` name is ambiguous because `ModelLog.to_pandas()` is pass-level while `LayerAccessor.to_pandas()` is layer-level (`torchlens/data_classes/interface.py:421-541`, `torchlens/data_classes/layer_log.py:665-687`). The new API should name the grain explicitly.
+- `tl.load(...)` should exist at package level because there is currently no load surface in `__init__.py` (`torchlens/__init__.py:14-34`).
+- Pickle should be explicit and visibly “less safe / less stable,” not the default silent protocol.
+
+### Backward compatibility and format versioning
+
+Recommendation: yes, add a format version tag immediately.
+
+I would store:
+- `io_format_version`
+- `torchlens_version`
+- `torch_version`
+- `schema_versions` per table
+- optional feature flags like `has_activations`, `has_gradients`, `lazy_tensor_encoding`
+
+Migration approach:
+- Directory bundle manifest drives migrations.
+- Keep loader-side migrators for at least N-1 minor schema versions.
+- Treat raw pickle as best-effort debug compatibility, not archival compatibility.
+
+This is necessary because the current object model already evolves via `FIELD_ORDER` changes and custom state logic, and older pickles are not otherwise self-describing (`torchlens/constants.py:3-11`, `torchlens/data_classes/model_log.py:337-365`).
+
+## 5. Implementation outline
+
+Ordered by dependency.
+
+### Phase 1: Normalize export surfaces first
+
+Goal:
+- Make existing in-memory metadata exportable at clear grains before introducing a bundle format.
+
+Work items:
+1. Add explicit DataFrame builders with grain-specific names:
+   - `ModelLog.passes_df()`
+   - `ModelLog.layers_df()`
+   - `ModelLog.modules_df()`
+   - `ModelLog.params_df()`
+   - `ModelLog.buffers_df()`
+2. Keep `to_pandas()` as a compatibility alias for `passes_df()` or deprecate it carefully.
+3. Add tests for param/buffer/module-pass exports.
+
+Files touched:
+- `torchlens/data_classes/interface.py`
+- `torchlens/data_classes/layer_log.py`
+- `torchlens/data_classes/module_log.py`
+- `torchlens/data_classes/param_log.py`
+- `torchlens/data_classes/buffer_log.py`
+- `torchlens/data_classes/model_log.py`
+- `torchlens/__init__.py`
+- `tests/`
+
+### Phase 2: Introduce a stable bundle writer
+
+Goal:
+- Persist metadata and tensors without using raw pickle as the primary format.
+
+Work items:
+1. Add an `io/` module or subpackage for manifest writing, Parquet writers, and `safetensors` tensor sharding.
+2. Add `ModelLog.save(...)`.
+3. Define manifest schema and versioning.
+4. Encode nested list/dict/set fields either as normalized child tables or JSON-encoded columns where appropriate.
+
+Files touched:
+- new `torchlens/io/` package
+- `torchlens/data_classes/model_log.py`
+- `torchlens/__init__.py`
+- possibly `pyproject.toml` / package metadata for dependencies
+- `tests/`
+
+### Phase 3: Build a loader that reconstructs usable logs
+
+Goal:
+- `tl.load(...)` returns a usable `ModelLog`, not just raw tables.
+
+Work items:
+1. Add bundle manifest reader and table loader.
+2. Reconstruct `ModelLog`, `LayerLog`, `LayerPassLog`, `ModuleLog`, `ParamLog`, and `BufferLog` from normalized tables.
+3. Rebuild `ModuleAccessor`, `BufferAccessor`, and weakref-backed graph links explicitly.
+4. Add lazy tensor references/proxies for activations and gradients.
+
+Files touched:
+- new `torchlens/io/load.py` or equivalent
+- `torchlens/data_classes/model_log.py`
+- `torchlens/data_classes/layer_pass_log.py`
+- `torchlens/data_classes/layer_log.py`
+- `torchlens/data_classes/module_log.py`
+- `torchlens/data_classes/param_log.py`
+- `torchlens/data_classes/buffer_log.py`
+- `torchlens/__init__.py`
+- `tests/`
+
+### Phase 4: Make pickle explicit and demoted
+
+Goal:
+- Preserve a debug path without pretending it is the main archival format.
+
+Work items:
+1. Add `ModelLog.to_pickle()` and `tl.load_pickle()`.
+2. Warn on load that pickle is trusted-input-only and version-brittle.
+3. Either strip or canonicalize `func_applied` for pickle mode specifically, or document that pickle is unsupported for some ops.
+
+Files touched:
+- `torchlens/data_classes/model_log.py`
+- `torchlens/data_classes/layer_pass_log.py`
+- `torchlens/__init__.py`
+- `tests/`
+
+### Phase 5: Optional streaming / spill-to-disk capture
+
+Goal:
+- Reduce RAM pressure for very large captures.
+
+Work items:
+1. Introduce a tensor-storage backend abstraction under `save_tensor_data()`.
+2. Support eager-in-memory and streamed-to-bundle backends.
+3. Update fast-path refresh and validation replay to understand externalized tensors.
+
+Files touched:
+- `torchlens/data_classes/layer_pass_log.py`
+- `torchlens/capture/output_tensors.py`
+- `torchlens/capture/source_tensors.py`
+- `torchlens/capture/trace.py`
+- `torchlens/validation/core.py`
+- new `torchlens/io/storage.py`
+- `tests/`
+
+Bottom line:
+- TorchLens already has useful in-memory capture and a few DataFrame summaries.
+- It does not yet have a coherent persistence system.
+- I would build a versioned bundle format around Parquet + `safetensors`, keep pickle only as an explicit escape hatch, and postpone true streaming capture until after stable save/load works.

--- a/.project-context/research/prior-art.md
+++ b/.project-context/research/prior-art.md
@@ -1,0 +1,433 @@
+# Prior Art Research: Python-level Control-flow Attribution for TorchLens
+
+Date: 2026-04-22
+
+## Scope
+
+Question: how should TorchLens attribute each captured PyTorch op to the enclosing
+Python `if` / `elif` / `else` branch in eager execution?
+
+Goal of this report:
+
+1. Survey prior art in PyTorch internals and adjacent Python tooling.
+2. Compare AST, bytecode, `sys.settrace`, and frame-inspection approaches.
+3. Recommend a low-risk stdlib-first design for TorchLens.
+
+Legend:
+
+- `Documented`: directly supported by cited docs or source.
+- `Inference`: reasoned conclusion drawn from the cited material.
+
+## Executive Summary
+
+- No surveyed activation/introspection tool already gives eager-mode per-op branch attribution for arbitrary Python `if` / `elif` / `else`.
+- `torch.fx.symbolic_trace` and `make_fx` do not preserve dynamic Python branches; they either reject data-dependent control flow, specialize it away, or capture only the executed path. [Documented: `torch/fx/proxy.py:382-390`, `torch/fx/_symbolic_trace.py:1280-1326`, https://docs.pytorch.org/docs/stable/fx.html, https://docs.pytorch.org/docs/2.9/compile/programming_model.non_strict_tracing_model.html]
+- TorchDynamo is the strongest prior art for Python-level control-flow handling in PyTorch. It works at CPython bytecode level, recognizes conditional jumps, specializes many branches with guards, and graph-breaks on data-dependent tensor branching. [Documented: `torch/_dynamo/symbolic_convert.py:575-631`, `torch/_dynamo/symbolic_convert.py:723-726`, `torch/_dynamo/symbolic_convert.py:2921-2924`, https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_dynamo_overview.html, https://pytorch.org/assets/pytorch2-2.pdf]
+- TorchScript is the strongest prior art for source-based handling: it requires source access, parses Python source with `ast.parse`, and lowers `if` statements into its own IR. [Documented: `torch/_sources.py:12-35`, `torch/_sources.py:120-138`, `torch/jit/frontend.py:326-343`, `torch/jit/frontend.py:804-811`, https://docs.pytorch.org/docs/2.9/generated/torch.jit.script.html]
+- `coverage.py` is the best general-Python prior art for combining static branch structure with runtime execution. It enumerates possible branch arcs from AST and records runtime line-to-line transitions via `sys.settrace`. [Documented: `coverage/parser.py:1001-1011`, `coverage/pytracer.py:313-325`, https://coverage.readthedocs.io/en/latest/branch.html]
+- Recommendation: use AST as the primary control-flow model, with per-op frame inspection at TorchLens capture points. Do not make `sys.settrace` the default. Keep bytecode/disassembly as a fallback/debug aid, not the primary implementation. [Inference]
+
+## Comparison Matrix
+
+| Tool / family | Detection mechanism | Branch granularity | Runtime cost | Activation mode | Applicability to TorchLens |
+| --- | --- | --- | --- | --- | --- |
+| `torch.fx.symbolic_trace` | Proxy-based symbolic execution | None for dynamic branches; static branches specialized | Moderate tracing-time cost | On-demand | Negative prior art: does not preserve eager branch identity |
+| `make_fx` / non-strict tracing | Python execution + operator overloading | Executed path only | Moderate tracing-time cost | On-demand | Negative prior art: single-path capture only |
+| TorchDynamo | Bytecode interpreter + guards + graph breaks | Conditional jump / continuation boundary | High implementation complexity; lower runtime cost than `settrace` | On-demand compiler path | Strong conceptual prior art; too heavyweight/version-sensitive to reuse directly |
+| TorchScript `script()` | Source extraction + AST parse + compiler IR | Statement / expression in TorchScript subset | Compile-time cost only | On-demand | Strong AST prior art; private helpers, subset semantics |
+| TorchScript `trace()` | Execute once and record ops | Executed path only | Tracing-time cost | On-demand | Negative prior art for branch attribution |
+| Captum | Hooks / forward-backward instrumentation | Module/layer execution only | Moderate to high depending on method | On-demand | No branch model |
+| DeepSpeed FLOPs profiler | Forward hooks + monkey-patched functionals | Module/function call only | Moderate | On-demand | No branch model |
+| `coverage.py` | AST for possible arcs + `sys.settrace` runtime events | Line-to-line arcs | High | Opt-in, global | Best Python prior art, but too heavy/conflicting for default TorchLens path |
+| `sys.settrace` directly | Line/opcode callbacks | Line/opcode; no branch event | High | Global or per-thread | Useful optional debug mode, not default |
+| `sys.setprofile` | Call/return profiler callbacks | No line/branch detail | Lower than `settrace`, but insufficient | Global or per-thread | Not enough information |
+| `trace` / `bdb` | Thin wrappers over tracing callbacks | Statement stepping, breakpoints | High | Opt-in | No extra branch semantics |
+| `dis` / `co_lines()` | Static bytecode and line-table inspection | Jump op / bytecode offset | Low offline cost | On-demand | Good fallback/debug aid only |
+| mypy / pytype / radon | Static AST / CFG analysis | Static only | Offline only | On-demand | Useful for design intuition, not runtime attribution |
+
+## PyTorch Prior Art
+
+### 1. `torch.fx.symbolic_trace`
+
+What it does:
+
+- FX rejects converting a `Proxy` to `bool` by default. `Tracer.to_bool()` raises `TraceError("symbolically traced variables cannot be used as inputs to control flow")`. [Documented: `torch/fx/proxy.py:382-390`]
+- The FX docs say dynamic control flow is the main limitation of symbolic tracing. Static control flow can be specialized, and `concrete_args` can partially specialize branch conditions. [Documented: https://docs.pytorch.org/docs/stable/fx.html, https://docs.pytorch.org/docs/stable/fx.html#limitations-of-symbolic-tracing, `torch/fx/_symbolic_trace.py:1280-1326`, `torch.fx` docs lines around `concrete_args`: https://docs.pytorch.org/docs/stable/fx.html]
+
+Evaluation:
+
+- Detection mechanism: symbolic execution via proxy objects, not AST or bytecode. [Documented]
+- Branch granularity: none for dynamic `if` / `elif` / `else`; static branches are burned in. [Documented]
+- Performance cost: moderate tracing-time overhead, but not always-on. [Inference]
+- Runtime activation: on-demand. [Documented]
+- TorchLens relevance: mostly a "what not to copy" for branch attribution. FX either errors, specializes away the branch, or leaves a leaf call. It does not preserve "this op belonged to else-arm N" in eager Python. [Inference]
+
+TorchLens takeaway:
+
+- Good negative prior art.
+- Reusable idea: treat source-level control flow and op-level tracing as separate concerns. [Inference]
+
+### 2. `make_fx` / functorch-style non-strict tracing
+
+What it does:
+
+- PyTorch's non-strict tracing docs explicitly say it runs a Python function and records tensor ops through operator overloading. The docs show an `if x.shape[0] > 2:` example where only the top branch is captured for the given input. [Documented: https://docs.pytorch.org/docs/2.9/compile/programming_model.non_strict_tracing_model.html]
+- `make_fx` is the main entry point for this style of tracing. [Documented: `torch/fx/experimental/proxy_tensor.py:2281+`, https://docs.pytorch.org/docs/2.9/compile/programming_model.non_strict_tracing_model.html]
+
+Evaluation:
+
+- Detection mechanism: Python execution plus operator overloading / proxy tensor machinery. [Documented]
+- Branch granularity: executed path only; no branch alternatives preserved. [Documented]
+- Performance cost: moderate tracing-time cost. [Inference]
+- Runtime activation: on-demand. [Documented]
+- TorchLens relevance: not suitable as the primary control-flow attribution mechanism. It observes "what happened", but not the unexecuted branch structure. [Inference]
+
+TorchLens takeaway:
+
+- Another strong negative prior art: "single executed path" tracing is insufficient if the product requirement is explicit branch attribution rather than just op capture. [Inference]
+
+### 3. TorchDynamo (`torch.compile`, `torch._dynamo`)
+
+What it does:
+
+- TorchDynamo works by interpreting Python bytecode and rewriting execution into compiled segments plus continuation frames. The overview docs show generated `__resume_at_<offset>` functions that resume after graph breaks. [Documented: https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_dynamo_overview.html]
+- In source, conditional bytecodes are routed through `generic_jump(...)`, and Python 3.11 jump opcodes are bound with `POP_JUMP_FORWARD_IF_TRUE/FALSE = generic_jump(...)`. [Documented: `torch/_dynamo/symbolic_convert.py:575-631`, `torch/_dynamo/symbolic_convert.py:2921-2924`]
+- `generic_jump` explicitly labels "Data-dependent branching", says Dynamo does not support tracing dynamic control flow, and suggests `torch.cond`. If the branch condition is tensor-dependent and partial-graph compilation is allowed, Dynamo graph-breaks, emits resume code, and continues after the jump. [Documented: `torch/_dynamo/symbolic_convert.py:575-585`, `torch/_dynamo/symbolic_convert.py:587-631`, `torch/_dynamo/symbolic_convert.py:723-726`]
+- The PyTorch 2 paper states that most control flow is optimized away through specialization/guards, while less common truly dynamic control flow triggers a graph break and then resumes analysis after the jump. [Documented: https://pytorch.org/assets/pytorch2-2.pdf]
+
+Evaluation:
+
+- Detection mechanism: bytecode interpretation plus guard system. [Documented]
+- Branch granularity: conditional-jump level, with explicit resume points. [Documented]
+- Performance cost: much better than `sys.settrace` for compiler use, but implementation complexity is very high and tied to CPython bytecode details. [Inference]
+- Runtime activation: on-demand via compile path. [Documented]
+- TorchLens relevance: excellent conceptual prior art, poor direct implementation fit. [Inference]
+
+Reusable ideas for TorchLens:
+
+- Distinguish guardable/static branches from truly data-dependent branches. [Documented + Inference]
+- Treat the current branch decision as a runtime fact derived from the executing frame, not from static source alone. [Inference]
+- Avoid reproducing Dynamo's bytecode interpreter unless source is unavailable and the fallback benefit is worth the maintenance cost. Dynamo is tightly coupled to Python opcode variants (`POP_JUMP_*`, `TO_BOOL`, resume bytecode generation). [Inference]
+
+### 4. TorchScript (`torch.jit.script`, `torch.jit.trace`)
+
+What `script()` does:
+
+- The public docs say `torch.jit.script` inspects source code and compiles it as TorchScript, supporting control-dependent operations. The docs include an `if x.max() > y.max(): ... else: ...` example. [Documented: https://docs.pytorch.org/docs/2.9/generated/torch.jit.script.html]
+- Internally, TorchScript source extraction uses `inspect.getsourcefile` and `inspect.getsourcelines`, errors if source is unavailable, normalizes indentation, and parses with `ast.parse`. [Documented: `torch/_sources.py:12-35`, `torch/_sources.py:120-138`]
+- In the frontend, `get_jit_def()` calls `parse_def()`, and `StmtBuilder.build_If()` lowers Python `ast.If` to TorchScript `If(...)`. [Documented: `torch/jit/frontend.py:326-343`, `torch/jit/frontend.py:804-811`]
+
+What `trace()` does:
+
+- The tracing docs say tracing only records operations seen for the provided example inputs and explicitly warn that it will not record control flow like `if` statements or loops. [Documented: https://docs.pytorch.org/docs/stable/generated/torch.jit.trace.html]
+
+Evaluation:
+
+- Detection mechanism:
+  - `script()`: source + AST + compiler frontend. [Documented]
+  - `trace()`: execute once and record ops. [Documented]
+- Branch granularity:
+  - `script()`: statement/expression in TorchScript subset; preserves `if` in TorchScript IR. [Documented]
+  - `trace()`: executed path only. [Documented]
+- Performance cost:
+  - `script()`: compile-time source parse and frontend cost. [Documented + Inference]
+  - `trace()`: tracing-time cost only. [Documented]
+- Runtime activation: on-demand. [Documented]
+- TorchLens relevance: `script()` is strong proof that source-plus-AST is viable for Python control flow, but TorchScript helpers are private and tied to compiler semantics/subset constraints. [Inference]
+
+TorchLens takeaway:
+
+- Copy the pattern, not the implementation:
+  - use `inspect.getsourcefile` / `inspect.getsourcelines`
+  - use `ast.parse`
+  - cache parsed source by code object / file span
+- Do not depend on `torch._sources.parse_def` or other private TorchScript internals as stable APIs. [Inference]
+
+### 5. Captum / DeepSpeed / activation tooling
+
+#### Captum
+
+- Captum FAQ says some methods rely on hooks during back-propagation; reused modules can cause layer or neuron attribution methods to compute attributions for the last execution of the module; JIT models do not support hooks for hook-based methods. [Documented: https://captum.ai/docs/faq]
+
+Evaluation:
+
+- Detection mechanism: hooks around modules/layers, not source, bytecode, or branch-aware tracing. [Documented]
+- Branch granularity: module execution only; repeated-module reuse is already ambiguous. [Documented]
+- TorchLens relevance: useful negative prior art. Hook-based activation attribution is orthogonal to Python branch attribution. [Inference]
+
+#### DeepSpeed FLOPs profiler
+
+- DeepSpeed's FLOPs profiler docs/source say it profiles forward passes by recursively adding attributes, monkey-patching functionals/tensor methods, and registering `register_forward_pre_hook` / `register_forward_hook` handlers. [Documented: https://deepspeed.readthedocs.io/en/stable/_modules/deepspeed/profiling/flops_profiler/profiler.html]
+
+Evaluation:
+
+- Detection mechanism: forward hooks plus monkey-patched functionals. [Documented]
+- Branch granularity: module/function-call level only. [Documented]
+- TorchLens relevance: no branch awareness; good evidence that adjacent profiling tools generally stop at module/op call accounting, not enclosing Python branch attribution. [Inference]
+
+## Python Stdlib and Coverage Prior Art
+
+### 6. `coverage.py`
+
+What it does:
+
+- Coverage docs say branch mode collects pairs of line numbers (source, destination), and compares measured transitions with statically possible transitions. [Documented: https://coverage.readthedocs.io/en/latest/branch.html]
+- In source, the AST parser's `_handle__If` enumerates possible exits for true and false arms. [Documented: `coverage/parser.py:1001-1011`]
+- Runtime collection uses `sys.settrace` in `PyTracer.start()`. [Documented: `coverage/pytracer.py:313-325`]
+- Coverage warns that `sys.settrace` conflicts with other tracers, and that `sys.setprofile` code execution is invisible to coverage's tracing. [Documented: https://coverage.readthedocs.io/en/latest/trouble.html]
+
+Evaluation:
+
+- Detection mechanism: hybrid AST + runtime tracing. [Documented]
+- Branch granularity: line-to-line arcs, not expression-level branch-arm identity. [Documented]
+- Performance cost: high relative to normal execution; coverage even exposes a slower `timid` trace mode. [Documented: `coverage/control.py:183-188`]
+- Runtime activation: opt-in, process-wide / thread-wide. [Documented]
+- TorchLens relevance: this is the best prior art outside PyTorch for "static branch possibilities + runtime execution facts." [Inference]
+
+TorchLens takeaway:
+
+- Strongly reuse the idea of separating:
+  - static branch structure from AST
+  - runtime location from execution events
+- But do not copy the "always-on global `sys.settrace`" part for default TorchLens usage. TorchLens already intercepts ops, so it can usually sample the active frame only when an op is captured. That should be much cheaper and less conflicting. [Inference]
+
+### 7. `sys.settrace`
+
+- Python docs say `sys.settrace` emits `call`, `line`, `return`, `exception`, and `opcode` events. Per-opcode events require setting `frame.f_trace_opcodes = True`. [Documented: https://docs.python.org/3.11/library/sys.html]
+- There is no branch event. You must infer branch decisions from line movement or opcode/jump execution. [Documented + Inference]
+- The docs state it is intended for debuggers, profilers, coverage tools, and similar implementation-platform tooling. [Documented: https://docs.python.org/3.11/library/sys.html]
+
+Evaluation:
+
+- Detection mechanism: interpreter callbacks on every traced event. [Documented]
+- Branch granularity: line-level by default; opcode-level with extra work. [Documented]
+- Performance cost: high. [Inference]
+- Runtime activation: global/per-thread while enabled. [Documented]
+- TorchLens relevance: good optional fallback or debug mode, poor default path. [Inference]
+
+Why not default to `settrace`:
+
+- No direct branch semantic; branch identity must still be reconstructed.
+- Conflicts with coverage/debuggers and other tracer users. [Documented: https://coverage.readthedocs.io/en/latest/trouble.html]
+- Overhead is paid for all executed Python, not just TorchLens-captured ops. [Inference]
+
+### 8. `sys.setprofile`
+
+- Python docs say `setprofile` is called on call/return and C-call events, not for each executed line. [Documented: https://docs.python.org/3.11/library/sys.html]
+- Coverage docs explicitly say code run under `sys.setprofile` does not fire trace events, so coverage cannot see it. [Documented: https://coverage.readthedocs.io/en/latest/trouble.html]
+
+Evaluation:
+
+- Detection mechanism: profiler callbacks. [Documented]
+- Branch granularity: none. [Documented]
+- TorchLens relevance: insufficient for branch attribution. [Inference]
+
+### 9. `trace` module and `bdb`
+
+- `trace` documents statement execution tracing and counting, and explicitly points users to coverage.py for advanced branch coverage. [Documented: https://docs.python.org/3.11/library/trace.html]
+- `bdb` dispatches `line`, `call`, `return`, and `exception` events and builds debugger stepping on top of `sys.settrace`, not on branch-specific events. [Documented: https://docs.python.org/3.11/library/bdb.html]
+
+Evaluation:
+
+- Detection mechanism: wrappers over trace callbacks. [Documented]
+- Branch granularity: none beyond line stepping / breakpoints. [Documented]
+- TorchLens relevance: not a direct solution. [Inference]
+
+### 10. `dis`, `code.co_lines()`, and bytecode inspection
+
+- Python's `dis` docs expose conditional jump opcodes such as `POP_JUMP_FORWARD_IF_FALSE` / `POP_JUMP_BACKWARD_IF_FALSE`. [Documented: https://docs.python.org/3.11/library/dis.html]
+- PEP 626 introduces precise line number semantics and `co_lines()` for mapping bytecode ranges to source lines. [Documented: https://peps.python.org/pep-0626/]
+
+Evaluation:
+
+- Detection mechanism: static bytecode inspection. [Documented]
+- Branch granularity: jump-op level; still requires runtime state to know which branch was taken. [Documented + Inference]
+- Performance cost: low offline cost. [Documented + Inference]
+- TorchLens relevance: useful as a source-unavailable fallback or debugging/validation aid, but not ideal as the primary implementation because CPython bytecode is version-sensitive and lower-level than the user-facing requirement. [Inference]
+
+## Static Analysis Prior Art
+
+### 11. mypy
+
+- `mypy.reachability.infer_reachability_of_if_statement()` statically marks `if` / `elif` / `else` blocks unreachable when conditions are provably constant. [Documented: `mypy/reachability.py:53-76`]
+- mypy's binder tracks frames for branching and type narrowing, explicitly noting a new frame for control-flow branching. [Documented: `mypy/binder.py:50-77`]
+
+Evaluation:
+
+- Detection mechanism: static AST/control-flow analysis. [Documented]
+- Branch granularity: static blocks and type states, not runtime branch choice. [Documented]
+- TorchLens relevance: useful for data structures and terminology, not runtime attribution. [Inference]
+
+### 12. pytype
+
+- Pytype developer docs say it builds a control-flow graph where each node roughly correlates with a statement, and models `if` / `else` as distinct CFG paths that merge later. [Documented: https://google.github.io/pytype/developers/typegraph.html]
+
+Evaluation:
+
+- Detection mechanism: static CFG/typegraph. [Documented]
+- Branch granularity: statement-level static paths. [Documented]
+- TorchLens relevance: confirms AST/CFG representations are conventional, but pytype is not a runtime attribution model. [Inference]
+
+### 13. Radon
+
+- Radon analyzes cyclomatic complexity from AST using `ComplexityVisitor`, and exposes `cc_visit_ast`. [Documented: https://radon.readthedocs.io/en/stable/api.html]
+
+Evaluation:
+
+- Detection mechanism: static AST metrics. [Documented]
+- Branch granularity: complexity counts, not runtime branch identity. [Documented]
+- TorchLens relevance: minimal. It can count branches, not attribute executed ops to one. [Inference]
+
+### 14. Pyright
+
+- I did not find a public, branch-oriented runtime API in pyright during this research pass. Public material around pyright is mostly about type checking and narrowing, not exposing executed-branch metadata to other tools. [Inference]
+
+Evaluation:
+
+- Detection mechanism: static type/narrowing analysis. [Inference]
+- TorchLens relevance: likely similar to mypy/pytype in spirit, but not directly reusable for runtime attribution. [Inference]
+
+## Research and Compiler-adjacent Material
+
+### 15. PyTorch 2 paper
+
+- The PyTorch 2 paper is the most directly relevant research-style writeup for Python control flow in PyTorch. It states that TorchDynamo specializes most control flow away and graph-breaks on truly data-dependent control flow, resuming after the jump. [Documented: https://pytorch.org/assets/pytorch2-2.pdf]
+
+TorchLens takeaway:
+
+- Good conceptual split between:
+  - static/specializable control flow
+  - truly runtime/data-dependent control flow
+- For TorchLens attribution, we do not need to compile or transform the program, only to name the enclosing branch of each already-captured op. That strongly argues for a simpler source-based approach than Dynamo. [Inference]
+
+### 16. GraphMend
+
+- GraphMend presents source-level transformations to remove graph breaks from dynamic control flow and Python side effects in PyTorch 2. [Documented: https://arxiv.org/abs/2509.16248]
+
+TorchLens takeaway:
+
+- Recent research treats unresolved Python control flow primarily as a source-transformation / CFG problem, not as an activation-hook problem. That supports AST-first thinking. [Inference]
+
+### 17. PyTorch/XLA / LazyTensor docs
+
+- XLA docs explicitly say Python `if/else/while/for` based on runtime values forces materialization and that two obvious solutions are either explicit control-flow ops or parsing Python source like TorchScript. [Documented: https://docs.pytorch.org/xla/release/r2.8/perf/recompilation.html]
+
+TorchLens takeaway:
+
+- This is an unusually direct external endorsement of the AST/source-parsing direction for Python control flow in PyTorch-adjacent tooling. [Inference]
+
+## Recommendation
+
+### Final recommendation
+
+Choose **AST as the primary mechanism**, with **op-time frame inspection** at TorchLens capture points.
+
+Do **not** make `sys.settrace` the default.
+
+Do **not** make bytecode interpretation the primary implementation.
+
+This is closest to "pure AST" in the choice set, but with an important clarification:
+
+- pure AST alone is not enough
+- the runtime fact should come from the frame already available when TorchLens captures an op
+- the branch model should come from cached AST/source analysis
+
+That is lower risk than an `AST + sys.settrace` hybrid and far lower maintenance than a bytecode-primary design. [Inference]
+
+### Why this is the best fit
+
+1. TorchLens already has op capture points.
+   At each wrapped torch op, TorchLens can inspect the active Python frame (`frame.f_code`, `frame.f_lineno`) without paying global tracing overhead. [Inference]
+
+2. Branch identity is a source-structure question.
+   The user wants "which `if`/`elif`/`else` arm enclosed this op?", which maps naturally to AST nodes and source spans, not bytecode offsets. TorchScript and coverage.py both reinforce that source structure is the right static model. [Documented + Inference]
+
+3. Bytecode is the wrong abstraction for the product requirement.
+   Dynamo proves bytecode works, but only with substantial interpreter emulation, guard machinery, and Python-version opcode maintenance. That is overkill for TorchLens attribution. [Inference]
+
+4. `sys.settrace` is too expensive/conflict-prone for default use.
+   Coverage.py uses it because it must observe all Python execution. TorchLens does not have that requirement; it only needs branch context when a captured op occurs. [Documented + Inference]
+
+### Concrete stdlib-only APIs TorchLens should use
+
+Primary path:
+
+- `inspect.getsourcefile(obj)` and `inspect.getsourcelines(obj)` for source recovery.
+- `ast.parse(source)` for parsing.
+- AST node location fields: `lineno`, `end_lineno`, `col_offset`, `end_col_offset`.
+- Runtime frame fields: `frame.f_code`, `frame.f_lineno`.
+- `linecache` as a resilience layer when source lookup is slightly messy. [Inference]
+
+Useful supporting APIs:
+
+- `code.co_firstlineno` for anchoring code objects to source.
+- `code.co_lines()` for validation/debugging on Python 3.10+ (PEP 626). [Documented: https://peps.python.org/pep-0626/]
+- `dis.get_instructions()` only for fallback/debugging, not as the primary path. [Documented: https://docs.python.org/3.11/library/dis.html]
+
+### Suggested attribution semantics
+
+Recommended labels:
+
+- `if.test` for ops executed while evaluating the predicate itself.
+- `if.body`
+- `if.orelse`
+- `elif[i].test`
+- `elif[i].body`
+- `else.body`
+
+Reason:
+
+- An op inside `if torch.sum(x) > 0:` occurs before branch choice is known; it should not be mislabeled as belonging to the taken arm. [Inference]
+
+### Fallback modes when source is unavailable
+
+Recommended degradation order:
+
+1. **Best effort source recovery**
+   Use `inspect.getsourcefile`, `inspect.getsourcelines`, `linecache`.
+
+2. **No source, but code object available**
+   Record coarse location only: filename, qualname, line number, and mark branch attribution as unavailable.
+
+3. **Optional debug fallback**
+   Use `dis` plus `co_lines()` to identify nearby conditional bytecode/jump structure for diagnostics, but do not synthesize a confident branch label unless the mapping is unambiguous.
+
+4. **Do not silently guess**
+   Prefer `branch_id=None` / `branch_unknown` over a wrong branch label. [Inference]
+
+### When to consider optional `sys.settrace`
+
+Only as an opt-in debug or research mode, for cases like:
+
+- validating the AST/frame implementation against line-to-line transitions
+- investigating tricky multi-line predicates, comprehensions, or exception-heavy code
+- collecting more exact path arcs than TorchLens needs in normal operation
+
+This should not be the default runtime path. [Inference]
+
+## What TorchLens Can Learn or Reuse
+
+Directly reusable ideas:
+
+- From TorchScript: source acquisition -> normalization -> AST parse -> branch-node lowering. [Documented: `torch/_sources.py:12-35`, `torch/_sources.py:120-138`, `torch/jit/frontend.py:804-811`]
+- From coverage.py: keep static branch structure separate from runtime execution evidence. [Documented: `coverage/parser.py:1001-1011`, `coverage/pytracer.py:313-325`, https://coverage.readthedocs.io/en/latest/branch.html]
+- From Dynamo: distinguish specialization-friendly branches from truly dynamic branches; keep fallbacks explicit rather than magical. [Documented: `torch/_dynamo/symbolic_convert.py:575-631`, https://pytorch.org/assets/pytorch2-2.pdf]
+
+Things to avoid:
+
+- Re-implementing a bytecode interpreter like Dynamo. [Inference]
+- Global `sys.settrace` for the common path. [Inference]
+- Depending on private TorchScript helpers as public API. [Inference]
+- Hook-only thinking from Captum/DeepSpeed; hooks tell you which module ran, not which Python branch enclosed the op. [Inference]
+
+## Bottom Line
+
+The prior art converges on a simple conclusion:
+
+- branch structure is best modeled from source/AST
+- runtime branch choice should come from execution state
+- for TorchLens, execution state can be sampled at existing op-capture sites
+
+So the lowest-risk design is:
+
+**AST-first branch modeling + per-op frame inspection, with explicit graceful degradation when source is unavailable.**

--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ streamed_log = tl.log_forward_pass(
 )
 ```
 
+## Security
+
+Portable bundles contain a pickle file in `metadata.pkl`. Only load bundles
+from trusted sources. Loading an untrusted bundle with `tl.load()` or
+`ModelLog.load()` can execute arbitrary code.
+
 Export options:
 - `to_pandas()` on model, layer, module, parameter, and buffer surfaces
 - `to_csv(...)`, `to_parquet(...)`, and `to_json(...)` on those same surfaces

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 *TorchLens* is a package for doing exactly two things:
 
-1) Easily extracting the activations from every single intermediate operation in a PyTorch model—no
-   modifications needed—in one line of code. "Every operation" means every operation; "one line" means one line.
+1) Easily extracting the activations from every single intermediate operation in a PyTorch model, with no
+   modifications needed, in one line of code. "Every operation" means every operation; "one line" means one line.
 2) Understanding the model's computational structure via an intuitive automatic visualization and extensive
    metadata ([partial list here](https://static-content.springer.com/esm/art%3A10.1038%2Fs41598-023-40807-0/MediaObjects/41598_2023_40807_MOESM1_ESM.pdf))
    about the network's computational graph.
@@ -201,6 +201,45 @@ print(model_history.layer_labels)
 ['conv2d_3_7', 'maxpool2d_3_13', 'linear_1_17', 'dropout_2_19', 'linear_2_20', 'linear_3_22']
 '''
 ```
+
+### Saving and Loading
+
+```python
+import torch
+import torch.nn as nn
+import torchlens as tl
+
+model = nn.Sequential(nn.Linear(4, 3), nn.ReLU())
+x = torch.randn(2, 4)
+model_log = tl.log_forward_pass(model, x, layers_to_save="all")
+tl.save(model_log, "demo_bundle")
+
+lazy_log = tl.load("demo_bundle", lazy=True)
+activation = lazy_log["linear_1_1"].materialize_activation()
+print(activation.shape)
+```
+
+You can also stream activations directly to disk during capture:
+
+```python
+streamed_log = tl.log_forward_pass(
+    model,
+    x,
+    layers_to_save="all",
+    save_activations_to="stream_bundle",
+    keep_activations_in_memory=False,
+)
+```
+
+Export options:
+- `to_pandas()` on model, layer, module, parameter, and buffer surfaces
+- `to_csv(...)`, `to_parquet(...)`, and `to_json(...)` on those same surfaces
+- `to_parquet(...)` requires `pyarrow`
+
+Caveats:
+- Portable bundles do not support `validate_forward_pass()` or replay-oriented validation.
+- Streaming capture is always strict; unsupported tensors abort the save instead of being skipped.
+- Portable bundle save/load requires `safetensors`.
 
 The main function of *TorchLens* is `log_forward_pass`; the remaining functions are:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "torchlens"
 version = "1.1.0"
-description = "A package for extracting activations from PyTorch models"
+description = "A package for extracting activations from PyTorch models and saving portable bundles"
 readme = "README.md"
 license = "GPL-3.0-only"
 requires-python = ">=3.9"
 authors = [
     {name = "JohnMark Taylor", email = "johnmarkedwardtaylor@gmail.com"},
 ]
-keywords = ["torch", "torchlens", "features"]
+keywords = ["torch", "torchlens", "activations", "features", "io"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
@@ -97,7 +97,7 @@ python_version = "3.11"
 warn_return_any = false
 warn_unused_configs = true
 ignore_missing_imports = true
-# Lenient for now — tighten as annotations improve
+# Lenient for now - tighten as annotations improve
 check_untyped_defs = false
 disallow_untyped_defs = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["ruff", "pytest", "pytest-cov", "mypy", "pip-audit", "pre-commit"]
+io = ["pyarrow"]
 test = [
     "lightning",
     "pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "numpy",
     "pandas",
     "torch",
+    "safetensors>=0.4",
     "tqdm",
     "ipython",
     "graphviz",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
 import os
+import sys
 from os.path import join as opj
 
 import pytest
 import torch
 
-from torchlens import _state
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from torchlens import _state  # noqa: E402
 
 # Deterministic seeding
 torch.manual_seed(0)

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -26,12 +26,13 @@ from torchlens.utils.arg_handling import _safe_copy_arg
 # ---------------------------------------------------------------------------
 
 from torchlens.constants import (
-    MODEL_LOG_FIELD_ORDER,
+    BUFFER_LOG_FIELD_ORDER,
+    FUNC_CALL_LOCATION_FIELD_ORDER,
     LAYER_PASS_LOG_FIELD_ORDER,
+    MODEL_LOG_FIELD_ORDER,
     MODULE_LOG_FIELD_ORDER,
     MODULE_PASS_LOG_FIELD_ORDER,
     PARAM_LOG_FIELD_ORDER,
-    FUNC_CALL_LOCATION_FIELD_ORDER,
 )
 
 
@@ -61,6 +62,7 @@ class TestFieldOrderSync:
             (MODULE_LOG_FIELD_ORDER, "MODULE_LOG_FIELD_ORDER"),
             (MODULE_PASS_LOG_FIELD_ORDER, "MODULE_PASS_LOG_FIELD_ORDER"),
             (PARAM_LOG_FIELD_ORDER, "PARAM_LOG_FIELD_ORDER"),
+            (BUFFER_LOG_FIELD_ORDER, "BUFFER_LOG_FIELD_ORDER"),
             (FUNC_CALL_LOCATION_FIELD_ORDER, "FUNC_CALL_LOCATION_FIELD_ORDER"),
         ],
     )

--- a/tests/test_io_bundle.py
+++ b/tests/test_io_bundle.py
@@ -268,52 +268,61 @@ def test_bundle_save_strict_false_records_unsupported_tensors(tmp_path: Path) ->
 
 
 @pytest.mark.parametrize(
-    ("scenario", "mutate_manifest", "expectation"),
+    ("scenario", "mutate_manifest", "expectation", "expected_text"),
     [
         (
             "io_format_newer",
             lambda manifest: manifest.__setitem__("io_format_version", IO_FORMAT_VERSION + 1),
             "raise",
+            str(IO_FORMAT_VERSION + 1),
         ),
         (
             "io_format_older",
             lambda manifest: manifest.__setitem__("io_format_version", IO_FORMAT_VERSION - 1),
             "deprecation_warning",
+            str(IO_FORMAT_VERSION - 1),
         ),
         (
             "io_format_equal",
             lambda manifest: manifest.__setitem__("io_format_version", IO_FORMAT_VERSION),
             "ok",
+            None,
         ),
         (
             "torch_major_mismatch",
             lambda manifest: manifest.__setitem__("torch_version", "999.0.0"),
             "raise",
+            "999.0.0",
         ),
         (
             "torch_minor_mismatch",
             lambda manifest: manifest.__setitem__("torch_version", _torch_minor_mismatch_version()),
             "warning",
+            lambda: _torch_minor_mismatch_version(),
         ),
         (
             "torchlens_newer",
             lambda manifest: manifest.__setitem__("torchlens_version", "999.0.0"),
             "warning",
+            "999.0.0",
         ),
         (
             "torchlens_older",
             lambda manifest: manifest.__setitem__("torchlens_version", "0.0.1"),
             "info_log",
+            "0.0.1",
         ),
         (
             "python_major_mismatch",
             lambda manifest: manifest.__setitem__("python_version", "999.0.0"),
             "python_major_mismatch",
+            "999.0.0",
         ),
         (
             "unknown_extra_blob_file",
             lambda manifest: manifest,
             "extra_blob_warning",
+            None,
         ),
     ],
 )
@@ -324,6 +333,7 @@ def test_bundle_version_policy_rows(
     scenario: str,
     mutate_manifest: Callable[[dict[str, Any]], Any],
     expectation: str,
+    expected_text: str | Callable[[], str] | None,
 ) -> None:
     """Fork F version and integrity policy rows should behave as specified."""
 
@@ -331,6 +341,7 @@ def test_bundle_version_policy_rows(
     manifest = _read_manifest(bundle_path)
     mutate_manifest(manifest)
     _write_manifest(bundle_path, manifest)
+    resolved_expected_text = expected_text() if callable(expected_text) else expected_text
 
     if expectation == "python_major_mismatch":
         (bundle_path / "metadata.pkl").write_bytes(b"not a pickle")
@@ -346,18 +357,18 @@ def test_bundle_version_policy_rows(
         return
 
     if expectation == "raise":
-        with pytest.raises(TorchLensIOError):
+        with pytest.raises(TorchLensIOError, match=resolved_expected_text or ""):
             load(bundle_path)
         return
 
     if expectation == "deprecation_warning":
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning, match=resolved_expected_text or ""):
             loaded = load(bundle_path)
         assert loaded.model_name == "_ConvBundleModel"
         return
 
     if expectation == "warning":
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match=resolved_expected_text or ""):
             loaded = load(bundle_path)
         assert loaded.model_name == "_ConvBundleModel"
         return
@@ -366,6 +377,8 @@ def test_bundle_version_policy_rows(
         with caplog.at_level(logging.INFO, logger="torchlens._io.manifest"):
             loaded = load(bundle_path)
         assert loaded.model_name == "_ConvBundleModel"
+        assert resolved_expected_text is not None
+        assert resolved_expected_text in caplog.text
         assert "older than runtime torchlens_version" in caplog.text
         return
 

--- a/tests/test_io_bundle.py
+++ b/tests/test_io_bundle.py
@@ -1,0 +1,532 @@
+"""Tests for portable TorchLens directory bundle save/load."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+from torchlens import ModelLog, cleanup_tmp, load, log_forward_pass, save
+from torchlens._io import IO_FORMAT_VERSION, TorchLensIOError
+from torchlens._io.manifest import Manifest
+
+
+class _ConvBundleModel(nn.Module):
+    """Small convolutional model used for bundle round-trip checks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 4, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(4, 4, kernel_size=3, padding=1)
+        self.conv3 = nn.Conv2d(4, 2, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the test model."""
+
+        x = torch.relu(self.conv1(x))
+        x = torch.relu(self.conv2(x))
+        return self.conv3(x)
+
+
+class _ActivationPostfuncModel(nn.Module):
+    """Small linear model for activation postfunc policy tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear1 = nn.Linear(4, 4)
+        self.linear2 = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the test model."""
+
+        return self.linear2(torch.relu(self.linear1(x)))
+
+
+def _build_conv_log(seed: int = 0) -> ModelLog:
+    """Create a deterministic ``ModelLog`` for bundle tests.
+
+    Parameters
+    ----------
+    seed:
+        Random seed used for model init and inputs.
+
+    Returns
+    -------
+    ModelLog
+        Logged forward pass with all activations saved.
+    """
+
+    torch.manual_seed(seed)
+    model = _ConvBundleModel()
+    x = torch.randn(1, 3, 8, 8)
+    return log_forward_pass(model, x, layers_to_save="all", random_seed=seed)
+
+
+def _build_postfunc_log(postfunc: Callable[[torch.Tensor], Any]) -> ModelLog:
+    """Create a deterministic log using a custom activation postfunc.
+
+    Parameters
+    ----------
+    postfunc:
+        Activation postprocessing function applied during logging.
+
+    Returns
+    -------
+    ModelLog
+        Logged forward pass with transformed activations.
+    """
+
+    torch.manual_seed(0)
+    model = _ActivationPostfuncModel()
+    x = torch.randn(2, 4)
+    return log_forward_pass(
+        model,
+        x,
+        layers_to_save="all",
+        activation_postfunc=postfunc,
+        random_seed=0,
+    )
+
+
+def _build_sparse_activation_log() -> ModelLog:
+    """Create a live log whose first saved activation is converted to sparse post-hoc.
+
+    Returns
+    -------
+    ModelLog
+        Model log containing an unsupported sparse activation tensor.
+    """
+
+    model_log = _build_conv_log()
+    first_saved_layer = next(layer for layer in model_log.layer_list if layer.has_saved_activations)
+    assert isinstance(first_saved_layer.activation, torch.Tensor)
+    first_saved_layer.activation = first_saved_layer.activation.to_sparse()
+    return model_log
+
+
+def _build_non_tensor_activation_log() -> ModelLog:
+    """Create a live log whose first saved activation becomes a non-tensor post-hoc.
+
+    Returns
+    -------
+    ModelLog
+        Model log containing a non-tensor activation payload.
+    """
+
+    model_log = _build_conv_log()
+    first_saved_layer = next(layer for layer in model_log.layer_list if layer.has_saved_activations)
+    first_saved_layer.activation = 1.0
+    model_log.activation_postfunc = lambda tensor: float(tensor.mean().item())
+    return model_log
+
+
+def _save_bundle(
+    tmp_path: Path, *, seed: int = 0, path_name: str = "bundle.tl"
+) -> tuple[Path, ModelLog]:
+    """Save a deterministic bundle and return both path and source log.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary test directory.
+    seed:
+        Random seed used for model init and inputs.
+    path_name:
+        Bundle directory name.
+
+    Returns
+    -------
+    tuple[Path, ModelLog]
+        Saved bundle path and the original live log.
+    """
+
+    model_log = _build_conv_log(seed=seed)
+    bundle_path = tmp_path / path_name
+    save(model_log, bundle_path)
+    return bundle_path, model_log
+
+
+def _read_manifest(bundle_path: Path) -> dict[str, Any]:
+    """Read a bundle manifest into a mutable dict.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+
+    Returns
+    -------
+    dict[str, Any]
+        Decoded manifest JSON.
+    """
+
+    with (bundle_path / "manifest.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _write_manifest(bundle_path: Path, manifest: dict[str, Any]) -> None:
+    """Overwrite a bundle manifest with JSON content.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+    manifest:
+        JSON-ready manifest content.
+    """
+
+    with (bundle_path / "manifest.json").open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+
+def _first_blob_path(bundle_path: Path) -> Path:
+    """Return the first tensor blob referenced by the bundle manifest.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+
+    Returns
+    -------
+    Path
+        Path to the first saved blob.
+    """
+
+    manifest = Manifest.read(bundle_path / "manifest.json")
+    return bundle_path / manifest.tensors[0].relative_path
+
+
+def _corrupt_blob_byte(blob_path: Path) -> None:
+    """Modify one byte in a blob file without deleting it.
+
+    Parameters
+    ----------
+    blob_path:
+        Blob file path to modify.
+    """
+
+    blob_bytes = bytearray(blob_path.read_bytes())
+    blob_bytes[-1] = (blob_bytes[-1] + 1) % 256
+    blob_path.write_bytes(bytes(blob_bytes))
+
+
+def test_bundle_roundtrip_preserves_saved_activations_bit_exactly(tmp_path: Path) -> None:
+    """Eager bundle load should restore all saved activations exactly."""
+
+    bundle_path, live_log = _save_bundle(tmp_path)
+
+    restored = load(bundle_path)
+
+    live_by_label = {
+        layer.layer_label: layer.activation
+        for layer in live_log.layer_list
+        if layer.has_saved_activations and isinstance(layer.activation, torch.Tensor)
+    }
+    restored_by_label = {
+        layer.layer_label: layer.activation
+        for layer in restored.layer_list
+        if layer.has_saved_activations and isinstance(layer.activation, torch.Tensor)
+    }
+
+    assert restored._loaded_from_bundle is True
+    assert isinstance(restored._source_bundle_manifest_sha256, str)
+    assert live_by_label.keys() == restored_by_label.keys()
+    for layer_label, live_activation in live_by_label.items():
+        assert torch.equal(live_activation, restored_by_label[layer_label])
+
+
+def test_bundle_save_strict_default_raises_on_sparse_tensor(tmp_path: Path) -> None:
+    """Strict bundle save should reject sparse tensors."""
+
+    model_log = _build_sparse_activation_log()
+
+    with pytest.raises(TorchLensIOError, match="sparse"):
+        save(model_log, tmp_path / "sparse_bundle.tl")
+
+
+def test_bundle_save_strict_false_records_unsupported_tensors(tmp_path: Path) -> None:
+    """Best-effort save should skip unsupported tensors and record them in the manifest."""
+
+    model_log = _build_sparse_activation_log()
+    bundle_path = tmp_path / "sparse_bundle.tl"
+
+    save(model_log, bundle_path, strict=False)
+
+    manifest = Manifest.read(bundle_path / "manifest.json")
+    assert manifest.unsupported_tensors
+    assert all(entry["kind"] == "activation" for entry in manifest.unsupported_tensors)
+    assert all("sparse" in entry["reason"] for entry in manifest.unsupported_tensors)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "mutate_manifest", "expectation"),
+    [
+        (
+            "io_format_newer",
+            lambda manifest: manifest.__setitem__("io_format_version", IO_FORMAT_VERSION + 1),
+            "raise",
+        ),
+        (
+            "io_format_older",
+            lambda manifest: manifest.__setitem__("io_format_version", IO_FORMAT_VERSION - 1),
+            "deprecation_warning",
+        ),
+        (
+            "io_format_equal",
+            lambda manifest: manifest.__setitem__("io_format_version", IO_FORMAT_VERSION),
+            "ok",
+        ),
+        (
+            "torch_major_mismatch",
+            lambda manifest: manifest.__setitem__("torch_version", "999.0.0"),
+            "raise",
+        ),
+        (
+            "torch_minor_mismatch",
+            lambda manifest: manifest.__setitem__("torch_version", _torch_minor_mismatch_version()),
+            "warning",
+        ),
+        (
+            "torchlens_newer",
+            lambda manifest: manifest.__setitem__("torchlens_version", "999.0.0"),
+            "warning",
+        ),
+        (
+            "torchlens_older",
+            lambda manifest: manifest.__setitem__("torchlens_version", "0.0.1"),
+            "info_log",
+        ),
+        (
+            "python_major_mismatch",
+            lambda manifest: manifest.__setitem__("python_version", "999.0.0"),
+            "python_major_mismatch",
+        ),
+        (
+            "unknown_extra_blob_file",
+            lambda manifest: manifest,
+            "extra_blob_warning",
+        ),
+    ],
+)
+def test_bundle_version_policy_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    scenario: str,
+    mutate_manifest: Callable[[dict[str, Any]], Any],
+    expectation: str,
+) -> None:
+    """Fork F version and integrity policy rows should behave as specified."""
+
+    bundle_path, _ = _save_bundle(tmp_path, path_name=f"{scenario}.tl")
+    manifest = _read_manifest(bundle_path)
+    mutate_manifest(manifest)
+    _write_manifest(bundle_path, manifest)
+
+    if expectation == "python_major_mismatch":
+        (bundle_path / "metadata.pkl").write_bytes(b"not a pickle")
+        with pytest.raises(TorchLensIOError, match="python_version=999.0.0"):
+            load(bundle_path)
+        return
+
+    if expectation == "extra_blob_warning":
+        (bundle_path / "blobs" / "extra.bin").write_bytes(b"extra")
+        with pytest.warns(UserWarning, match="unreferenced extra files"):
+            loaded = load(bundle_path)
+        assert loaded.model_name == "_ConvBundleModel"
+        return
+
+    if expectation == "raise":
+        with pytest.raises(TorchLensIOError):
+            load(bundle_path)
+        return
+
+    if expectation == "deprecation_warning":
+        with pytest.warns(DeprecationWarning):
+            loaded = load(bundle_path)
+        assert loaded.model_name == "_ConvBundleModel"
+        return
+
+    if expectation == "warning":
+        with pytest.warns(UserWarning):
+            loaded = load(bundle_path)
+        assert loaded.model_name == "_ConvBundleModel"
+        return
+
+    if expectation == "info_log":
+        with caplog.at_level(logging.INFO, logger="torchlens._io.manifest"):
+            loaded = load(bundle_path)
+        assert loaded.model_name == "_ConvBundleModel"
+        assert "older than runtime torchlens_version" in caplog.text
+        return
+
+    loaded = load(bundle_path)
+    assert loaded.model_name == "_ConvBundleModel"
+
+
+def test_bundle_load_raises_for_missing_safetensors_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Load should wrap backend import failures with an install hint."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+
+    def _raise_backend_import(path: Path, device: str) -> dict[str, torch.Tensor]:
+        raise ImportError("missing backend")
+
+    monkeypatch.setattr("torchlens._io.bundle.load_file", _raise_backend_import)
+
+    with pytest.raises(TorchLensIOError, match="Install safetensors>=0.4"):
+        load(bundle_path)
+
+
+def test_bundle_load_raises_on_corrupt_manifest(tmp_path: Path) -> None:
+    """Non-JSON manifests should fail with ``TorchLensIOError``."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    (bundle_path / "manifest.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(TorchLensIOError, match="Failed to read manifest"):
+        load(bundle_path)
+
+
+def test_bundle_load_raises_on_missing_blob_file(tmp_path: Path) -> None:
+    """Manifest entries without corresponding files should fail and name the blob id."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    manifest = Manifest.read(bundle_path / "manifest.json")
+    blob_entry = manifest.tensors[0]
+    (bundle_path / blob_entry.relative_path).unlink()
+
+    with pytest.raises(TorchLensIOError, match=blob_entry.blob_id):
+        load(bundle_path)
+
+
+def test_bundle_load_raises_on_truncated_safetensors(tmp_path: Path) -> None:
+    """Truncated blob files should fail bundle load."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    blob_path = _first_blob_path(bundle_path)
+    blob_path.write_bytes(blob_path.read_bytes()[:16])
+
+    with pytest.raises(TorchLensIOError):
+        load(bundle_path)
+
+
+def test_bundle_load_raises_on_checksum_tamper(tmp_path: Path) -> None:
+    """Blob checksum tampering should be detected eagerly."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    manifest = Manifest.read(bundle_path / "manifest.json")
+    blob_entry = manifest.tensors[0]
+    _corrupt_blob_byte(bundle_path / blob_entry.relative_path)
+
+    with pytest.raises(TorchLensIOError, match=blob_entry.blob_id):
+        load(bundle_path)
+
+
+def test_bundle_save_overwrite_false_wraps_file_exists_error(tmp_path: Path) -> None:
+    """Existing target paths should fail unless ``overwrite=True``."""
+
+    bundle_path, model_log = _save_bundle(tmp_path)
+
+    with pytest.raises(TorchLensIOError) as excinfo:
+        save(model_log, bundle_path)
+
+    assert isinstance(excinfo.value.__cause__, FileExistsError)
+
+
+def test_bundle_save_overwrite_true_replaces_existing_bundle(tmp_path: Path) -> None:
+    """Overwrite mode should atomically replace an existing bundle."""
+
+    bundle_path, first_log = _save_bundle(tmp_path, seed=0)
+    second_log = _build_conv_log(seed=1)
+
+    save(second_log, bundle_path, overwrite=True)
+    restored = load(bundle_path)
+
+    first_output = first_log.layer_list[-1].activation
+    second_output = second_log.layer_list[-1].activation
+    restored_output = restored.layer_list[-1].activation
+
+    assert isinstance(first_output, torch.Tensor)
+    assert isinstance(second_output, torch.Tensor)
+    assert isinstance(restored_output, torch.Tensor)
+    assert not torch.equal(first_output, second_output)
+    assert torch.equal(second_output, restored_output)
+
+
+def test_bundle_save_rejects_symlink_target(tmp_path: Path) -> None:
+    """Bundle save should refuse symlinked target paths."""
+
+    model_log = _build_conv_log()
+    real_path = tmp_path / "real_bundle"
+    real_path.mkdir()
+    symlink_path = tmp_path / "bundle_link"
+    symlink_path.symlink_to(real_path, target_is_directory=True)
+
+    with pytest.raises(TorchLensIOError, match="symlinked save target"):
+        save(model_log, symlink_path)
+
+
+def test_bundle_loaded_log_validation_guard_raises(tmp_path: Path) -> None:
+    """Portable-loaded logs should reject replay validation APIs."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    restored = load(bundle_path)
+
+    assert restored._loaded_from_bundle is True
+    with pytest.raises(TorchLensIOError, match="portable bundles drop them"):
+        restored.validate_forward_pass([])
+
+
+def test_bundle_save_rejects_non_tensor_activation_postfunc_output(tmp_path: Path) -> None:
+    """Save should fail before writing blobs when activation_postfunc returned a non-tensor."""
+
+    model_log = _build_non_tensor_activation_log()
+    bundle_path = tmp_path / "non_tensor_bundle.tl"
+
+    with pytest.raises(TorchLensIOError, match="activation_postfunc outputs"):
+        save(model_log, bundle_path)
+
+    assert not bundle_path.exists()
+
+
+def test_cleanup_tmp_removes_partial_temp_directories(tmp_path: Path) -> None:
+    """``cleanup_tmp`` should remove sibling temp dirs marked as partial."""
+
+    target_path = tmp_path / "bundle.tl"
+    partial_tmp_path = tmp_path / f"{target_path.name}.tmp.partial"
+    partial_tmp_path.mkdir()
+    (partial_tmp_path / "PARTIAL").write_text("", encoding="utf-8")
+
+    removed = cleanup_tmp(target_path)
+
+    assert removed == [partial_tmp_path]
+    assert not partial_tmp_path.exists()
+
+
+def _torch_minor_mismatch_version() -> str:
+    """Return a torch version string with the same major and different minor.
+
+    Returns
+    -------
+    str
+        Version string suitable for the minor-mismatch policy test.
+    """
+
+    version_parts = torch.__version__.split("+", maxsplit=1)[0].split(".")
+    major = int(version_parts[0])
+    minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+    patch = int(version_parts[2]) if len(version_parts) > 2 and version_parts[2].isdigit() else 0
+    return f"{major}.{minor + 1}.{patch}"

--- a/tests/test_io_corruption.py
+++ b/tests/test_io_corruption.py
@@ -1,0 +1,256 @@
+"""Corruption-path regression tests for portable TorchLens bundles."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+from torchlens import load, log_forward_pass, save
+from torchlens._io import TorchLensIOError
+from torchlens._io.manifest import sha256_of_file
+from torchlens.data_classes.model_log import ModelLog
+
+
+class _CorruptionModel(nn.Module):
+    """Small model used to create deterministic corruption fixtures."""
+
+    def __init__(self) -> None:
+        """Initialize the corruption test model."""
+
+        super().__init__()
+        self.linear1 = nn.Linear(4, 6)
+        self.linear2 = nn.Linear(6, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the corruption test model.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        return self.linear2(torch.relu(self.linear1(x)))
+
+
+def _save_bundle(tmp_path: Path, path_name: str = "bundle.tl") -> Path:
+    """Create a deterministic portable bundle for corruption tests.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary test directory.
+    path_name:
+        Bundle directory name.
+
+    Returns
+    -------
+    Path
+        Saved bundle path.
+    """
+
+    torch.manual_seed(0)
+    model = _CorruptionModel()
+    inputs = torch.randn(2, 4)
+    model_log = log_forward_pass(model, inputs, layers_to_save="all", random_seed=0)
+    bundle_path = tmp_path / path_name
+    save(model_log, bundle_path)
+    return bundle_path
+
+
+def _read_manifest(bundle_path: Path) -> dict[str, Any]:
+    """Read one bundle manifest into a mutable dictionary.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+
+    Returns
+    -------
+    dict[str, Any]
+        Decoded manifest JSON.
+    """
+
+    with (bundle_path / "manifest.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _write_manifest(bundle_path: Path, manifest: dict[str, Any]) -> None:
+    """Overwrite one bundle manifest with JSON content.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+    manifest:
+        JSON-ready manifest content.
+    """
+
+    with (bundle_path / "manifest.json").open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+
+def _first_tensor_entry(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Return the first tensor entry from a decoded manifest.
+
+    Parameters
+    ----------
+    manifest:
+        Decoded manifest mapping.
+
+    Returns
+    -------
+    dict[str, Any]
+        First tensor entry.
+    """
+
+    tensors = manifest["tensors"]
+    assert isinstance(tensors, list)
+    return tensors[0]
+
+
+def _first_saved_layer(model_log: ModelLog) -> Any:
+    """Return the first saved layer from one model log.
+
+    Parameters
+    ----------
+    model_log:
+        Model log under test.
+
+    Returns
+    -------
+    Any
+        First saved layer-pass entry.
+    """
+
+    return next(layer for layer in model_log.layer_list if layer.has_saved_activations)
+
+
+def test_truncated_safetensors_blob_raises_with_blob_path(tmp_path: Path) -> None:
+    """Truncated safetensors payloads should fail materialization with the blob path."""
+
+    bundle_path = _save_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    tensor_entry = _first_tensor_entry(manifest)
+    blob_path = bundle_path / tensor_entry["relative_path"]
+    original_bytes = blob_path.read_bytes()
+    blob_path.write_bytes(original_bytes[: len(original_bytes) // 2])
+    tensor_entry["sha256"] = sha256_of_file(blob_path)
+    _write_manifest(bundle_path, manifest)
+
+    lazy_log = load(bundle_path, lazy=True)
+    layer = _first_saved_layer(lazy_log)
+
+    with pytest.raises(
+        TorchLensIOError,
+        match=rf"Failed to materialize blob at {re.escape(str(blob_path))}\.",
+    ):
+        layer.materialize_activation()
+
+
+def test_missing_blob_file_raises_with_blob_id(tmp_path: Path) -> None:
+    """Missing blobs should fail eager load with the missing blob id."""
+
+    bundle_path = _save_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    tensor_entry = _first_tensor_entry(manifest)
+    blob_path = bundle_path / tensor_entry["relative_path"]
+    blob_path.unlink()
+
+    with pytest.raises(
+        TorchLensIOError,
+        match=rf"missing blob files for blob_id\(s\): {re.escape(tensor_entry['blob_id'])}",
+    ):
+        load(bundle_path)
+
+
+def test_corrupt_metadata_pickle_raises_with_metadata_path(tmp_path: Path) -> None:
+    """Garbage metadata should fail load with the metadata file path."""
+
+    bundle_path = _save_bundle(tmp_path)
+    metadata_path = bundle_path / "metadata.pkl"
+    metadata_path.write_bytes(b"not a pickle")
+
+    with pytest.raises(
+        TorchLensIOError,
+        match=rf"Failed to load bundle metadata from {re.escape(str(metadata_path))}\.",
+    ):
+        load(bundle_path)
+
+
+def test_tampered_manifest_field_raises_with_field_name(tmp_path: Path) -> None:
+    """Tampered manifest tensor metadata should fail load with the offending field."""
+
+    bundle_path = _save_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    tensor_entry = _first_tensor_entry(manifest)
+    tensor_entry["dtype"] = "totally_fake_dtype"
+    _write_manifest(bundle_path, manifest)
+
+    with pytest.raises(TorchLensIOError, match=r"Unsupported dtype string in manifest"):
+        load(bundle_path, lazy=True)
+
+
+def test_stale_blob_counts_raise_with_count_field(tmp_path: Path) -> None:
+    """Manifest blob-count drift should fail with the mismatched count field name."""
+
+    bundle_path = _save_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    manifest["n_activation_blobs"] += 1
+    _write_manifest(bundle_path, manifest)
+
+    with pytest.raises(TorchLensIOError, match=r"n_activation_blobs"):
+        load(bundle_path)
+
+
+def test_unknown_extra_files_warn_but_do_not_raise(tmp_path: Path) -> None:
+    """Unreferenced files under ``blobs/`` should warn without aborting load."""
+
+    bundle_path = _save_bundle(tmp_path)
+    extra_blob_path = bundle_path / "blobs" / "unexpected.bin"
+    extra_blob_path.write_bytes(b"extra")
+
+    with pytest.warns(
+        UserWarning,
+        match=rf"unreferenced extra files in blobs/: {re.escape(extra_blob_path.name)}",
+    ):
+        restored = load(bundle_path, lazy=True)
+
+    assert isinstance(restored, ModelLog)
+    assert restored._loaded_from_bundle is True
+
+
+def test_checksum_mismatch_raises_with_blob_id_and_path(tmp_path: Path) -> None:
+    """Checksum mismatches should fail eager load with blob id and path details."""
+
+    bundle_path = _save_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    tensor_entry = _first_tensor_entry(manifest)
+    blob_path = bundle_path / tensor_entry["relative_path"]
+    blob_bytes = bytearray(blob_path.read_bytes())
+    blob_bytes[-1] = (blob_bytes[-1] + 1) % 256
+    blob_path.write_bytes(bytes(blob_bytes))
+
+    with pytest.raises(
+        TorchLensIOError,
+        match=(
+            rf"Checksum mismatch for blob_id={re.escape(tensor_entry['blob_id'])} at "
+            rf"{re.escape(str(blob_path))}\."
+        ),
+    ):
+        load(bundle_path)

--- a/tests/test_io_export.py
+++ b/tests/test_io_export.py
@@ -1,0 +1,322 @@
+"""Tests for IO-S3 export wrappers across all DataFrame-producing surfaces."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+import torch
+import torch.nn as nn
+
+from torchlens import log_forward_pass
+
+PARQUET_IMPORT_ERROR = "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
+
+SURFACE_COLUMNS: dict[str, list[str]] = {
+    "model_log": [
+        "layer_label",
+        "layer_type",
+        "pass_num",
+        "func_name",
+        "is_input_layer",
+        "is_output_layer",
+    ],
+    "layers": [
+        "layer_label",
+        "layer_type",
+        "func_name",
+        "num_passes",
+        "is_input_layer",
+        "is_output_layer",
+    ],
+    "modules": [
+        "address",
+        "module_class_name",
+        "nesting_depth",
+        "num_params",
+        "num_layers",
+        "num_passes",
+    ],
+    "module_log": [
+        "layer_label",
+        "layer_type",
+        "pass_num",
+        "func_name",
+    ],
+    "module_pass": [
+        "module_address",
+        "pass_num",
+        "pass_label",
+        "num_layers",
+        "forward_args_summary",
+        "forward_kwargs_summary",
+    ],
+    "params": [
+        "address",
+        "name",
+        "num_params",
+        "trainable",
+        "module_address",
+    ],
+    "buffers": [
+        "buffer_address",
+        "name",
+        "pass_num",
+        "has_saved_activations",
+    ],
+}
+
+
+class _ExportBlock(nn.Module):
+    """Submodule used to exercise module-pass export summaries."""
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        payload: list[Any],
+        config: dict[str, Any],
+        *,
+        flag: bool,
+        note: str,
+        optional: dict[str, Any],
+    ) -> torch.Tensor:
+        """Apply a small transform using mixed-typed call arguments.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+        payload:
+            Mixed positional payload.
+        config:
+            Mixed positional configuration.
+        flag:
+            Boolean keyword switch.
+        note:
+            String keyword metadata.
+        optional:
+            Nested keyword payload.
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed tensor.
+        """
+        del note, optional
+        if payload[0]:
+            x = x + config["bias"]
+        if flag:
+            x = x * config["scale"]
+        return x
+
+
+class _IoExportModel(nn.Module):
+    """Small model covering all seven tabular export surfaces."""
+
+    def __init__(self) -> None:
+        """Initialize the module graph used by the export tests."""
+        super().__init__()
+        self.block = _ExportBlock()
+        self.proj = nn.Linear(2, 2)
+        self.register_buffer("offset", torch.tensor([0.5, -0.5], dtype=torch.float32))
+
+    def build_block_inputs(
+        self, x: torch.Tensor
+    ) -> tuple[list[Any], dict[str, Any], dict[str, Any]]:
+        """Construct the exact args passed into ``self.block``.
+
+        Parameters
+        ----------
+        x:
+            Input tensor for the current forward pass.
+
+        Returns
+        -------
+        tuple[list[Any], dict[str, Any], dict[str, Any]]
+            Positional payload, positional config, and keyword args.
+        """
+        payload = [True, 7, 2.5, "tag", self.offset]
+        config = {
+            "scale": 2.0,
+            "bias": self.offset,
+            "nested": [None, {"inner": x}],
+        }
+        kwargs = {
+            "flag": False,
+            "note": "hello",
+            "optional": {"path": [1, self.offset]},
+        }
+        return payload, config, kwargs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the summary block followed by a linear projection.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+        payload, config, kwargs = self.build_block_inputs(x)
+        x = self.block(x, payload, config, **kwargs)
+        return self.proj(x)
+
+
+@pytest.fixture
+def io_export_log() -> Any:
+    """Build a real ModelLog covering every DataFrame export surface.
+
+    Returns
+    -------
+    Any
+        Logged forward-pass result.
+    """
+    torch.manual_seed(0)
+    model = _IoExportModel()
+    x = torch.randn(2, 2)
+    return log_forward_pass(model, x)
+
+
+def _get_surface(log: Any, surface_name: str) -> Any:
+    """Resolve one named export surface from the logged model.
+
+    Parameters
+    ----------
+    log:
+        Logged model output under test.
+    surface_name:
+        Export surface selector.
+
+    Returns
+    -------
+    Any
+        Surface exposing ``to_pandas()``, ``to_csv()``, ``to_json()``, and ``to_parquet()``.
+    """
+    if surface_name == "model_log":
+        return log
+    if surface_name == "layers":
+        return log.layers
+    if surface_name == "modules":
+        return log.modules
+    if surface_name == "module_log":
+        return log.modules["block"]
+    if surface_name == "module_pass":
+        return log.modules["block:1"]
+    if surface_name == "params":
+        return log.params
+    return log.buffers
+
+
+def _assert_round_trip_matches(
+    expected_df: pd.DataFrame, actual_df: pd.DataFrame, columns: list[str]
+) -> None:
+    """Assert that a selected set of export columns survives a file round-trip.
+
+    Parameters
+    ----------
+    expected_df:
+        Original DataFrame produced by the export surface.
+    actual_df:
+        DataFrame loaded back from disk.
+    columns:
+        Stable columns that should match after serialization.
+    """
+    assert list(actual_df.columns) == list(expected_df.columns)
+    expected_subset = expected_df.loc[:, columns].astype(object)
+    actual_subset = actual_df.loc[:, columns].astype(object)
+    expected_subset = expected_subset.where(pd.notna(expected_subset), "<NA>").astype(str)
+    actual_subset = actual_subset.where(pd.notna(actual_subset), "<NA>").astype(str)
+    pd.testing.assert_frame_equal(
+        expected_subset.reset_index(drop=True),
+        actual_subset.reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize("surface_name", list(SURFACE_COLUMNS))
+def test_tabular_exports_round_trip_csv_and_json(
+    io_export_log: Any, surface_name: str, tmp_path: Path
+) -> None:
+    """CSV and JSON exports should preserve schema and stable values.
+
+    Parameters
+    ----------
+    io_export_log:
+        Logged model fixture.
+    surface_name:
+        Export surface selector.
+    tmp_path:
+        Temporary output directory.
+    """
+    surface = _get_surface(io_export_log, surface_name)
+    expected_df = surface.to_pandas()
+    stable_columns = SURFACE_COLUMNS[surface_name]
+
+    csv_path = tmp_path / f"{surface_name}.csv"
+    surface.to_csv(csv_path)
+    csv_df = pd.read_csv(csv_path)
+    _assert_round_trip_matches(expected_df, csv_df, stable_columns)
+
+    json_path = tmp_path / f"{surface_name}.json"
+    surface.to_json(json_path, orient="records")
+    json_df = pd.read_json(json_path, orient="records")
+    _assert_round_trip_matches(expected_df, json_df, stable_columns)
+
+
+@pytest.mark.parametrize("surface_name", list(SURFACE_COLUMNS))
+def test_tabular_exports_round_trip_parquet(
+    io_export_log: Any, surface_name: str, tmp_path: Path
+) -> None:
+    """Parquet exports should preserve schema and stable values when pyarrow exists.
+
+    Parameters
+    ----------
+    io_export_log:
+        Logged model fixture.
+    surface_name:
+        Export surface selector.
+    tmp_path:
+        Temporary output directory.
+    """
+    pytest.importorskip("pyarrow")
+
+    surface = _get_surface(io_export_log, surface_name)
+    expected_df = surface.to_pandas()
+    stable_columns = SURFACE_COLUMNS[surface_name]
+
+    parquet_path = tmp_path / f"{surface_name}.parquet"
+    surface.to_parquet(parquet_path)
+    parquet_df = pd.read_parquet(parquet_path)
+    _assert_round_trip_matches(expected_df, parquet_df, stable_columns)
+
+
+@pytest.mark.parametrize("surface_name", list(SURFACE_COLUMNS))
+def test_to_parquet_requires_pyarrow_when_missing(
+    io_export_log: Any, surface_name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All parquet wrappers should raise the shared install-hint message without pyarrow.
+
+    Parameters
+    ----------
+    io_export_log:
+        Logged model fixture.
+    surface_name:
+        Export surface selector.
+    tmp_path:
+        Temporary output directory.
+    monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    surface = _get_surface(io_export_log, surface_name)
+    monkeypatch.setitem(sys.modules, "pyarrow", None)
+
+    with pytest.raises(ImportError, match=re.escape(PARQUET_IMPORT_ERROR)):
+        surface.to_parquet(tmp_path / f"{surface_name}.parquet")

--- a/tests/test_io_integration.py
+++ b/tests/test_io_integration.py
@@ -1,0 +1,273 @@
+"""Integration tests for the TorchLens portable I/O flow."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+from torchlens import load, log_forward_pass, rehydrate_nested, save
+from torchlens._io import BlobRef
+from torchlens.data_classes.model_log import ModelLog
+
+PYARROW_AVAILABLE = importlib.util.find_spec("pyarrow") is not None
+
+
+class _IntegrationConvModel(nn.Module):
+    """Small convolutional model used for end-to-end I/O tests."""
+
+    def __init__(self) -> None:
+        """Initialize the integration test model."""
+
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 4, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(4, 4, kernel_size=3, padding=1)
+        self.conv3 = nn.Conv2d(4, 2, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the integration test model.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        x = torch.relu(self.conv1(x))
+        x = torch.relu(self.conv2(x))
+        return self.conv3(x)
+
+
+def _build_conv_inputs(seed: int = 0) -> tuple[_IntegrationConvModel, torch.Tensor]:
+    """Build a deterministic model/input pair for integration tests.
+
+    Parameters
+    ----------
+    seed:
+        Random seed used for model initialization and input generation.
+
+    Returns
+    -------
+    tuple[_IntegrationConvModel, torch.Tensor]
+        Fresh model and input tensor.
+    """
+
+    torch.manual_seed(seed)
+    return _IntegrationConvModel(), torch.randn(1, 3, 8, 8)
+
+
+def _saved_layers(model_log: ModelLog) -> list[Any]:
+    """Return the saved layer-pass entries from one model log.
+
+    Parameters
+    ----------
+    model_log:
+        Model log under test.
+
+    Returns
+    -------
+    list[Any]
+        Saved layer-pass entries in log order.
+    """
+
+    return [layer for layer in model_log.layer_list if layer.has_saved_activations]
+
+
+def _first_saved_layer(model_log: ModelLog) -> Any:
+    """Return the first saved layer from one model log.
+
+    Parameters
+    ----------
+    model_log:
+        Model log under test.
+
+    Returns
+    -------
+    Any
+        First saved layer-pass entry.
+    """
+
+    return next(layer for layer in model_log.layer_list if layer.has_saved_activations)
+
+
+def _contains_blob_ref(value: Any) -> bool:
+    """Return whether a nested value contains any ``BlobRef`` entries.
+
+    Parameters
+    ----------
+    value:
+        Nested value to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` when any descendant is a ``BlobRef``.
+    """
+
+    if isinstance(value, BlobRef):
+        return True
+    if isinstance(value, list):
+        return any(_contains_blob_ref(item) for item in value)
+    if isinstance(value, tuple):
+        return any(_contains_blob_ref(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_blob_ref(item) for item in value.values())
+    if isinstance(value, set):
+        return any(_contains_blob_ref(item) for item in value)
+    return False
+
+
+def test_streaming_lazy_materialize_and_parquet_round_trip(tmp_path: Path) -> None:
+    """Streaming save should compose with lazy load, materialize, and parquet export."""
+
+    if not PYARROW_AVAILABLE:
+        pytest.skip("pyarrow is required for parquet round-trip coverage")
+
+    bundle_path = tmp_path / "streamed_bundle.tl"
+    model, inputs = _build_conv_inputs()
+
+    streamed_log = log_forward_pass(
+        model,
+        inputs,
+        layers_to_save="all",
+        save_activations_to=bundle_path,
+        random_seed=0,
+    )
+    assert (bundle_path / "manifest.json").exists()
+    assert (bundle_path / "metadata.pkl").exists()
+    assert sorted((bundle_path / "blobs").glob("*.safetensors"))
+
+    lazy_log = load(bundle_path, lazy=True)
+    saved_layers = _saved_layers(lazy_log)
+    assert saved_layers
+
+    for layer in saved_layers[:3]:
+        tensor = layer.materialize_activation()
+        assert isinstance(tensor, torch.Tensor)
+        assert layer.activation_ref is not None
+
+    parquet_path = tmp_path / "streamed_layers.parquet"
+    lazy_log.to_parquet(parquet_path)
+    parquet_df = pd.read_parquet(parquet_path)
+    exported_df = lazy_log.to_pandas()
+
+    assert len(streamed_log.layer_list) == len(lazy_log.layer_list)
+    assert len(parquet_df) == len(exported_df)
+    assert parquet_df["layer_label"].tolist() == exported_df["layer_label"].tolist()
+    assert parquet_df["layer_type"].tolist() == exported_df["layer_type"].tolist()
+    assert parquet_df["pass_num"].tolist() == exported_df["pass_num"].tolist()
+
+
+def test_post_hoc_save_lazy_rehydrate_nested_and_resave(tmp_path: Path) -> None:
+    """Post-hoc bundle save should support lazy nested rehydration and resave."""
+
+    source_path = tmp_path / "post_hoc_bundle.tl"
+    resaved_path = tmp_path / "resaved_bundle.tl"
+    model, inputs = _build_conv_inputs()
+    live_log = log_forward_pass(
+        model,
+        inputs,
+        layers_to_save="all",
+        save_function_args=True,
+        random_seed=0,
+    )
+
+    save(live_log, source_path, include_captured_args=True)
+    lazy_log = load(source_path, lazy=True, materialize_nested=False)
+
+    nested_blob_layer = next(
+        layer
+        for layer in lazy_log.layer_list
+        if layer.captured_args is not None and _contains_blob_ref(layer.captured_args)
+    )
+    assert nested_blob_layer.activation_ref is not None
+    assert _contains_blob_ref(nested_blob_layer.captured_args)
+
+    rehydrate_nested(lazy_log)
+
+    assert not _contains_blob_ref(nested_blob_layer.captured_args)
+    save(lazy_log, resaved_path, include_captured_args=True)
+    restored = load(resaved_path, lazy=False)
+
+    live_layer = _first_saved_layer(live_log)
+    restored_layer = _first_saved_layer(restored)
+    assert isinstance(live_layer.activation, torch.Tensor)
+    assert isinstance(restored_layer.activation, torch.Tensor)
+    assert torch.equal(restored_layer.activation, live_layer.activation)
+    assert restored.model_name == live_log.model_name
+    assert len(restored.layer_list) == len(live_log.layer_list)
+    assert any(
+        layer.captured_args is not None
+        and any(isinstance(arg, torch.Tensor) for arg in layer.captured_args)
+        for layer in restored.layer_list
+    )
+
+
+def test_streaming_keep_activations_in_memory_false_materializes_from_refs(
+    tmp_path: Path,
+) -> None:
+    """Streaming eviction mode should leave only refs until materialization."""
+
+    bundle_path = tmp_path / "stream_evict.tl"
+    model, inputs = _build_conv_inputs()
+    streamed_log = log_forward_pass(
+        model,
+        inputs,
+        layers_to_save="all",
+        save_activations_to=bundle_path,
+        keep_activations_in_memory=False,
+        random_seed=0,
+    )
+    eager_log = load(bundle_path, lazy=False)
+
+    streamed_layer = _first_saved_layer(streamed_log)
+    eager_layer = _first_saved_layer(eager_log)
+
+    assert streamed_layer.activation is None
+    assert streamed_layer.activation_ref is not None
+    tensor = streamed_layer.materialize_activation()
+
+    assert isinstance(tensor, torch.Tensor)
+    assert isinstance(eager_layer.activation, torch.Tensor)
+    assert torch.equal(tensor, eager_layer.activation)
+
+
+def test_streaming_keep_activations_in_memory_true_keeps_tensor_and_ref(tmp_path: Path) -> None:
+    """Streaming keep-in-memory mode should retain both tensors and lazy refs."""
+
+    bundle_path = tmp_path / "stream_keep.tl"
+    model, inputs = _build_conv_inputs()
+    streamed_log = log_forward_pass(
+        model,
+        inputs,
+        layers_to_save="all",
+        save_activations_to=bundle_path,
+        keep_activations_in_memory=True,
+        random_seed=0,
+    )
+
+    saved_layers = _saved_layers(streamed_log)
+    assert saved_layers
+    for layer in saved_layers:
+        assert isinstance(layer.activation, torch.Tensor)
+        assert layer.activation_ref is not None
+
+
+def test_data_parallel_and_ddp_streaming_case_is_explicitly_skipped() -> None:
+    """TorchLens streaming coverage intentionally skips parallel-process wrappers."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    pytest.skip("torchlens is single-process; DataParallel/DDP streaming coverage is skipped")

--- a/tests/test_io_lazy.py
+++ b/tests/test_io_lazy.py
@@ -49,6 +49,7 @@ def _build_log(
     *,
     seed: int = 0,
     save_function_args: bool = False,
+    save_rng_states: bool = False,
 ) -> ModelLog:
     """Build a deterministic ``ModelLog`` for lazy I/O tests.
 
@@ -58,6 +59,8 @@ def _build_log(
         Random seed used for model initialization and inputs.
     save_function_args:
         Whether function arguments should be captured in the log.
+    save_rng_states:
+        Whether RNG state tensors should be captured in the log.
 
     Returns
     -------
@@ -73,6 +76,7 @@ def _build_log(
         inputs,
         layers_to_save="all",
         save_function_args=save_function_args,
+        save_rng_states=save_rng_states,
         random_seed=seed,
     )
 
@@ -82,7 +86,9 @@ def _save_bundle(
     *,
     seed: int = 0,
     save_function_args: bool = False,
+    save_rng_states: bool = False,
     include_captured_args: bool = False,
+    include_rng_states: bool = False,
     path_name: str = "bundle.tl",
 ) -> tuple[Path, ModelLog]:
     """Save a deterministic bundle and return the path plus source log.
@@ -95,8 +101,12 @@ def _save_bundle(
         Random seed used for model initialization and inputs.
     save_function_args:
         Whether function arguments should be captured in the source log.
+    save_rng_states:
+        Whether RNG state tensors should be captured in the source log.
     include_captured_args:
         Whether nested captured args should be persisted in the bundle.
+    include_rng_states:
+        Whether nested RNG-state tensors should be persisted in the bundle.
     path_name:
         Bundle directory name.
 
@@ -106,9 +116,18 @@ def _save_bundle(
         Saved bundle path and the original live log.
     """
 
-    model_log = _build_log(seed=seed, save_function_args=save_function_args)
+    model_log = _build_log(
+        seed=seed,
+        save_function_args=save_function_args,
+        save_rng_states=save_rng_states,
+    )
     bundle_path = tmp_path / path_name
-    save(model_log, bundle_path, include_captured_args=include_captured_args)
+    save(
+        model_log,
+        bundle_path,
+        include_captured_args=include_captured_args,
+        include_rng_states=include_rng_states,
+    )
     return bundle_path, model_log
 
 
@@ -347,6 +366,33 @@ def test_save_rejects_unmaterialized_nested_blob_refs(tmp_path: Path) -> None:
         match="Call torchlens.rehydrate_nested\\(model_log\\) before saving",
     ):
         save(lazy_log, tmp_path / "resaved.tl", include_captured_args=True)
+
+
+def test_save_drops_unmaterialized_nested_blob_refs_when_fields_are_excluded(
+    tmp_path: Path,
+) -> None:
+    """Excluded nested BlobRef fields should not block a portable resave."""
+
+    bundle_path, _ = _save_bundle(
+        tmp_path,
+        save_function_args=True,
+        save_rng_states=True,
+        include_captured_args=True,
+        include_rng_states=True,
+        path_name="captured_args_and_rng.tl",
+    )
+    lazy_log = load(bundle_path, lazy=True, materialize_nested=False)
+    resaved_path = tmp_path / "resaved_without_nested_fields.tl"
+
+    save(
+        lazy_log,
+        resaved_path,
+        include_captured_args=False,
+        include_rng_states=False,
+    )
+    restored = load(resaved_path, lazy=False)
+
+    assert restored.model_name == lazy_log.model_name
 
 
 @pytest.mark.parametrize("lazy", [False, True])

--- a/tests/test_io_lazy.py
+++ b/tests/test_io_lazy.py
@@ -1,0 +1,388 @@
+"""Tests for lazy activation refs, drift checks, and nested rehydration."""
+
+from __future__ import annotations
+
+import gc
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+from torchlens import load, log_forward_pass, rehydrate_nested, save
+from torchlens._io import BlobRef, TorchLensIOError
+from torchlens.data_classes.model_log import ModelLog
+
+
+class _LazyIOModel(nn.Module):
+    """Small deterministic model used for lazy I/O tests."""
+
+    def __init__(self) -> None:
+        """Initialize the model under test."""
+
+        super().__init__()
+        self.linear1 = nn.Linear(4, 6)
+        self.linear2 = nn.Linear(6, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model under test.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        return self.linear2(torch.relu(self.linear1(x)))
+
+
+def _build_log(
+    *,
+    seed: int = 0,
+    save_function_args: bool = False,
+) -> ModelLog:
+    """Build a deterministic ``ModelLog`` for lazy I/O tests.
+
+    Parameters
+    ----------
+    seed:
+        Random seed used for model initialization and inputs.
+    save_function_args:
+        Whether function arguments should be captured in the log.
+
+    Returns
+    -------
+    ModelLog
+        Logged forward pass with all activations saved.
+    """
+
+    torch.manual_seed(seed)
+    model = _LazyIOModel()
+    inputs = torch.randn(2, 4)
+    return log_forward_pass(
+        model,
+        inputs,
+        layers_to_save="all",
+        save_function_args=save_function_args,
+        random_seed=seed,
+    )
+
+
+def _save_bundle(
+    tmp_path: Path,
+    *,
+    seed: int = 0,
+    save_function_args: bool = False,
+    include_captured_args: bool = False,
+    path_name: str = "bundle.tl",
+) -> tuple[Path, ModelLog]:
+    """Save a deterministic bundle and return the path plus source log.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary test directory.
+    seed:
+        Random seed used for model initialization and inputs.
+    save_function_args:
+        Whether function arguments should be captured in the source log.
+    include_captured_args:
+        Whether nested captured args should be persisted in the bundle.
+    path_name:
+        Bundle directory name.
+
+    Returns
+    -------
+    tuple[Path, ModelLog]
+        Saved bundle path and the original live log.
+    """
+
+    model_log = _build_log(seed=seed, save_function_args=save_function_args)
+    bundle_path = tmp_path / path_name
+    save(model_log, bundle_path, include_captured_args=include_captured_args)
+    return bundle_path, model_log
+
+
+def _first_saved_layer(model_log: ModelLog) -> Any:
+    """Return the first saved layer entry from a model log.
+
+    Parameters
+    ----------
+    model_log:
+        Model log under test.
+
+    Returns
+    -------
+    Any
+        First saved layer-pass entry.
+    """
+
+    return next(layer for layer in model_log.layer_list if layer.has_saved_activations)
+
+
+def _read_manifest(bundle_path: Path) -> dict[str, Any]:
+    """Read one bundle manifest into a mutable dict.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+
+    Returns
+    -------
+    dict[str, Any]
+        Decoded manifest JSON.
+    """
+
+    with (bundle_path / "manifest.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _write_manifest(bundle_path: Path, manifest: dict[str, Any]) -> None:
+    """Overwrite one bundle manifest with JSON content.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+    manifest:
+        JSON-ready manifest content.
+    """
+
+    with (bundle_path / "manifest.json").open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+
+def _corrupt_one_blob(bundle_path: Path) -> None:
+    """Modify one persisted blob byte in place.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+    """
+
+    blob_path = next((bundle_path / "blobs").glob("*.safetensors"))
+    blob_bytes = bytearray(blob_path.read_bytes())
+    blob_bytes[-1] = (blob_bytes[-1] + 1) % 256
+    blob_path.write_bytes(bytes(blob_bytes))
+
+
+def _contains_blob_ref(value: Any) -> bool:
+    """Return whether a nested value contains any ``BlobRef`` instances.
+
+    Parameters
+    ----------
+    value:
+        Nested value to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` when any descendant is a ``BlobRef``.
+    """
+
+    if isinstance(value, BlobRef):
+        return True
+    if isinstance(value, list):
+        return any(_contains_blob_ref(item) for item in value)
+    if isinstance(value, tuple):
+        return any(_contains_blob_ref(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_blob_ref(item) for item in value.values())
+    if isinstance(value, set):
+        return any(_contains_blob_ref(item) for item in value)
+    return False
+
+
+def test_lazy_ref_metadata_access_does_not_materialize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lazy ref metadata should be readable without touching the filesystem."""
+
+    bundle_path, live_log = _save_bundle(tmp_path)
+    restored = load(bundle_path, lazy=True)
+    layer = _first_saved_layer(restored)
+    live_layer = _first_saved_layer(live_log)
+    ref = layer.activation_ref
+
+    assert ref is not None
+    assert isinstance(live_layer.activation, torch.Tensor)
+
+    def _fail(*_: Any, **__: Any) -> Any:
+        raise AssertionError("filesystem access should not occur")
+
+    monkeypatch.setattr("torchlens._io.lazy.sha256_of_file", _fail)
+    monkeypatch.setattr("torchlens._io.lazy.load_file", _fail)
+
+    assert ref.shape == tuple(layer.tensor_shape)
+    assert ref.dtype == layer.tensor_dtype
+    assert ref.device_at_save == str(live_layer.activation.device)
+
+
+def test_lazy_materialize_matches_eager_load_bit_exactly(tmp_path: Path) -> None:
+    """Lazy materialization should match the eager-loaded tensor exactly."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    eager_log = load(bundle_path, lazy=False)
+    lazy_log = load(bundle_path, lazy=True)
+
+    eager_layer = _first_saved_layer(eager_log)
+    lazy_layer = _first_saved_layer(lazy_log)
+
+    eager_tensor = eager_layer.activation
+    assert isinstance(eager_tensor, torch.Tensor)
+    lazy_tensor = lazy_layer.materialize_activation()
+
+    assert torch.equal(lazy_tensor, eager_tensor)
+
+
+def test_lazy_materialize_honors_cuda_map_location(tmp_path: Path) -> None:
+    """Lazy materialization should respect ``map_location='cuda'`` when available."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    lazy_log = load(bundle_path, lazy=True)
+    layer = _first_saved_layer(lazy_log)
+
+    tensor = layer.materialize_activation(map_location="cuda")
+
+    assert tensor.device.type == "cuda"
+
+
+def test_lazy_resave_detects_manifest_level_drift(tmp_path: Path) -> None:
+    """Resaving a lazy-loaded log should fail if the source manifest changed."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    lazy_log = load(bundle_path, lazy=True)
+    manifest = _read_manifest(bundle_path)
+    manifest["created_at"] = "2099-01-01T00:00:00Z"
+    _write_manifest(bundle_path, manifest)
+
+    with pytest.raises(TorchLensIOError, match="source bundle manifest has changed since load"):
+        save(lazy_log, tmp_path / "resaved.tl")
+
+
+def test_lazy_resave_detects_blob_level_drift(tmp_path: Path) -> None:
+    """Resaving a lazy-loaded log should fail if a source blob was tampered with."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    lazy_log = load(bundle_path, lazy=True)
+    _corrupt_one_blob(bundle_path)
+
+    with pytest.raises(TorchLensIOError, match="sha256 mismatch"):
+        save(lazy_log, tmp_path / "resaved.tl")
+
+
+def test_lazy_resave_fast_copy_produces_valid_bundle(tmp_path: Path) -> None:
+    """Clean-source lazy resave should fast-copy blobs into a new valid bundle."""
+
+    bundle_path, live_log = _save_bundle(tmp_path)
+    lazy_log = load(bundle_path, lazy=True)
+    resaved_path = tmp_path / "resaved.tl"
+
+    save(lazy_log, resaved_path)
+    restored = load(resaved_path, lazy=False)
+
+    live_tensor = _first_saved_layer(live_log).activation
+    restored_tensor = _first_saved_layer(restored).activation
+
+    assert isinstance(live_tensor, torch.Tensor)
+    assert isinstance(restored_tensor, torch.Tensor)
+    assert torch.equal(restored_tensor, live_tensor)
+
+
+def test_rehydrate_nested_materializes_captured_args_blob_refs(tmp_path: Path) -> None:
+    """``rehydrate_nested`` should replace nested captured-arg refs with tensors."""
+
+    bundle_path, _ = _save_bundle(
+        tmp_path,
+        save_function_args=True,
+        include_captured_args=True,
+        path_name="captured_args.tl",
+    )
+    lazy_log = load(bundle_path, lazy=True, materialize_nested=False)
+    layer = next(
+        layer
+        for layer in lazy_log.layer_list
+        if layer.args_captured
+        and layer.captured_args is not None
+        and _contains_blob_ref(layer.captured_args)
+    )
+
+    assert _contains_blob_ref(layer.captured_args)
+
+    rehydrate_nested(lazy_log)
+
+    assert not _contains_blob_ref(layer.captured_args)
+    assert any(isinstance(arg, torch.Tensor) for arg in layer.captured_args)
+
+
+def test_save_rejects_unmaterialized_nested_blob_refs(tmp_path: Path) -> None:
+    """Fork M: resaving with nested lazy blob refs should fail with guidance."""
+
+    bundle_path, _ = _save_bundle(
+        tmp_path,
+        save_function_args=True,
+        include_captured_args=True,
+        path_name="captured_args.tl",
+    )
+    lazy_log = load(bundle_path, lazy=True, materialize_nested=False)
+
+    with pytest.raises(
+        TorchLensIOError,
+        match="Call torchlens.rehydrate_nested\\(model_log\\) before saving",
+    ):
+        save(lazy_log, tmp_path / "resaved.tl", include_captured_args=True)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize("method_name", ["validate_forward_pass", "validate_saved_activations"])
+def test_portable_loaded_logs_reject_validation_entry_points(
+    tmp_path: Path,
+    lazy: bool,
+    method_name: str,
+) -> None:
+    """Fork L: portable-loaded logs should reject both validation entry points."""
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    restored = load(bundle_path, lazy=lazy)
+    validate_fn = getattr(restored, method_name)
+
+    with pytest.raises(TorchLensIOError, match="portable bundles drop them"):
+        validate_fn([])
+
+
+def test_lazy_materialize_does_not_leak_file_descriptors(tmp_path: Path) -> None:
+    """Repeated materialization should not leave extra file descriptors open."""
+
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.exists():
+        pytest.skip("/proc/self/fd is unavailable on this platform")
+
+    bundle_path, _ = _save_bundle(tmp_path)
+    lazy_log = load(bundle_path, lazy=True)
+    ref = _first_saved_layer(lazy_log).activation_ref
+    assert ref is not None
+
+    before = len(list(fd_dir.iterdir()))
+    for _ in range(20):
+        tensor = ref.materialize()
+        assert isinstance(tensor, torch.Tensor)
+    gc.collect()
+    after = len(list(fd_dir.iterdir()))
+
+    assert after == before

--- a/tests/test_io_pandas.py
+++ b/tests/test_io_pandas.py
@@ -1,0 +1,283 @@
+"""Tests for IO-S2 pandas and file-export surfaces."""
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+import torch
+import torch.nn as nn
+
+from torchlens import log_forward_pass
+from torchlens.constants import (
+    BUFFER_LOG_FIELD_ORDER,
+    MODULE_PASS_LOG_FIELD_ORDER,
+    PARAM_LOG_FIELD_ORDER,
+)
+from torchlens.data_classes._summary import format_call_arg
+from torchlens.data_classes.buffer_log import BufferAccessor
+from torchlens.data_classes.module_log import ModulePassLog
+from torchlens.data_classes.param_log import ParamAccessor
+
+
+class _SummaryBlock(nn.Module):
+    """Submodule used to exercise module-pass argument summaries."""
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        payload: list[Any],
+        config: dict[str, Any],
+        *,
+        flag: bool,
+        note: str,
+        optional: dict[str, Any],
+    ) -> torch.Tensor:
+        """Apply a small transform using mixed-typed call arguments.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+        payload:
+            Mixed positional payload.
+        config:
+            Mixed positional configuration.
+        flag:
+            Boolean keyword switch.
+        note:
+            String keyword metadata.
+        optional:
+            Nested keyword payload.
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed tensor.
+        """
+        scale = config["scale"]
+        bias = config["bias"]
+        if payload[0]:
+            x = x + bias
+        if flag:
+            x = x * scale
+        return x
+
+
+class _IoPandasModel(nn.Module):
+    """Small model with params, buffers, and a submodule call carrying mixed args."""
+
+    def __init__(self) -> None:
+        """Initialize the test module graph."""
+        super().__init__()
+        self.block = _SummaryBlock()
+        self.proj = nn.Linear(2, 2)
+        self.register_buffer("offset", torch.tensor([0.5, -0.5], dtype=torch.float32))
+
+    def build_block_inputs(
+        self, x: torch.Tensor
+    ) -> tuple[list[Any], dict[str, Any], dict[str, Any]]:
+        """Construct the exact args passed into ``self.block``.
+
+        Parameters
+        ----------
+        x:
+            Input tensor for the current forward pass.
+
+        Returns
+        -------
+        tuple[list[Any], dict[str, Any], dict[str, Any]]
+            Positional payload, positional config, and keyword args.
+        """
+        payload = [True, 7, 2.5, "tag", self.offset]
+        config = {
+            "scale": 2.0,
+            "bias": self.offset,
+            "nested": [None, {"inner": x}],
+        }
+        kwargs = {
+            "flag": False,
+            "note": "hello",
+            "optional": {"path": [1, self.offset]},
+        }
+        return payload, config, kwargs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the summary block followed by a linear projection.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+        payload, config, kwargs = self.build_block_inputs(x)
+        x = self.block(x, payload, config, **kwargs)
+        return self.proj(x)
+
+
+@pytest.fixture
+def io_pandas_log() -> tuple[Any, _IoPandasModel, torch.Tensor]:
+    """Build a real ModelLog covering params, buffers, and module-pass summaries.
+
+    Returns
+    -------
+    tuple[Any, _IoPandasModel, torch.Tensor]
+        Logged model output context.
+    """
+    model = _IoPandasModel()
+    x = torch.randn(2, 2)
+    log = log_forward_pass(model, x)
+    return log, model, x
+
+
+@pytest.mark.parametrize(
+    ("accessor", "field_order"),
+    [
+        (ParamAccessor({}), PARAM_LOG_FIELD_ORDER),
+        (BufferAccessor({}), BUFFER_LOG_FIELD_ORDER),
+    ],
+)
+def test_empty_accessors_to_pandas_schema(accessor: Any, field_order: list[str]) -> None:
+    """Empty accessors should still export the correct schema.
+
+    Parameters
+    ----------
+    accessor:
+        Empty accessor under test.
+    field_order:
+        Expected column order.
+    """
+    df = accessor.to_pandas()
+    assert df.empty
+    assert list(df.columns) == field_order
+
+
+def test_param_accessor_to_pandas_schema(
+    io_pandas_log: tuple[Any, _IoPandasModel, torch.Tensor],
+) -> None:
+    """ParamAccessor should export one row per parameter with canonical columns.
+
+    Parameters
+    ----------
+    io_pandas_log:
+        Logged model fixture.
+    """
+    log, _, _ = io_pandas_log
+    df = log.params.to_pandas()
+    assert list(df.columns) == PARAM_LOG_FIELD_ORDER
+    assert len(df) == len(log.params)
+
+
+def test_buffer_accessor_to_pandas_schema(
+    io_pandas_log: tuple[Any, _IoPandasModel, torch.Tensor],
+) -> None:
+    """BufferAccessor should export one row per buffer with canonical columns.
+
+    Parameters
+    ----------
+    io_pandas_log:
+        Logged model fixture.
+    """
+    log, _, _ = io_pandas_log
+    df = log.buffers.to_pandas()
+    assert list(df.columns) == BUFFER_LOG_FIELD_ORDER
+    assert len(df) == len(log.buffers)
+
+
+def test_module_pass_log_to_pandas_schema(
+    io_pandas_log: tuple[Any, _IoPandasModel, torch.Tensor],
+) -> None:
+    """ModulePassLog should export a single canonical row including summaries.
+
+    Parameters
+    ----------
+    io_pandas_log:
+        Logged model fixture.
+    """
+    log, _, _ = io_pandas_log
+    pass_log = log.modules["block:1"]
+    df = pass_log.to_pandas()
+    assert isinstance(pass_log, ModulePassLog)
+    assert list(df.columns) == MODULE_PASS_LOG_FIELD_ORDER
+    assert len(df) == 1
+    assert df.loc[0, "forward_args_summary"]
+    assert df.loc[0, "forward_kwargs_summary"]
+
+
+def test_module_pass_summaries_are_formatted_before_gc(
+    io_pandas_log: tuple[Any, _IoPandasModel, torch.Tensor],
+) -> None:
+    """Module-pass summary strings should survive the forward-arg GC step.
+
+    Parameters
+    ----------
+    io_pandas_log:
+        Logged model fixture.
+    """
+    log, model, x = io_pandas_log
+    payload, config, kwargs = model.build_block_inputs(x)
+    pass_log = log.modules["block:1"]
+
+    expected_args_summary = format_call_arg((x, payload, config))
+    expected_kwargs_summary = format_call_arg(kwargs)
+
+    assert pass_log.forward_args is None
+    assert pass_log.forward_kwargs is None
+    assert pass_log.forward_args_summary == expected_args_summary
+    assert pass_log.forward_kwargs_summary == expected_kwargs_summary
+
+
+@pytest.mark.parametrize("surface_name", ["params", "buffers", "module_pass"])
+def test_tabular_exports_round_trip(
+    io_pandas_log: tuple[Any, _IoPandasModel, torch.Tensor],
+    surface_name: str,
+    tmp_path: Path,
+) -> None:
+    """CSV/JSON exports should round-trip and Parquet should succeed or hint clearly.
+
+    Parameters
+    ----------
+    io_pandas_log:
+        Logged model fixture.
+    surface_name:
+        Export surface selector.
+    tmp_path:
+        Temporary output directory.
+    """
+    log, _, _ = io_pandas_log
+    if surface_name == "params":
+        surface = log.params
+    elif surface_name == "buffers":
+        surface = log.buffers
+    else:
+        surface = log.modules["block:1"]
+
+    expected_df = surface.to_pandas()
+
+    csv_path = tmp_path / f"{surface_name}.csv"
+    surface.to_csv(csv_path)
+    csv_df = pd.read_csv(csv_path)
+    assert list(csv_df.columns) == list(expected_df.columns)
+    assert len(csv_df) == len(expected_df)
+
+    json_path = tmp_path / f"{surface_name}.json"
+    surface.to_json(json_path)
+    json_df = pd.read_json(json_path, orient="records")
+    assert list(json_df.columns) == list(expected_df.columns)
+    assert len(json_df) == len(expected_df)
+
+    parquet_path = tmp_path / f"{surface_name}.parquet"
+    if importlib.util.find_spec("pyarrow") is None:
+        with pytest.raises(ImportError, match=r"torchlens\[io\]"):
+            surface.to_parquet(parquet_path)
+    else:
+        surface.to_parquet(parquet_path)
+        parquet_df = pd.read_parquet(parquet_path)
+        assert list(parquet_df.columns) == list(expected_df.columns)
+        assert len(parquet_df) == len(expected_df)

--- a/tests/test_io_pickle.py
+++ b/tests/test_io_pickle.py
@@ -1,0 +1,162 @@
+"""Tests for portable pickle scrubbing and rehydration."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from torchlens import ModelLog, log_forward_pass
+from torchlens._io import IO_FORMAT_VERSION, TorchLensIOError
+from torchlens._io.rehydrate import rehydrate_model_log
+from torchlens._io.scrub import scrub_for_save
+
+
+class _TinyIOModel(nn.Module):
+    """Small model covering modules, params, buffers, and captured args."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bn = nn.BatchNorm1d(4)
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tiny test model."""
+        return torch.relu(self.linear(self.bn(x)))
+
+
+class _PlainPickleModel(nn.Module):
+    """Model using only plain-picklable ops for compatibility checks."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the plain-pickle compatibility model."""
+        return torch.sin(x)
+
+
+def _build_live_log() -> ModelLog:
+    """Create a canonical live log for portable I/O tests."""
+
+    torch.manual_seed(0)
+    model = _TinyIOModel()
+    x = torch.randn(2, 4)
+    return log_forward_pass(
+        model,
+        x,
+        layers_to_save="all",
+        save_function_args=True,
+        save_rng_states=True,
+        save_source_context=True,
+        random_seed=0,
+    )
+
+
+def _write_manifest(tmp_path, blob_specs) -> dict[str, object]:
+    """Persist blob specs into a minimal temporary manifest layout."""
+
+    bundle_path = tmp_path
+    blob_dir = bundle_path / "blobs"
+    blob_dir.mkdir()
+    tensors = []
+    for blob_id, tensor, kind, label in blob_specs:
+        relative_path = f"blobs/{blob_id}.safetensors"
+        save_file({"tensor": tensor.detach().cpu()}, bundle_path / relative_path)
+        tensors.append(
+            {
+                "blob_id": blob_id,
+                "kind": kind,
+                "label": label,
+                "relative_path": relative_path,
+            }
+        )
+    return {"io_format_version": IO_FORMAT_VERSION, "tensors": tensors}
+
+
+def test_scrubbed_pickle_roundtrip_rehydrates_accessors(tmp_path) -> None:
+    """Scrubbed portable state should rehydrate modules, buffers, and blobs."""
+
+    live_log = _build_live_log()
+    scrubbed_state, blob_specs = scrub_for_save(
+        live_log,
+        include_activations=True,
+        include_gradients=False,
+        include_captured_args=True,
+        include_rng_states=True,
+    )
+    manifest = _write_manifest(tmp_path, blob_specs)
+
+    roundtripped_state = pickle.loads(pickle.dumps(scrubbed_state))
+    restored = rehydrate_model_log(
+        roundtripped_state,
+        manifest,
+        tmp_path,
+        lazy=False,
+        map_location="cpu",
+        materialize_nested=True,
+    )
+
+    assert restored.modules["self"].address == "self"
+    assert restored.modules["bn"].address == "bn"
+    assert restored.modules["bn"]._source_model_log is restored
+    assert restored.buffers["bn.running_mean"].buffer_address == "bn.running_mean"
+
+    first_saved_layer = next(layer for layer in restored.layer_list if layer.has_saved_activations)
+    assert isinstance(first_saved_layer.activation, torch.Tensor)
+    assert (
+        first_saved_layer.parent_layer_log
+        is restored.layer_logs[first_saved_layer.layer_label_no_pass]
+    )
+
+    first_arg_layer = next(
+        layer
+        for layer in restored.layer_list
+        if layer.captured_args is not None and len(layer.captured_args) > 0
+    )
+    assert isinstance(first_arg_layer.captured_args[0], torch.Tensor)
+
+
+def test_model_log_setstate_default_fills_pre_sprint_state() -> None:
+    """Missing version tags should warn and default-fill new S1 fields."""
+
+    live_log = _build_live_log()
+    old_state = live_log.__getstate__()
+    old_state.pop("io_format_version", None)
+    old_state.pop("activation_postfunc_repr", None)
+
+    restored = ModelLog.__new__(ModelLog)
+    with pytest.warns(DeprecationWarning):
+        restored.__setstate__(old_state)
+
+    assert restored.io_format_version == IO_FORMAT_VERSION
+    assert restored.activation_postfunc_repr is None
+
+
+def test_model_log_setstate_rejects_newer_io_versions() -> None:
+    """Future portable versions must fail fast."""
+
+    live_log = _build_live_log()
+    future_state = live_log.__getstate__()
+    future_state["io_format_version"] = IO_FORMAT_VERSION + 1
+
+    restored = ModelLog.__new__(ModelLog)
+    with pytest.raises(TorchLensIOError):
+        restored.__setstate__(future_state)
+
+
+def test_plain_pickle_roundtrip_still_works() -> None:
+    """Existing plain ``pickle.dump`` behavior should remain available."""
+
+    live_log = log_forward_pass(
+        _PlainPickleModel(),
+        torch.randn(2, 4),
+        layers_to_save="all",
+        random_seed=0,
+    )
+    restored = pickle.loads(pickle.dumps(live_log))
+
+    assert isinstance(restored, ModelLog)
+    assert restored.model_name == live_log.model_name
+    assert len(restored.layer_list) == len(live_log.layer_list)
+    assert restored.layer_list[0].source_model_log is restored

--- a/tests/test_io_plain_pickle.py
+++ b/tests/test_io_plain_pickle.py
@@ -1,0 +1,150 @@
+"""Regression tests for plain ``pickle.dump`` compatibility."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+from torchlens import ModelLog, log_forward_pass
+
+
+class _PlainPickleModel(nn.Module):
+    """Simple model used for plain pickle regression checks."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the plain pickle test model.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        return torch.sin(x) + torch.cos(x)
+
+
+def _build_model_log(seed: int = 0) -> ModelLog:
+    """Build a deterministic ``ModelLog`` for plain pickle tests.
+
+    Parameters
+    ----------
+    seed:
+        Random seed used for model initialization and input generation.
+
+    Returns
+    -------
+    ModelLog
+        Logged forward pass with saved activations.
+    """
+
+    torch.manual_seed(seed)
+    model = _PlainPickleModel()
+    inputs = torch.randn(2, 4)
+    return log_forward_pass(model, inputs, layers_to_save="all", random_seed=seed)
+
+
+def _first_saved_layer(model_log: ModelLog) -> Any:
+    """Return the first saved layer from one model log.
+
+    Parameters
+    ----------
+    model_log:
+        Model log under test.
+
+    Returns
+    -------
+    Any
+        First saved layer-pass entry.
+    """
+
+    return next(layer for layer in model_log.layer_list if layer.has_saved_activations)
+
+
+def test_plain_pickle_dump_and_load_still_work(tmp_path: Path) -> None:
+    """Fresh ``ModelLog`` objects should still survive plain pickle round-trips."""
+
+    model_log = _build_model_log()
+    pickle_path = tmp_path / "model_log.pkl"
+
+    with pickle_path.open("wb") as handle:
+        pickle.dump(model_log, handle)
+    with pickle_path.open("rb") as handle:
+        restored = pickle.load(handle)
+
+    assert isinstance(restored, ModelLog)
+    assert restored.model_name == model_log.model_name
+    assert len(restored.layer_list) == len(model_log.layer_list)
+    assert restored[restored.output_layers[0]].layer_label == restored.output_layers[0]
+    assert restored.layer_list[0].source_model_log is restored
+    assert isinstance(_first_saved_layer(restored).activation, torch.Tensor)
+
+
+def test_old_style_pickle_without_io_format_version_warns_and_remains_usable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forged pre-sprint pickles should warn on load and keep accessors working."""
+
+    model_log = _build_model_log()
+    pickle_path = tmp_path / "old_style_model_log.pkl"
+    original_getstate = ModelLog.__getstate__
+
+    def _legacy_getstate(self: ModelLog) -> dict[str, Any]:
+        """Return a forged pre-sprint pickle state for one ``ModelLog``.
+
+        Parameters
+        ----------
+        self:
+            Model log being pickled.
+
+        Returns
+        -------
+        dict[str, Any]
+            State missing the portable format version tag.
+        """
+
+        state = original_getstate(self)
+        state.pop("io_format_version", None)
+        return state
+
+    monkeypatch.setattr(ModelLog, "__getstate__", _legacy_getstate)
+    with pickle_path.open("wb") as handle:
+        pickle.dump(model_log, handle)
+
+    with pytest.warns(DeprecationWarning):
+        with pickle_path.open("rb") as handle:
+            restored = pickle.load(handle)
+
+    assert isinstance(restored, ModelLog)
+    assert restored[restored.output_layers[0]].layer_label == restored.output_layers[0]
+    assert restored.layer_list[0].source_model_log is restored
+    assert isinstance(_first_saved_layer(restored).activation, torch.Tensor)
+
+
+def test_plain_pickle_preserves_in_memory_activations(tmp_path: Path) -> None:
+    """Plain pickles should keep activations resident rather than turning them into refs."""
+
+    model_log = _build_model_log()
+    source_layer = _first_saved_layer(model_log)
+    assert isinstance(source_layer.activation, torch.Tensor)
+
+    pickle_path = tmp_path / "in_memory_model_log.pkl"
+    with pickle_path.open("wb") as handle:
+        pickle.dump(model_log, handle)
+    with pickle_path.open("rb") as handle:
+        restored = pickle.load(handle)
+
+    restored_layer = _first_saved_layer(restored)
+    assert isinstance(restored_layer.activation, torch.Tensor)
+    assert restored_layer.activation_ref is None
+    assert torch.equal(restored_layer.activation, source_layer.activation)

--- a/tests/test_io_scrub_policy.py
+++ b/tests/test_io_scrub_policy.py
@@ -1,0 +1,74 @@
+"""Completeness lint for portable scrub policy coverage."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from torchlens import log_forward_pass
+from torchlens.data_classes.buffer_log import BufferLog
+from torchlens.data_classes.func_call_location import FuncCallLocation
+from torchlens.data_classes.layer_log import LayerLog
+from torchlens.data_classes.layer_pass_log import LayerPassLog
+from torchlens.data_classes.model_log import ModelLog
+from torchlens.data_classes.module_log import ModuleLog, ModulePassLog
+from torchlens.data_classes.param_log import ParamLog
+
+
+class _TinyIOModel(nn.Module):
+    """Small model covering every target log class."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bn = nn.BatchNorm1d(4)
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tiny test model."""
+        return torch.relu(self.linear(self.bn(x)))
+
+
+def _build_live_log() -> ModelLog:
+    """Create one canonical live ``ModelLog`` for completeness checks."""
+
+    torch.manual_seed(0)
+    model = _TinyIOModel()
+    x = torch.randn(2, 4)
+    return log_forward_pass(
+        model,
+        x,
+        layers_to_save="all",
+        save_function_args=True,
+        save_rng_states=True,
+        save_source_context=True,
+        random_seed=0,
+    )
+
+
+def test_portable_state_specs_cover_every_live_attribute() -> None:
+    """Each target class must map every live attribute to a scrub policy."""
+
+    live_log = _build_live_log()
+    instances = {
+        ModelLog: live_log,
+        LayerPassLog: next(layer for layer in live_log.layer_list if type(layer) is LayerPassLog),
+        LayerLog: next(iter(live_log.layer_logs.values())),
+        ModuleLog: next(iter(live_log.modules)),
+        ModulePassLog: next(iter(live_log.modules._pass_dict.values())),
+        ParamLog: next(iter(live_log.param_logs)),
+        BufferLog: next(layer for layer in live_log.layer_list if isinstance(layer, BufferLog)),
+        FuncCallLocation: next(
+            frame
+            for layer in live_log.layer_list
+            for frame in layer.func_call_stack
+            if layer.func_call_stack
+        ),
+    }
+
+    missing_by_class = {}
+    for cls, instance in instances.items():
+        missing = sorted(set(vars(instance)) - set(cls.PORTABLE_STATE_SPEC))
+        if missing:
+            missing_by_class[cls.__name__] = missing
+
+    assert missing_by_class == {}

--- a/tests/test_io_security.py
+++ b/tests/test_io_security.py
@@ -1,0 +1,219 @@
+"""Security-focused tests for portable TorchLens bundle loading."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+from torchlens import load, log_forward_pass, save
+from torchlens._io import TorchLensIOError
+
+
+class _SecurityIOModel(nn.Module):
+    """Small deterministic model for bundle security tests."""
+
+    def __init__(self) -> None:
+        """Initialize the model under test."""
+
+        super().__init__()
+        self.linear1 = nn.Linear(4, 6)
+        self.linear2 = nn.Linear(6, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model under test.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        return self.linear2(torch.relu(self.linear1(x)))
+
+
+def _build_bundle(tmp_path: Path, *, name: str = "bundle.tl") -> Path:
+    """Create one deterministic portable bundle for security tests.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary test directory.
+    name:
+        Bundle directory name.
+
+    Returns
+    -------
+    Path
+        Saved bundle path.
+    """
+
+    torch.manual_seed(0)
+    model = _SecurityIOModel()
+    inputs = torch.randn(2, 4)
+    model_log = log_forward_pass(model, inputs, layers_to_save="all", random_seed=0)
+    bundle_path = tmp_path / name
+    save(model_log, bundle_path)
+    return bundle_path
+
+
+def _read_manifest(bundle_path: Path) -> dict[str, Any]:
+    """Read one bundle manifest into a mutable dict.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+
+    Returns
+    -------
+    dict[str, Any]
+        Decoded manifest JSON.
+    """
+
+    with (bundle_path / "manifest.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _write_manifest(bundle_path: Path, manifest: dict[str, Any]) -> None:
+    """Overwrite one bundle manifest with JSON content.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+    manifest:
+        JSON-ready manifest content.
+    """
+
+    with (bundle_path / "manifest.json").open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+
+def _first_blob_path(bundle_path: Path) -> Path:
+    """Return the first persisted blob file from one bundle.
+
+    Parameters
+    ----------
+    bundle_path:
+        Bundle directory path.
+
+    Returns
+    -------
+    Path
+        First safetensors blob path.
+    """
+
+    return next((bundle_path / "blobs").glob("*.safetensors"))
+
+
+def test_load_rejects_manifest_parent_traversal_even_with_valid_sha(tmp_path: Path) -> None:
+    """Manifest paths that escape the bundle should hard-fail on load."""
+
+    bundle_path = _build_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    original_blob_path = _first_blob_path(bundle_path)
+    outside_blob_path = tmp_path / "outside.safetensors"
+    shutil.copy2(original_blob_path, outside_blob_path)
+    manifest["tensors"][0]["relative_path"] = "../outside.safetensors"
+    _write_manifest(bundle_path, manifest)
+
+    with pytest.raises(TorchLensIOError, match="Bundle rejected"):
+        load(bundle_path)
+
+
+def test_load_rejects_manifest_absolute_blob_path(tmp_path: Path) -> None:
+    """Absolute manifest blob paths should never be trusted."""
+
+    bundle_path = _build_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    original_blob_path = _first_blob_path(bundle_path)
+    outside_blob_path = tmp_path / "absolute_blob.safetensors"
+    shutil.copy2(original_blob_path, outside_blob_path)
+    manifest["tensors"][0]["relative_path"] = str(outside_blob_path.resolve())
+    _write_manifest(bundle_path, manifest)
+
+    with pytest.raises(TorchLensIOError, match="absolute relative_path"):
+        load(bundle_path)
+
+
+def test_load_rejects_manifest_parent_segments_that_resolve_back_inside(tmp_path: Path) -> None:
+    """Parent segments are rejected even if the final path stays under ``blobs/``."""
+
+    bundle_path = _build_bundle(tmp_path)
+    manifest = _read_manifest(bundle_path)
+    original_blob_name = _first_blob_path(bundle_path).name
+    manifest["tensors"][0]["relative_path"] = f"blobs/../blobs/{original_blob_name}"
+    _write_manifest(bundle_path, manifest)
+
+    with pytest.raises(TorchLensIOError, match="parent traversal"):
+        load(bundle_path)
+
+
+def test_load_rejects_manifest_path_into_sibling_bundle(tmp_path: Path) -> None:
+    """Manifest paths must not target another bundle's ``blobs/`` directory."""
+
+    source_bundle = _build_bundle(tmp_path, name="source_bundle.tl")
+    sibling_bundle = _build_bundle(tmp_path, name="other_bundle.tl")
+    sibling_blob_name = _first_blob_path(sibling_bundle).name
+    manifest = _read_manifest(source_bundle)
+    manifest["tensors"][0]["relative_path"] = f"../{sibling_bundle.name}/blobs/{sibling_blob_name}"
+    _write_manifest(source_bundle, manifest)
+
+    with pytest.raises(TorchLensIOError, match="Bundle rejected"):
+        load(source_bundle)
+
+
+def test_lazy_materialize_rejects_tampered_relative_path(tmp_path: Path) -> None:
+    """Lazy refs should enforce the same path traversal policy on materialization."""
+
+    bundle_path = _build_bundle(tmp_path)
+    lazy_log = load(bundle_path, lazy=True)
+    layer = next(layer for layer in lazy_log.layer_list if layer.has_saved_activations)
+    ref = layer.activation_ref
+    assert ref is not None
+
+    outside_blob_path = tmp_path / "outside_materialize.safetensors"
+    shutil.copy2(_first_blob_path(bundle_path), outside_blob_path)
+    layer.activation_ref = replace(ref, relative_path="../outside_materialize.safetensors")
+
+    with pytest.raises(TorchLensIOError, match="Bundle rejected"):
+        layer.materialize_activation()
+
+
+def test_extra_blob_with_manifest_sha_collision_raises(tmp_path: Path) -> None:
+    """Extra files that duplicate a manifest blob payload should hard-fail."""
+
+    bundle_path = _build_bundle(tmp_path)
+    original_blob_path = _first_blob_path(bundle_path)
+    collision_path = bundle_path / "blobs" / "collision_copy.safetensors"
+    shutil.copy2(original_blob_path, collision_path)
+
+    with pytest.raises(TorchLensIOError, match="sha256 matches a manifest entry"):
+        load(bundle_path)
+
+
+def test_orphaned_extra_blob_only_warns(tmp_path: Path) -> None:
+    """Unreferenced files without checksum collisions should remain warnings."""
+
+    bundle_path = _build_bundle(tmp_path)
+    (bundle_path / "blobs" / "orphan.bin").write_bytes(b"orphan")
+
+    with pytest.warns(UserWarning, match="unreferenced extra files"):
+        restored = load(bundle_path)
+
+    assert restored.model_name == "_SecurityIOModel"

--- a/tests/test_io_streaming.py
+++ b/tests/test_io_streaming.py
@@ -1,0 +1,310 @@
+"""Tests for streaming activation save during ``log_forward_pass``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+import torchlens.postprocess as postprocess_module
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+from torchlens import cleanup_tmp, log_forward_pass
+from torchlens._io import TorchLensIOError
+from torchlens.data_classes.model_log import ModelLog
+
+
+class _StreamingModel(nn.Module):
+    """Small model used for streaming-save integration tests."""
+
+    def __init__(self) -> None:
+        """Initialize the test model."""
+
+        super().__init__()
+        self.linear1 = nn.Linear(4, 6)
+        self.linear2 = nn.Linear(6, 5)
+        self.linear3 = nn.Linear(5, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model under test.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        x = torch.relu(self.linear1(x))
+        x = torch.relu(self.linear2(x))
+        return self.linear3(x)
+
+
+def _make_streaming_model() -> tuple[_StreamingModel, torch.Tensor]:
+    """Create a deterministic model/input pair for streaming tests.
+
+    Returns
+    -------
+    tuple[_StreamingModel, torch.Tensor]
+        Fresh model and input tensor.
+    """
+
+    torch.manual_seed(0)
+    return _StreamingModel(), torch.randn(2, 4)
+
+
+def _saved_layers(model_log: ModelLog) -> list[Any]:
+    """Return all layers with saved activations from one model log.
+
+    Parameters
+    ----------
+    model_log:
+        Completed model log under test.
+
+    Returns
+    -------
+    list
+        Saved layer-pass entries.
+    """
+
+    return [layer for layer in model_log.layer_list if layer.has_saved_activations]
+
+
+def _tmp_dirs_for(bundle_path: Path) -> list[Path]:
+    """Return sibling temp bundle directories for one target path.
+
+    Parameters
+    ----------
+    bundle_path:
+        Final bundle directory path.
+
+    Returns
+    -------
+    list[Path]
+        Matching temp bundle paths.
+    """
+
+    return sorted(bundle_path.parent.glob(f"{bundle_path.name}.tmp.*"))
+
+
+def test_streaming_writes_blobs_before_postprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Streaming save should create blob files before postprocess step 1 starts."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    observed: dict[str, object] = {}
+    original_add_output_layers = postprocess_module._add_output_layers
+
+    def _capturing_add_output_layers(
+        self: ModelLog,
+        output_tensors: list[torch.Tensor],
+        output_tensor_addresses: list[str],
+    ) -> None:
+        tmp_dirs = _tmp_dirs_for(bundle_path)
+        observed["tmp_dirs"] = tmp_dirs
+        observed["final_exists"] = bundle_path.exists()
+        observed["blob_files"] = sorted(tmp_dirs[0].glob("blobs/*.safetensors")) if tmp_dirs else []
+        original_add_output_layers(self, output_tensors, output_tensor_addresses)
+
+    monkeypatch.setattr(postprocess_module, "_add_output_layers", _capturing_add_output_layers)
+
+    model, inputs = _make_streaming_model()
+    log_forward_pass(model, inputs, save_activations_to=bundle_path, layers_to_save="all")
+
+    assert observed["final_exists"] is False
+    tmp_dirs = observed["tmp_dirs"]
+    assert isinstance(tmp_dirs, list)
+    assert len(tmp_dirs) == 1
+    blob_files = observed["blob_files"]
+    assert isinstance(blob_files, list)
+    assert blob_files
+    assert bundle_path.exists()
+
+
+def test_step_19_finalizes_bundle_and_keeps_activations_in_memory(tmp_path: Path) -> None:
+    """Step 19 should finalize the bundle and attach lazy refs without eviction."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    model, inputs = _make_streaming_model()
+    model_log = log_forward_pass(
+        model,
+        inputs,
+        save_activations_to=bundle_path,
+        keep_activations_in_memory=True,
+        layers_to_save="all",
+    )
+
+    saved_layers = _saved_layers(model_log)
+    assert bundle_path.exists()
+    assert not _tmp_dirs_for(bundle_path)
+    assert saved_layers
+    for layer in saved_layers:
+        assert isinstance(layer.activation, torch.Tensor)
+        assert layer.activation_ref is not None
+        assert layer.activation_ref.source_bundle_path == bundle_path
+        assert ".tmp." not in str(layer.activation_ref.source_bundle_path)
+
+
+def test_step_20_evicts_streamed_activations_when_requested(tmp_path: Path) -> None:
+    """Step 20 should drop in-memory activations after refs are attached."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    model, inputs = _make_streaming_model()
+    model_log = log_forward_pass(
+        model,
+        inputs,
+        save_activations_to=bundle_path,
+        keep_activations_in_memory=False,
+        layers_to_save="all",
+    )
+
+    saved_layers = _saved_layers(model_log)
+    assert bundle_path.exists()
+    assert saved_layers
+    for layer in saved_layers:
+        assert layer.activation is None
+        assert layer.activation_ref is not None
+        assert layer.activation_ref.source_bundle_path == bundle_path
+
+
+def test_streaming_mid_pass_exception_marks_partial_tmp_dir(tmp_path: Path) -> None:
+    """Exceptions raised during activation postprocessing should leave a partial temp dir."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+
+    def _raise_on_activation(_: torch.Tensor) -> torch.Tensor:
+        raise RuntimeError("boom")
+
+    model, inputs = _make_streaming_model()
+    with pytest.raises(TorchLensIOError, match="Streaming activation save failed"):
+        log_forward_pass(
+            model,
+            inputs,
+            save_activations_to=bundle_path,
+            activation_postfunc=_raise_on_activation,
+            layers_to_save="all",
+        )
+
+    assert not bundle_path.exists()
+    tmp_dirs = _tmp_dirs_for(bundle_path)
+    assert len(tmp_dirs) == 1
+    assert (tmp_dirs[0] / "PARTIAL").exists()
+    assert (tmp_dirs[0] / "REASON.txt").exists()
+
+
+def test_streaming_rejects_non_tensor_activation_postfunc_output(tmp_path: Path) -> None:
+    """Streaming save should abort when activation postprocessing returns a non-tensor."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    model, inputs = _make_streaming_model()
+    with pytest.raises(TorchLensIOError, match="activation_postfunc outputs"):
+        log_forward_pass(
+            model,
+            inputs,
+            save_activations_to=bundle_path,
+            activation_postfunc=lambda tensor: tensor.detach().cpu().numpy(),
+            layers_to_save="all",
+        )
+
+    assert not bundle_path.exists()
+    tmp_dirs = _tmp_dirs_for(bundle_path)
+    assert len(tmp_dirs) == 1
+    assert (tmp_dirs[0] / "PARTIAL").exists()
+
+
+def test_streaming_is_always_strict_for_sparse_tensors(tmp_path: Path) -> None:
+    """Streaming save should fail immediately on sparse activations."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    model, inputs = _make_streaming_model()
+    with pytest.raises(TorchLensIOError, match="sparse"):
+        log_forward_pass(
+            model,
+            inputs,
+            save_activations_to=bundle_path,
+            activation_postfunc=lambda tensor: tensor.to_sparse(),
+            layers_to_save="all",
+        )
+
+    assert not bundle_path.exists()
+    tmp_dirs = _tmp_dirs_for(bundle_path)
+    assert len(tmp_dirs) == 1
+    assert (tmp_dirs[0] / "PARTIAL").exists()
+
+
+def test_activation_sink_receives_saved_tensors_and_is_mutually_exclusive(
+    tmp_path: Path,
+) -> None:
+    """Activation sink callbacks should receive saved tensors and conflict with streaming save."""
+
+    received: list[tuple[str, torch.Tensor]] = []
+
+    def _sink(label: str, tensor: torch.Tensor) -> None:
+        received.append((label, tensor))
+
+    model, inputs = _make_streaming_model()
+    model_log = log_forward_pass(model, inputs, activation_sink=_sink, layers_to_save="all")
+    capture_time_layers = [layer for layer in _saved_layers(model_log) if not layer.is_output_layer]
+
+    assert received
+    assert len(received) == len(capture_time_layers)
+    assert all(isinstance(label, str) and label for label, _ in received)
+    assert all(isinstance(tensor, torch.Tensor) for _, tensor in received)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        model2, inputs2 = _make_streaming_model()
+        log_forward_pass(
+            model2,
+            inputs2,
+            save_activations_to=tmp_path / "stream_bundle.tl",
+            activation_sink=_sink,
+        )
+
+
+def test_cleanup_tmp_removes_partial_dirs_and_rejects_symlinks(tmp_path: Path) -> None:
+    """``cleanup_tmp`` should remove partial dirs and refuse symlink temp entries."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    partial_dir = tmp_path / f"{bundle_path.name}.tmp.partial"
+    partial_dir.mkdir()
+    (partial_dir / "PARTIAL").write_text("", encoding="utf-8")
+
+    removed = cleanup_tmp(bundle_path)
+    assert removed == [partial_dir]
+    assert not partial_dir.exists()
+
+    target_dir = tmp_path / "real_tmp_dir"
+    target_dir.mkdir()
+    symlink_dir = tmp_path / f"{bundle_path.name}.tmp.symlink"
+    symlink_dir.symlink_to(target_dir, target_is_directory=True)
+
+    with pytest.raises(TorchLensIOError, match="symlink temp directory"):
+        cleanup_tmp(bundle_path)
+
+
+def test_lazy_refs_point_at_final_bundle_path_after_streaming_save(tmp_path: Path) -> None:
+    """Streaming-attached lazy refs should point at the final renamed bundle path."""
+
+    bundle_path = tmp_path / "stream_bundle.tl"
+    model, inputs = _make_streaming_model()
+    model_log = log_forward_pass(
+        model,
+        inputs,
+        save_activations_to=bundle_path,
+        keep_activations_in_memory=True,
+        layers_to_save="all",
+    )
+
+    first_saved_layer = _saved_layers(model_log)[0]
+    assert first_saved_layer.activation_ref is not None
+    assert first_saved_layer.activation_ref.source_bundle_path == bundle_path
+    assert ".tmp." not in str(first_saved_layer.activation_ref.source_bundle_path)

--- a/tests/test_io_streaming.py
+++ b/tests/test_io_streaming.py
@@ -15,6 +15,7 @@ pytest.importorskip("safetensors")
 
 from torchlens import cleanup_tmp, log_forward_pass
 from torchlens._io import TorchLensIOError
+from torchlens._io.manifest import Manifest
 from torchlens.data_classes.model_log import ModelLog
 
 
@@ -153,6 +154,9 @@ def test_step_19_finalizes_bundle_and_keeps_activations_in_memory(tmp_path: Path
         assert layer.activation_ref.source_bundle_path == bundle_path
         assert ".tmp." not in str(layer.activation_ref.source_bundle_path)
 
+    manifest = Manifest.read(bundle_path / "manifest.json")
+    assert manifest.tensors
+
 
 def test_step_20_evicts_streamed_activations_when_requested(tmp_path: Path) -> None:
     """Step 20 should drop in-memory activations after refs are attached."""
@@ -268,6 +272,41 @@ def test_activation_sink_receives_saved_tensors_and_is_mutually_exclusive(
             save_activations_to=tmp_path / "stream_bundle.tl",
             activation_sink=_sink,
         )
+
+
+def test_selective_streaming_save_is_rejected(tmp_path: Path) -> None:
+    """Selective streaming-to-bundle should fail instead of producing an empty bundle."""
+
+    bundle_path = tmp_path / "selective_stream_bundle.tl"
+    model, inputs = _make_streaming_model()
+
+    with pytest.raises(TorchLensIOError, match='layers_to_save="all"'):
+        log_forward_pass(
+            model,
+            inputs,
+            layers_to_save="linear",
+            save_activations_to=bundle_path,
+            keep_activations_in_memory=False,
+        )
+
+    assert not bundle_path.exists()
+
+
+def test_selective_activation_sink_still_works() -> None:
+    """Selective activation sinks should still use the supported two-pass path."""
+
+    received: list[tuple[str, torch.Tensor]] = []
+
+    def _sink(label: str, tensor: torch.Tensor) -> None:
+        received.append((label, tensor))
+
+    model, inputs = _make_streaming_model()
+    model_log = log_forward_pass(model, inputs, activation_sink=_sink, layers_to_save="linear")
+
+    capture_time_layers = [layer for layer in _saved_layers(model_log) if not layer.is_output_layer]
+    assert capture_time_layers
+    assert len(received) == len(capture_time_layers)
+    assert all("linear" in label for label, _ in received)
 
 
 def test_cleanup_tmp_removes_partial_dirs_and_rejects_symlinks(tmp_path: Path) -> None:

--- a/tests/test_save_new_activations.py
+++ b/tests/test_save_new_activations.py
@@ -153,6 +153,22 @@ def test_save_new_activations_layers_to_save():
     log.cleanup()
 
 
+def test_save_new_activations_fast_path_does_not_attach_streaming_refs() -> None:
+    """The fast-path re-extraction flow should not create streaming bundle refs."""
+
+    model = _SimpleFF()
+    log = log_forward_pass(model, torch.randn(2, 5), random_seed=42)
+    output_label = log.output_layers[0]
+
+    log.save_new_activations(
+        model, torch.randn(2, 5), random_seed=42, layers_to_save=[output_label]
+    )
+
+    assert getattr(log, "_activation_writer", None) is None
+    assert all(getattr(layer, "activation_ref", None) is None for layer in log.layer_list)
+    log.cleanup()
+
+
 # =============================================================================
 # Known failure: torchvision models with identity-propagated ops
 # =============================================================================

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -21,6 +21,7 @@ from .user_funcs import (
 )
 from .validation.invariants import check_metadata_invariants, MetadataInvariantError
 from ._io.bundle import save, load, cleanup_tmp
+from ._io import rehydrate_nested
 
 # ---- Public API: data classes users interact with ------------------------
 

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -20,6 +20,7 @@ from .user_funcs import (
     validate_batch_of_models_and_inputs,
 )
 from .validation.invariants import check_metadata_invariants, MetadataInvariantError
+from ._io.bundle import save, load, cleanup_tmp
 
 # ---- Public API: data classes users interact with ------------------------
 

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -1,10 +1,12 @@
-"""TorchLens — extract activations and metadata from PyTorch models.
+"""TorchLens - extract activations and metadata from PyTorch models.
 
 Importing torchlens has **no side effects** on the torch namespace.  Torch
 functions are wrapped lazily on the first call to ``log_forward_pass()`` (or
 any other entry point) and stay wrapped afterward.  To restore the original
 torch callables, call ``unwrap_torch()``.  To explicitly (re-)wrap, call
 ``wrap_torch()``.  The ``wrapped()`` context manager handles the full lifecycle.
+The top-level package also exports portable bundle helpers: ``save()``,
+``load()``, ``cleanup_tmp()``, and ``rehydrate_nested()``.
 """
 
 __version__ = "1.1.0"

--- a/torchlens/_io/__init__.py
+++ b/torchlens/_io/__init__.py
@@ -12,6 +12,8 @@ import warnings
 from enum import Enum
 from typing import Any, NamedTuple
 
+import torch
+
 IO_FORMAT_VERSION = 1
 
 
@@ -59,7 +61,7 @@ def read_io_format_version(state: dict[str, Any], *, cls_name: str) -> int:
         is not an integer.
     """
 
-    version = state.get("io_format_version")
+    version = state.pop("io_format_version", None)
     if version is None:
         warnings.warn(
             f"{cls_name} pickle state predates TorchLens portable I/O versioning; "
@@ -95,3 +97,19 @@ def default_fill_state(state: dict[str, Any], *, defaults: dict[str, Any]) -> No
     for field_name, default_value in defaults.items():
         if field_name not in state:
             state[field_name] = copy.deepcopy(default_value)
+
+
+def rehydrate_nested(model_log: Any, *, map_location: str | torch.device = "cpu") -> None:
+    """Materialize nested portable blob refs on a loaded model log.
+
+    Parameters
+    ----------
+    model_log:
+        Model log loaded from a portable bundle.
+    map_location:
+        Target device for the materialized nested tensors.
+    """
+
+    from .rehydrate import rehydrate_nested as _rehydrate_nested
+
+    _rehydrate_nested(model_log, map_location=map_location)

--- a/torchlens/_io/__init__.py
+++ b/torchlens/_io/__init__.py
@@ -1,8 +1,14 @@
 """Portable I/O primitives for TorchLens model logs.
 
-This module defines the shared versioning, field-policy, and compatibility
-helpers used by the portable scrub/rehydrate path introduced in the I/O
-sprint.
+The ``torchlens._io`` package implements TorchLens' portable save/load path:
+it scrubs a ``ModelLog`` into metadata plus tensor blobs, writes directory
+bundles backed by ``safetensors``, and rehydrates those bundles into eager or
+lazy model logs. Portable bundles are for archival and analysis, not replay:
+``validate_forward_pass()`` is unsupported after ``torchlens.load()`` (Fork L),
+expert ``lazy=True, materialize_nested=False`` loads must call
+``torchlens.rehydrate_nested()`` before re-save (Fork M), and lazy refs open,
+verify, and close blob files per materialization instead of sharing handles
+(Fork K).
 """
 
 from __future__ import annotations
@@ -108,6 +114,13 @@ def rehydrate_nested(model_log: Any, *, map_location: str | torch.device = "cpu"
         Model log loaded from a portable bundle.
     map_location:
         Target device for the materialized nested tensors.
+
+    Examples
+    --------
+    >>> import torchlens as tl
+    >>> model_log = tl.load("demo_bundle", lazy=True, materialize_nested=False)
+    >>> tl.rehydrate_nested(model_log)
+    >>> model_log.save("demo_bundle_copy")
     """
 
     from .rehydrate import rehydrate_nested as _rehydrate_nested

--- a/torchlens/_io/__init__.py
+++ b/torchlens/_io/__init__.py
@@ -1,0 +1,97 @@
+"""Portable I/O primitives for TorchLens model logs.
+
+This module defines the shared versioning, field-policy, and compatibility
+helpers used by the portable scrub/rehydrate path introduced in the I/O
+sprint.
+"""
+
+from __future__ import annotations
+
+import copy
+import warnings
+from enum import Enum
+from typing import Any, NamedTuple
+
+IO_FORMAT_VERSION = 1
+
+
+class TorchLensIOError(RuntimeError):
+    """Raised when TorchLens portable bundle state is invalid or unsupported."""
+
+
+class BlobRef(NamedTuple):
+    """Reference to a persisted tensor blob in a portable bundle."""
+
+    blob_id: str
+    kind: str
+
+
+class FieldPolicy(str, Enum):
+    """Portable scrub policy for one serialized field."""
+
+    KEEP = "keep"
+    BLOB = "blob"
+    BLOB_RECURSIVE = "blob_recursive"
+    DROP = "drop"
+    STRINGIFY = "stringify"
+    WEAKREF_STRIP = "weakref_strip"
+
+
+def read_io_format_version(state: dict[str, Any], *, cls_name: str) -> int:
+    """Validate the serialized I/O format version for one object state.
+
+    Parameters
+    ----------
+    state:
+        Serialized state dict for the object being restored.
+    cls_name:
+        Human-readable class name used in warnings and errors.
+
+    Returns
+    -------
+    int
+        The decoded version. Pre-sprint states return ``0``.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the serialized version is newer than this runtime understands or
+        is not an integer.
+    """
+
+    version = state.get("io_format_version")
+    if version is None:
+        warnings.warn(
+            f"{cls_name} pickle state predates TorchLens portable I/O versioning; "
+            "compat mode is deprecated.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return 0
+    if not isinstance(version, int):
+        raise TorchLensIOError(
+            f"{cls_name} pickle state has invalid io_format_version={version!r}."
+        )
+    if version > IO_FORMAT_VERSION:
+        raise TorchLensIOError(
+            f"{cls_name} pickle state uses io_format_version={version}, "
+            f"but this runtime only supports up to {IO_FORMAT_VERSION}."
+        )
+    return version
+
+
+def default_fill_state(state: dict[str, Any], *, defaults: dict[str, Any]) -> None:
+    """Populate missing state keys with deep-copied default values.
+
+    Parameters
+    ----------
+    state:
+        Mutable serialized state dict being restored.
+    defaults:
+        Mapping from field name to the default value that should be injected
+        when that field is absent.
+    """
+
+    for field_name, default_value in defaults.items():
+        if field_name not in state:
+            state[field_name] = copy.deepcopy(default_value)

--- a/torchlens/_io/__init__.py
+++ b/torchlens/_io/__init__.py
@@ -106,7 +106,11 @@ def default_fill_state(state: dict[str, Any], *, defaults: dict[str, Any]) -> No
 
 
 def rehydrate_nested(model_log: Any, *, map_location: str | torch.device = "cpu") -> None:
-    """Materialize nested portable blob refs on a loaded model log.
+    """Replace any remaining nested portable blob refs on a loaded model log.
+
+    This function is a no-op unless the model log was loaded with
+    ``lazy=True, materialize_nested=False``. In the default load mode, nested
+    tensors are already materialized.
 
     Parameters
     ----------
@@ -118,9 +122,9 @@ def rehydrate_nested(model_log: Any, *, map_location: str | torch.device = "cpu"
     Examples
     --------
     >>> import torchlens as tl
-    >>> model_log = tl.load("demo_bundle", lazy=True, materialize_nested=False)
-    >>> tl.rehydrate_nested(model_log)
-    >>> model_log.save("demo_bundle_copy")
+    >>> log = tl.load("demo_bundle", lazy=True, materialize_nested=False)
+    >>> tl.rehydrate_nested(log)
+    >>> log.save("demo_bundle_copy")
     """
 
     from .rehydrate import rehydrate_nested as _rehydrate_nested

--- a/torchlens/_io/accessor_rebuild.py
+++ b/torchlens/_io/accessor_rebuild.py
@@ -1,4 +1,10 @@
-"""Rebuild weakref-backed model accessors after finalization or rehydrate."""
+"""Rebuild weakref-backed model accessors after finalization or rehydrate.
+
+Portable loads intentionally avoid rebuilding every weakref-backed accessor in
+``__setstate__``. This module centralizes the post-load repair step that
+reconnects module and buffer accessors to the owning ``ModelLog`` once the
+rehydrated object graph is ready for normal user access.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/accessor_rebuild.py
+++ b/torchlens/_io/accessor_rebuild.py
@@ -1,0 +1,47 @@
+"""Rebuild weakref-backed model accessors after finalization or rehydrate."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..data_classes.buffer_log import BufferAccessor
+from ..data_classes.module_log import ModuleAccessor
+
+if TYPE_CHECKING:
+    from ..data_classes.model_log import ModelLog
+    from ..data_classes.module_log import ModuleLog, ModulePassLog
+
+
+def rebuild_model_log_accessors(
+    model_log: "ModelLog",
+    module_dict: dict[str, "ModuleLog"],
+    module_order: list["ModuleLog"],
+    pass_dict: dict[str, "ModulePassLog"],
+) -> None:
+    """Rebuild the user-facing module and buffer accessors on a ``ModelLog``.
+
+    Parameters
+    ----------
+    model_log:
+        Model log receiving the rebuilt accessors.
+    module_dict:
+        Mapping from primary module address to ``ModuleLog``.
+    module_order:
+        Ordered list of module logs for iteration and integer indexing.
+    pass_dict:
+        Mapping from ``"address:pass"`` labels to ``ModulePassLog`` entries.
+    """
+
+    for module_log in module_dict.values():
+        module_log._source_model_log = model_log
+        module_log._buffer_accessor = None
+
+    model_log._module_logs = ModuleAccessor(module_dict, module_order, pass_dict)
+
+    buffer_dict = {}
+    for label in model_log.buffer_layers:
+        if label in model_log.layer_dict_all_keys:
+            entry = model_log.layer_dict_all_keys[label]
+            if entry.buffer_address is not None:
+                buffer_dict[entry.buffer_address] = entry
+    model_log._buffer_accessor = BufferAccessor(buffer_dict, source_model_log=model_log)  # type: ignore[assignment, arg-type]

--- a/torchlens/_io/bundle.py
+++ b/torchlens/_io/bundle.py
@@ -1,4 +1,11 @@
-"""Portable directory-bundle save/load helpers for TorchLens model logs."""
+"""Portable directory-bundle save/load helpers for TorchLens model logs.
+
+This module owns the high-level bundle lifecycle for TorchLens portable I/O:
+save a completed ``ModelLog`` into a directory bundle, load that bundle back
+eagerly or lazily, and clean up interrupted ``.tmp.*`` directories left behind
+by partial saves. The bundle format is intentionally a plain directory with
+``manifest.json``, ``metadata.pkl``, and one ``safetensors`` file per blob.
+"""
 
 from __future__ import annotations
 
@@ -90,6 +97,19 @@ def save(
     ------
     TorchLensIOError
         If the bundle cannot be created or contains unsupported state.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import torch.nn as nn
+    >>> import torchlens as tl
+    >>> model = nn.Sequential(nn.Linear(4, 3), nn.ReLU())
+    >>> x = torch.randn(2, 4)
+    >>> model_log = tl.log_forward_pass(model, x, layers_to_save="all")
+    >>> tl.save(model_log, "demo_bundle", overwrite=True)
+    >>> loaded = tl.load("demo_bundle")
+    >>> loaded["linear_1_1"].activation.shape
+    torch.Size([2, 3])
     """
 
     bundle_path = Path(path)
@@ -217,6 +237,17 @@ def load(
     ------
     TorchLensIOError
         If the bundle is invalid, corrupt, or incompatible with this runtime.
+
+    Examples
+    --------
+    >>> import torchlens as tl
+    >>> model_log = tl.load("demo_bundle", lazy=True)
+    >>> layer = model_log["linear_1_1"]
+    >>> layer.activation is None
+    True
+    >>> activation = layer.materialize_activation()
+    >>> activation.shape
+    torch.Size([2, 3])
     """
 
     bundle_path = Path(path)
@@ -287,6 +318,16 @@ def cleanup_tmp(path: str | Path, *, force: bool = False) -> list[Path]:
     ------
     TorchLensIOError
         If the requested target path or candidate temp dirs are symlinks.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> import torchlens as tl
+    >>> partial = Path("demo_bundle.tmp.partial")
+    >>> partial.mkdir(exist_ok=True)
+    >>> (partial / "PARTIAL").write_text("", encoding="ascii")
+    >>> tl.cleanup_tmp("demo_bundle")
+    [PosixPath('demo_bundle.tmp.partial')]
     """
 
     bundle_path = Path(path)

--- a/torchlens/_io/bundle.py
+++ b/torchlens/_io/bundle.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
 import os
 import platform
 import pickle
@@ -16,7 +18,8 @@ from typing import Any
 import torch
 from safetensors.torch import load_file, save_file
 
-from . import BlobRef, IO_FORMAT_VERSION, TorchLensIOError
+from . import BlobRef, FieldPolicy, IO_FORMAT_VERSION, TorchLensIOError
+from .lazy import LazyActivationRef
 from .manifest import Manifest, TensorEntry, enforce_version_policy, sha256_of_file
 from .rehydrate import rehydrate_model_log
 from .scrub import scrub_for_save
@@ -27,6 +30,28 @@ from ..data_classes.model_log import ModelLog
 PARTIAL_SENTINEL = "PARTIAL"
 REASON_SENTINEL = "REASON.txt"
 _BLOB_TENSOR_KEY = "data"
+
+
+@dataclass(frozen=True)
+class _FastCopySpec:
+    """One lazily-backed direct tensor field that can be copied into a new bundle.
+
+    Parameters
+    ----------
+    blob_id:
+        New blob id allocated for the destination bundle.
+    kind:
+        Logical tensor kind recorded in the destination manifest.
+    label:
+        Human-readable label stored alongside the destination manifest entry.
+    source_ref:
+        Lazy source blob reference from the current in-memory ``ModelLog``.
+    """
+
+    blob_id: str
+    kind: str
+    label: str
+    source_ref: LazyActivationRef
 
 
 def save(
@@ -70,6 +95,7 @@ def save(
     bundle_path = Path(path)
     _reject_symlink_path(bundle_path, context="save target")
     _validate_activation_postfunc_outputs(model_log, include_activations=include_activations)
+    _raise_for_unmaterialized_nested_blob_refs(model_log)
 
     backup_path: Path | None = None
     tmp_path = _make_tmp_bundle_path(bundle_path)
@@ -91,6 +117,13 @@ def save(
             include_captured_args=include_captured_args,
             include_rng_states=include_rng_states,
         )
+        fast_copy_specs = _attach_fast_copy_specs(
+            model_log,
+            scrubbed_state=scrubbed_state,
+            blob_specs=blob_specs,
+            include_activations=include_activations,
+            include_gradients=include_gradients,
+        )
 
         tensor_entries: list[TensorEntry] = []
         unsupported_tensors: list[dict[str, str]] = []
@@ -111,6 +144,21 @@ def save(
                 )
             unsupported_tensors.append({"label": label, "kind": kind, "reason": decision.text})
             skipped_blob_ids.add(blob_id)
+
+        source_manifest_cache: dict[Path, dict[str, TensorEntry]] = {}
+        for fast_copy_spec in fast_copy_specs:
+            manifest_index = _load_and_verify_fast_copy_source(
+                model_log,
+                fast_copy_spec.source_ref.source_bundle_path,
+                cache=source_manifest_cache,
+            )
+            tensor_entries.append(
+                _fast_copy_tensor_blob(
+                    tmp_path=tmp_path,
+                    fast_copy_spec=fast_copy_spec,
+                    manifest_index=manifest_index,
+                )
+            )
 
         if skipped_blob_ids:
             _apply_skipped_blobs_to_scrubbed_state(scrubbed_state, skipped_blob_ids)
@@ -216,6 +264,7 @@ def load(
     )
     setattr(model_log, "_loaded_from_bundle", True)
     setattr(model_log, "_source_bundle_manifest_sha256", sha256_of_file(manifest_path))
+    setattr(model_log, "_source_bundle_path", bundle_path)
     return model_log
 
 
@@ -291,7 +340,11 @@ def _scrub_model_log_for_bundle(
     """
 
     transient_attrs = {}
-    for attr_name in ("_loaded_from_bundle", "_source_bundle_manifest_sha256"):
+    for attr_name in (
+        "_loaded_from_bundle",
+        "_source_bundle_manifest_sha256",
+        "_source_bundle_path",
+    ):
         if hasattr(model_log, attr_name):
             transient_attrs[attr_name] = getattr(model_log, attr_name)
             delattr(model_log, attr_name)
@@ -353,6 +406,257 @@ def _write_tensor_blob(
         layout=str(contiguous_tensor.layout).replace("torch.", ""),
         bytes=int(contiguous_tensor.numel() * contiguous_tensor.element_size()),
         sha256=sha256_of_file(blob_path),
+    )
+
+
+def _attach_fast_copy_specs(
+    model_log: ModelLog,
+    *,
+    scrubbed_state: dict[str, Any],
+    blob_specs: list[tuple[str, torch.Tensor, str, str]],
+    include_activations: bool,
+    include_gradients: bool,
+) -> list[_FastCopySpec]:
+    """Attach direct-field blob refs for lazily-backed tensors that can be fast-copied.
+
+    Parameters
+    ----------
+    model_log:
+        Live model log being saved.
+    scrubbed_state:
+        Scrubbed metadata state returned by ``scrub_for_save``.
+    blob_specs:
+        Existing eager-write blob specs.
+    include_activations:
+        Whether activation fields should be persisted.
+    include_gradients:
+        Whether gradient fields should be persisted.
+
+    Returns
+    -------
+    list[_FastCopySpec]
+        Lazily-backed direct tensor fields that should be copied from their source
+        bundles into the new bundle.
+    """
+
+    scrubbed_layers = scrubbed_state.get("layer_list")
+    if not isinstance(scrubbed_layers, list):
+        return []
+
+    used_blob_ids = {blob_id for blob_id, _, _, _ in blob_specs}
+    fast_copy_specs: list[_FastCopySpec] = []
+    for live_layer, scrubbed_layer in zip(model_log.layer_list, scrubbed_layers):
+        if include_activations:
+            fast_copy_spec = _maybe_make_fast_copy_spec(
+                live_layer=live_layer,
+                scrubbed_layer=scrubbed_layer,
+                tensor_field="activation",
+                ref_field="activation_ref",
+                kind="activation",
+                has_field="has_saved_activations",
+                used_blob_ids=used_blob_ids,
+            )
+            if fast_copy_spec is not None:
+                fast_copy_specs.append(fast_copy_spec)
+        if include_gradients:
+            fast_copy_spec = _maybe_make_fast_copy_spec(
+                live_layer=live_layer,
+                scrubbed_layer=scrubbed_layer,
+                tensor_field="gradient",
+                ref_field="gradient_ref",
+                kind="gradient",
+                has_field="has_gradient",
+                used_blob_ids=used_blob_ids,
+            )
+            if fast_copy_spec is not None:
+                fast_copy_specs.append(fast_copy_spec)
+    return fast_copy_specs
+
+
+def _maybe_make_fast_copy_spec(
+    *,
+    live_layer: Any,
+    scrubbed_layer: Any,
+    tensor_field: str,
+    ref_field: str,
+    kind: str,
+    has_field: str,
+    used_blob_ids: set[str],
+) -> _FastCopySpec | None:
+    """Create one fast-copy spec for a lazily-backed direct tensor field.
+
+    Parameters
+    ----------
+    live_layer:
+        Live ``LayerPassLog`` instance being saved.
+    scrubbed_layer:
+        Scrubbed ``LayerPassLog`` counterpart that will be pickled.
+    tensor_field:
+        Direct tensor field name, for example ``"activation"``.
+    ref_field:
+        Matching lazy-ref field name.
+    kind:
+        Logical manifest tensor kind.
+    has_field:
+        Boolean field indicating whether the tensor is expected to exist.
+    used_blob_ids:
+        Set of blob ids already allocated for the destination bundle.
+
+    Returns
+    -------
+    _FastCopySpec | None
+        Fast-copy spec when the field should be copied from its source bundle,
+        otherwise ``None``.
+    """
+
+    if not bool(getattr(live_layer, has_field, False)):
+        return None
+    if getattr(scrubbed_layer, tensor_field, None) is not None:
+        return None
+    if getattr(live_layer, tensor_field, None) is not None:
+        return None
+
+    source_ref = getattr(live_layer, ref_field, None)
+    if not isinstance(source_ref, LazyActivationRef):
+        return None
+
+    blob_id = _next_bundle_blob_id(used_blob_ids)
+    setattr(scrubbed_layer, tensor_field, BlobRef(blob_id=blob_id, kind=kind))
+    return _FastCopySpec(
+        blob_id=blob_id,
+        kind=kind,
+        label=str(getattr(live_layer, "_streaming_label")),
+        source_ref=source_ref,
+    )
+
+
+def _next_bundle_blob_id(used_blob_ids: set[str]) -> str:
+    """Allocate the next monotonically increasing bundle blob id.
+
+    Parameters
+    ----------
+    used_blob_ids:
+        Set of blob ids already reserved for the destination bundle.
+
+    Returns
+    -------
+    str
+        Newly-allocated zero-padded blob id.
+    """
+
+    next_id = max((int(blob_id) for blob_id in used_blob_ids), default=0) + 1
+    blob_id = f"{next_id:010d}"
+    used_blob_ids.add(blob_id)
+    return blob_id
+
+
+def _load_and_verify_fast_copy_source(
+    model_log: ModelLog,
+    source_bundle_path: Path,
+    *,
+    cache: dict[Path, dict[str, TensorEntry]],
+) -> dict[str, TensorEntry]:
+    """Load and drift-verify one source bundle used for lazy fast-copy.
+
+    Parameters
+    ----------
+    model_log:
+        Model log being resaved.
+    source_bundle_path:
+        Source bundle directory referenced by one lazy tensor ref.
+    cache:
+        Per-save cache keyed by source bundle path.
+
+    Returns
+    -------
+    dict[str, TensorEntry]
+        Source manifest entries indexed by blob id.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the source manifest is missing or has changed since the refs were loaded.
+    """
+
+    if source_bundle_path in cache:
+        return cache[source_bundle_path]
+
+    manifest_path = source_bundle_path / "manifest.json"
+    _reject_symlink_path(manifest_path, context="source manifest")
+    if not manifest_path.exists():
+        raise TorchLensIOError(f"Source bundle manifest not found at {manifest_path}.")
+
+    expected_manifest_sha256 = getattr(model_log, "_source_bundle_manifest_sha256", None)
+    if not isinstance(expected_manifest_sha256, str):
+        raise TorchLensIOError(
+            "source bundle manifest fingerprint is unavailable; materialize refs and retry"
+        )
+    observed_manifest_sha256 = sha256_of_file(manifest_path)
+    if observed_manifest_sha256 != expected_manifest_sha256:
+        raise TorchLensIOError(
+            "source bundle manifest has changed since load; materialize refs and retry"
+        )
+
+    manifest = Manifest.read(manifest_path)
+    manifest_index = {entry.blob_id: entry for entry in manifest.tensors}
+    cache[source_bundle_path] = manifest_index
+    return manifest_index
+
+
+def _fast_copy_tensor_blob(
+    *,
+    tmp_path: Path,
+    fast_copy_spec: _FastCopySpec,
+    manifest_index: dict[str, TensorEntry],
+) -> TensorEntry:
+    """Copy one lazily-backed tensor blob into a new bundle without decoding it.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary destination bundle directory.
+    fast_copy_spec:
+        Fast-copy instruction for the destination field.
+    manifest_index:
+        Source manifest entries indexed by blob id.
+
+    Returns
+    -------
+    TensorEntry
+        Destination manifest entry for the copied blob.
+    """
+
+    source_entry = manifest_index.get(fast_copy_spec.source_ref.blob_id)
+    if source_entry is None:
+        raise TorchLensIOError(f"Manifest is missing blob_id={fast_copy_spec.source_ref.blob_id}.")
+
+    source_blob_path = fast_copy_spec.source_ref.blob_path()
+    _reject_symlink_path(source_blob_path, context="source blob")
+    if not source_blob_path.exists():
+        raise TorchLensIOError(f"Tensor blob not found at {source_blob_path}.")
+
+    observed_sha256 = sha256_of_file(source_blob_path)
+    if observed_sha256 != fast_copy_spec.source_ref.expected_sha256:
+        raise TorchLensIOError(
+            f"blob at {source_blob_path} sha256 mismatch; expected "
+            f"{fast_copy_spec.source_ref.expected_sha256} got {observed_sha256}"
+        )
+
+    relative_path = Path("blobs") / f"{fast_copy_spec.blob_id}.safetensors"
+    destination_blob_path = tmp_path / relative_path
+    shutil.copy2(source_blob_path, destination_blob_path)
+    return TensorEntry(
+        blob_id=fast_copy_spec.blob_id,
+        kind=fast_copy_spec.kind,
+        label=fast_copy_spec.label,
+        relative_path=relative_path.as_posix(),
+        backend=source_entry.backend,
+        shape=list(source_entry.shape),
+        dtype=source_entry.dtype,
+        device_at_save=source_entry.device_at_save,
+        layout=source_entry.layout,
+        bytes=source_entry.bytes,
+        sha256=source_entry.sha256,
     )
 
 
@@ -526,6 +830,109 @@ def _replace_skipped_blob_refs(value: Any, skipped_blob_ids: set[str]) -> Any:
         if field_name == "gradient" and replaced_value is None and hasattr(value, "has_gradient"):
             value.has_gradient = False
     return value
+
+
+def _raise_for_unmaterialized_nested_blob_refs(model_log: ModelLog) -> None:
+    """Reject resave attempts that still contain nested lazy ``BlobRef`` objects.
+
+    Parameters
+    ----------
+    model_log:
+        Model log about to be scrubbed for portable save.
+
+    Raises
+    ------
+    TorchLensIOError
+        If any nested portable blob refs remain in blob-recursive fields.
+    """
+
+    if _contains_nested_blob_refs(model_log, seen=set()):
+        raise TorchLensIOError(
+            "ModelLog contains unmaterialized nested blob references. "
+            "Call torchlens.rehydrate_nested(model_log) before saving."
+        )
+
+
+def _contains_nested_blob_refs(value: Any, *, seen: set[int]) -> bool:
+    """Return whether any blob-recursive field still contains live ``BlobRef`` values.
+
+    Parameters
+    ----------
+    value:
+        Object graph node to inspect.
+    seen:
+        Identity set used to avoid infinite recursion on shared objects.
+
+    Returns
+    -------
+    bool
+        ``True`` when a nested ``BlobRef`` is still present in a blob-recursive field.
+    """
+
+    if isinstance(value, (str, int, float, bool, type(None), torch.dtype, torch.device)):
+        return False
+    if isinstance(value, BlobRef):
+        return False
+    if isinstance(value, list):
+        return any(_contains_nested_blob_refs(item, seen=seen) for item in value)
+    if isinstance(value, tuple):
+        return any(_contains_nested_blob_refs(item, seen=seen) for item in value)
+    if isinstance(value, OrderedDict):
+        return any(_contains_nested_blob_refs(item, seen=seen) for item in value.values())
+    if isinstance(value, defaultdict):
+        return any(_contains_nested_blob_refs(item, seen=seen) for item in value.values())
+    if isinstance(value, dict):
+        return any(_contains_nested_blob_refs(item, seen=seen) for item in value.values())
+    if isinstance(value, set):
+        return any(_contains_nested_blob_refs(item, seen=seen) for item in value)
+
+    spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
+    if spec is None:
+        return False
+
+    obj_id = id(value)
+    if obj_id in seen:
+        return False
+    seen.add(obj_id)
+
+    for field_name, field_value in vars(value).items():
+        policy = spec.get(field_name)
+        if policy == FieldPolicy.BLOB_RECURSIVE and _container_contains_blob_ref(field_value):
+            return True
+        if policy == FieldPolicy.KEEP and _contains_nested_blob_refs(field_value, seen=seen):
+            return True
+    return False
+
+
+def _container_contains_blob_ref(value: Any) -> bool:
+    """Return whether a nested container still contains a ``BlobRef`` leaf.
+
+    Parameters
+    ----------
+    value:
+        Nested container or leaf value to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` when any descendant is a ``BlobRef``.
+    """
+
+    if isinstance(value, BlobRef):
+        return True
+    if isinstance(value, list):
+        return any(_container_contains_blob_ref(item) for item in value)
+    if isinstance(value, tuple):
+        return any(_container_contains_blob_ref(item) for item in value)
+    if isinstance(value, OrderedDict):
+        return any(_container_contains_blob_ref(item) for item in value.values())
+    if isinstance(value, defaultdict):
+        return any(_container_contains_blob_ref(item) for item in value.values())
+    if isinstance(value, dict):
+        return any(_container_contains_blob_ref(item) for item in value.values())
+    if isinstance(value, set):
+        return any(_container_contains_blob_ref(item) for item in value)
+    return False
 
 
 def _check_unknown_blob_entries(manifest: Manifest, blobs_path: Path) -> None:

--- a/torchlens/_io/bundle.py
+++ b/torchlens/_io/bundle.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+from safetensors import SafetensorError
 from safetensors.torch import load_file, save_file
 
 from . import BlobRef, FieldPolicy, IO_FORMAT_VERSION, TorchLensIOError
@@ -1070,6 +1071,8 @@ def _load_safetensors_file(
         raise TorchLensIOError(
             "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
         ) from exc
+    except (OSError, SafetensorError, ValueError) as exc:
+        raise TorchLensIOError(f"Failed to read safetensors blob at {blob_path}.") from exc
 
 
 def _reject_symlink_path(path: Path, *, context: str) -> None:

--- a/torchlens/_io/bundle.py
+++ b/torchlens/_io/bundle.py
@@ -29,6 +29,7 @@ from safetensors.torch import load_file, save_file
 from . import BlobRef, FieldPolicy, IO_FORMAT_VERSION, TorchLensIOError
 from .lazy import LazyActivationRef
 from .manifest import Manifest, TensorEntry, enforce_version_policy, sha256_of_file
+from .paths import resolve_bundle_blob_path
 from .rehydrate import rehydrate_model_log
 from .scrub import scrub_for_save
 from .tensor_policy import FailReason, Ok, SkipReason, is_supported_for_save
@@ -111,12 +112,16 @@ def save(
     >>> loaded = tl.load("demo_bundle")
     >>> loaded["linear_1_1"].activation.shape
     torch.Size([2, 3])
+
+    Warnings
+    --------
+    Portable bundles contain a pickle file. Only load bundles from trusted
+    sources. Loading an untrusted bundle can execute arbitrary code.
     """
 
     bundle_path = Path(path)
     _reject_symlink_path(bundle_path, context="save target")
     _validate_activation_postfunc_outputs(model_log, include_activations=include_activations)
-    _raise_for_unmaterialized_nested_blob_refs(model_log)
 
     backup_path: Path | None = None
     tmp_path = _make_tmp_bundle_path(bundle_path)
@@ -137,6 +142,10 @@ def save(
             include_gradients=include_gradients,
             include_captured_args=include_captured_args,
             include_rng_states=include_rng_states,
+        )
+        _raise_for_unmaterialized_nested_blob_refs(
+            scrubbed_state,
+            allowed_blob_ids={blob_id for blob_id, _, _, _ in blob_specs},
         )
         fast_copy_specs = _attach_fast_copy_specs(
             model_log,
@@ -249,6 +258,11 @@ def load(
     >>> activation = layer.materialize_activation()
     >>> activation.shape
     torch.Size([2, 3])
+
+    Warnings
+    --------
+    Portable bundles contain a pickle file. Only load bundles from trusted
+    sources. Loading an untrusted bundle can execute arbitrary code.
     """
 
     bundle_path = Path(path)
@@ -263,8 +277,8 @@ def load(
     try:
         manifest = Manifest.read(manifest_path)
         enforce_version_policy(manifest)
-        _check_unknown_blob_entries(manifest, blobs_path)
         _validate_manifest_blob_paths(manifest, bundle_path)
+        _check_unknown_blob_entries(manifest, blobs_path)
         if not lazy:
             _eager_verify_blob_payloads(manifest, bundle_path, map_location)
 
@@ -672,7 +686,10 @@ def _fast_copy_tensor_blob(
     if source_entry is None:
         raise TorchLensIOError(f"Manifest is missing blob_id={fast_copy_spec.source_ref.blob_id}.")
 
-    source_blob_path = fast_copy_spec.source_ref.blob_path()
+    source_blob_path = resolve_bundle_blob_path(
+        fast_copy_spec.source_ref.source_bundle_path,
+        source_entry.relative_path,
+    )
     _reject_symlink_path(source_blob_path, context="source blob")
     if not source_blob_path.exists():
         raise TorchLensIOError(f"Tensor blob not found at {source_blob_path}.")
@@ -874,13 +891,21 @@ def _replace_skipped_blob_refs(value: Any, skipped_blob_ids: set[str]) -> Any:
     return value
 
 
-def _raise_for_unmaterialized_nested_blob_refs(model_log: ModelLog) -> None:
+def _raise_for_unmaterialized_nested_blob_refs(
+    value: Any,
+    *,
+    allowed_blob_ids: set[str],
+) -> None:
     """Reject resave attempts that still contain nested lazy ``BlobRef`` objects.
 
     Parameters
     ----------
-    model_log:
-        Model log about to be scrubbed for portable save.
+    value:
+        Scrubbed portable state about to be written.
+    allowed_blob_ids:
+        Blob ids created during the current scrub pass. Any surviving nested
+        ``BlobRef`` outside this set came from a prior lazy load and must be
+        materialized before resave.
 
     Raises
     ------
@@ -888,14 +913,19 @@ def _raise_for_unmaterialized_nested_blob_refs(model_log: ModelLog) -> None:
         If any nested portable blob refs remain in blob-recursive fields.
     """
 
-    if _contains_nested_blob_refs(model_log, seen=set()):
+    if _contains_nested_blob_refs(value, seen=set(), allowed_blob_ids=allowed_blob_ids):
         raise TorchLensIOError(
             "ModelLog contains unmaterialized nested blob references. "
             "Call torchlens.rehydrate_nested(model_log) before saving."
         )
 
 
-def _contains_nested_blob_refs(value: Any, *, seen: set[int]) -> bool:
+def _contains_nested_blob_refs(
+    value: Any,
+    *,
+    seen: set[int],
+    allowed_blob_ids: set[str],
+) -> bool:
     """Return whether any blob-recursive field still contains live ``BlobRef`` values.
 
     Parameters
@@ -914,19 +944,37 @@ def _contains_nested_blob_refs(value: Any, *, seen: set[int]) -> bool:
     if isinstance(value, (str, int, float, bool, type(None), torch.dtype, torch.device)):
         return False
     if isinstance(value, BlobRef):
-        return False
+        return value.blob_id not in allowed_blob_ids
     if isinstance(value, list):
-        return any(_contains_nested_blob_refs(item, seen=seen) for item in value)
+        return any(
+            _contains_nested_blob_refs(item, seen=seen, allowed_blob_ids=allowed_blob_ids)
+            for item in value
+        )
     if isinstance(value, tuple):
-        return any(_contains_nested_blob_refs(item, seen=seen) for item in value)
+        return any(
+            _contains_nested_blob_refs(item, seen=seen, allowed_blob_ids=allowed_blob_ids)
+            for item in value
+        )
     if isinstance(value, OrderedDict):
-        return any(_contains_nested_blob_refs(item, seen=seen) for item in value.values())
+        return any(
+            _contains_nested_blob_refs(item, seen=seen, allowed_blob_ids=allowed_blob_ids)
+            for item in value.values()
+        )
     if isinstance(value, defaultdict):
-        return any(_contains_nested_blob_refs(item, seen=seen) for item in value.values())
+        return any(
+            _contains_nested_blob_refs(item, seen=seen, allowed_blob_ids=allowed_blob_ids)
+            for item in value.values()
+        )
     if isinstance(value, dict):
-        return any(_contains_nested_blob_refs(item, seen=seen) for item in value.values())
+        return any(
+            _contains_nested_blob_refs(item, seen=seen, allowed_blob_ids=allowed_blob_ids)
+            for item in value.values()
+        )
     if isinstance(value, set):
-        return any(_contains_nested_blob_refs(item, seen=seen) for item in value)
+        return any(
+            _contains_nested_blob_refs(item, seen=seen, allowed_blob_ids=allowed_blob_ids)
+            for item in value
+        )
 
     spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
     if spec is None:
@@ -939,14 +987,21 @@ def _contains_nested_blob_refs(value: Any, *, seen: set[int]) -> bool:
 
     for field_name, field_value in vars(value).items():
         policy = spec.get(field_name)
-        if policy == FieldPolicy.BLOB_RECURSIVE and _container_contains_blob_ref(field_value):
+        if policy == FieldPolicy.BLOB_RECURSIVE and _container_contains_blob_ref(
+            field_value,
+            allowed_blob_ids=allowed_blob_ids,
+        ):
             return True
-        if policy == FieldPolicy.KEEP and _contains_nested_blob_refs(field_value, seen=seen):
+        if policy == FieldPolicy.KEEP and _contains_nested_blob_refs(
+            field_value,
+            seen=seen,
+            allowed_blob_ids=allowed_blob_ids,
+        ):
             return True
     return False
 
 
-def _container_contains_blob_ref(value: Any) -> bool:
+def _container_contains_blob_ref(value: Any, *, allowed_blob_ids: set[str]) -> bool:
     """Return whether a nested container still contains a ``BlobRef`` leaf.
 
     Parameters
@@ -961,19 +1016,34 @@ def _container_contains_blob_ref(value: Any) -> bool:
     """
 
     if isinstance(value, BlobRef):
-        return True
+        return value.blob_id not in allowed_blob_ids
     if isinstance(value, list):
-        return any(_container_contains_blob_ref(item) for item in value)
+        return any(
+            _container_contains_blob_ref(item, allowed_blob_ids=allowed_blob_ids) for item in value
+        )
     if isinstance(value, tuple):
-        return any(_container_contains_blob_ref(item) for item in value)
+        return any(
+            _container_contains_blob_ref(item, allowed_blob_ids=allowed_blob_ids) for item in value
+        )
     if isinstance(value, OrderedDict):
-        return any(_container_contains_blob_ref(item) for item in value.values())
+        return any(
+            _container_contains_blob_ref(item, allowed_blob_ids=allowed_blob_ids)
+            for item in value.values()
+        )
     if isinstance(value, defaultdict):
-        return any(_container_contains_blob_ref(item) for item in value.values())
+        return any(
+            _container_contains_blob_ref(item, allowed_blob_ids=allowed_blob_ids)
+            for item in value.values()
+        )
     if isinstance(value, dict):
-        return any(_container_contains_blob_ref(item) for item in value.values())
+        return any(
+            _container_contains_blob_ref(item, allowed_blob_ids=allowed_blob_ids)
+            for item in value.values()
+        )
     if isinstance(value, set):
-        return any(_container_contains_blob_ref(item) for item in value)
+        return any(
+            _container_contains_blob_ref(item, allowed_blob_ids=allowed_blob_ids) for item in value
+        )
     return False
 
 
@@ -995,6 +1065,23 @@ def _check_unknown_blob_entries(manifest: Manifest, blobs_path: Path) -> None:
             raise TorchLensIOError(f"Refusing to load symlinked blob path {child}.")
         actual_names.add(child.name)
     extra_names = sorted(actual_names - expected_names)
+    if not extra_names:
+        return
+
+    expected_sha256s = {entry.sha256 for entry in manifest.tensors}
+    colliding_extra_names: list[str] = []
+    for extra_name in extra_names:
+        extra_path = blobs_path / extra_name
+        extra_sha256 = sha256_of_file(extra_path)
+        if extra_sha256 in expected_sha256s:
+            colliding_extra_names.append(extra_name)
+
+    if colliding_extra_names:
+        raise TorchLensIOError(
+            "Bundle contains unreferenced blob files whose sha256 matches a manifest entry: "
+            f"{', '.join(colliding_extra_names)}."
+        )
+
     if extra_names:
         warnings.warn(
             f"Bundle contains unreferenced extra files in blobs/: {', '.join(extra_names)}.",
@@ -1021,7 +1108,7 @@ def _validate_manifest_blob_paths(manifest: Manifest, bundle_path: Path) -> None
 
     missing_blob_ids: list[str] = []
     for entry in manifest.tensors:
-        blob_path = bundle_path / entry.relative_path
+        blob_path = resolve_bundle_blob_path(bundle_path, entry.relative_path)
         if blob_path.is_symlink():
             raise TorchLensIOError(f"Refusing to load symlinked blob path {blob_path}.")
         if not blob_path.exists():
@@ -1051,7 +1138,7 @@ def _eager_verify_blob_payloads(
     """
 
     for entry in manifest.tensors:
-        blob_path = bundle_path / entry.relative_path
+        blob_path = resolve_bundle_blob_path(bundle_path, entry.relative_path)
         observed_sha256 = sha256_of_file(blob_path)
         if observed_sha256 != entry.sha256:
             raise TorchLensIOError(f"Checksum mismatch for blob_id={entry.blob_id} at {blob_path}.")

--- a/torchlens/_io/bundle.py
+++ b/torchlens/_io/bundle.py
@@ -1,0 +1,768 @@
+"""Portable directory-bundle save/load helpers for TorchLens model logs."""
+
+from __future__ import annotations
+
+import os
+import platform
+import pickle
+import shutil
+import sys
+import uuid
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file, save_file
+
+from . import BlobRef, IO_FORMAT_VERSION, TorchLensIOError
+from .manifest import Manifest, TensorEntry, enforce_version_policy, sha256_of_file
+from .rehydrate import rehydrate_model_log
+from .scrub import scrub_for_save
+from .tensor_policy import FailReason, Ok, SkipReason, is_supported_for_save
+from .. import __version__ as TORCHLENS_VERSION
+from ..data_classes.model_log import ModelLog
+
+PARTIAL_SENTINEL = "PARTIAL"
+REASON_SENTINEL = "REASON.txt"
+_BLOB_TENSOR_KEY = "data"
+
+
+def save(
+    model_log: ModelLog,
+    path: str | Path,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,
+    include_captured_args: bool = False,
+    include_rng_states: bool = False,
+    strict: bool = True,
+    overwrite: bool = False,
+) -> None:
+    """Persist a ``ModelLog`` into a portable TorchLens directory bundle.
+
+    Parameters
+    ----------
+    model_log:
+        Completed model log to save.
+    path:
+        Output bundle directory path.
+    include_activations:
+        Whether activations should be saved as blobs.
+    include_gradients:
+        Whether gradients should be saved as blobs.
+    include_captured_args:
+        Whether captured args/kwargs and related tensor payloads should be saved.
+    include_rng_states:
+        Whether per-layer RNG state tensors should be saved.
+    strict:
+        Whether unsupported tensors should abort the save instead of being skipped.
+    overwrite:
+        Whether an existing bundle at ``path`` may be replaced.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the bundle cannot be created or contains unsupported state.
+    """
+
+    bundle_path = Path(path)
+    _reject_symlink_path(bundle_path, context="save target")
+    _validate_activation_postfunc_outputs(model_log, include_activations=include_activations)
+
+    backup_path: Path | None = None
+    tmp_path = _make_tmp_bundle_path(bundle_path)
+    try:
+        if bundle_path.exists():
+            if not overwrite:
+                raise FileExistsError(f"Bundle path already exists: {bundle_path}")
+            backup_path = _make_backup_path(bundle_path)
+            bundle_path.rename(backup_path)
+
+        tmp_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.mkdir()
+        (tmp_path / "blobs").mkdir()
+
+        scrubbed_state, blob_specs = _scrub_model_log_for_bundle(
+            model_log,
+            include_activations=include_activations,
+            include_gradients=include_gradients,
+            include_captured_args=include_captured_args,
+            include_rng_states=include_rng_states,
+        )
+
+        tensor_entries: list[TensorEntry] = []
+        unsupported_tensors: list[dict[str, str]] = []
+        skipped_blob_ids: set[str] = set()
+
+        for blob_id, tensor, kind, label in blob_specs:
+            decision = is_supported_for_save(tensor, strict=strict)
+            if isinstance(decision, Ok):
+                tensor_entries.append(
+                    _write_tensor_blob(
+                        tmp_path=tmp_path, blob_id=blob_id, tensor=tensor, kind=kind, label=label
+                    )
+                )
+                continue
+            if isinstance(decision, FailReason):
+                raise TorchLensIOError(
+                    f"Unsupported tensor for bundle save at {label} ({kind}): {decision.text}"
+                )
+            unsupported_tensors.append({"label": label, "kind": kind, "reason": decision.text})
+            skipped_blob_ids.add(blob_id)
+
+        if skipped_blob_ids:
+            _apply_skipped_blobs_to_scrubbed_state(scrubbed_state, skipped_blob_ids)
+
+        manifest = _build_manifest(
+            model_log=model_log,
+            tensor_entries=tensor_entries,
+            unsupported_tensors=unsupported_tensors,
+        )
+        manifest.write(tmp_path / "manifest.json")
+        with (tmp_path / "metadata.pkl").open("wb") as handle:
+            pickle.dump(scrubbed_state, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+        tmp_path.rename(bundle_path)
+        if backup_path is not None:
+            _remove_path(backup_path)
+    except TorchLensIOError:
+        _mark_partial(tmp_path)
+        if backup_path is not None and not bundle_path.exists() and backup_path.exists():
+            _restore_backup(backup_path, bundle_path)
+        raise
+    except (ImportError, OSError, ValueError, pickle.PickleError) as exc:
+        _mark_partial(tmp_path, reason=str(exc))
+        if backup_path is not None and not bundle_path.exists() and backup_path.exists():
+            _restore_backup(backup_path, bundle_path)
+        raise TorchLensIOError(f"Failed to save bundle at {bundle_path}.") from exc
+
+
+def load(
+    path: str | Path,
+    *,
+    lazy: bool = False,
+    map_location: str | torch.device = "cpu",
+    materialize_nested: bool = True,
+) -> ModelLog:
+    """Load a portable TorchLens bundle into a ``ModelLog``.
+
+    Parameters
+    ----------
+    path:
+        Bundle directory path.
+    lazy:
+        Whether direct activation/gradient blobs should remain lazy placeholders.
+    map_location:
+        Target device for eager tensor materialization.
+    materialize_nested:
+        Whether nested blob refs in captured args and RNG states should be
+        materialized when ``lazy=True``.
+
+    Returns
+    -------
+    ModelLog
+        Rehydrated model log.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the bundle is invalid, corrupt, or incompatible with this runtime.
+    """
+
+    bundle_path = Path(path)
+    _reject_symlink_path(bundle_path, context="bundle path")
+    manifest_path = bundle_path / "manifest.json"
+    metadata_path = bundle_path / "metadata.pkl"
+    blobs_path = bundle_path / "blobs"
+    _reject_symlink_path(manifest_path, context="manifest")
+    _reject_symlink_path(metadata_path, context="metadata")
+    _reject_symlink_path(blobs_path, context="blobs directory")
+
+    try:
+        manifest = Manifest.read(manifest_path)
+        enforce_version_policy(manifest)
+        _check_unknown_blob_entries(manifest, blobs_path)
+        _validate_manifest_blob_paths(manifest, bundle_path)
+        if not lazy:
+            _eager_verify_blob_payloads(manifest, bundle_path, map_location)
+
+        python_major_mismatch = _python_major_mismatch(manifest)
+        with metadata_path.open("rb") as handle:
+            scrubbed_state = pickle.load(handle)
+    except TorchLensIOError:
+        raise
+    except (pickle.UnpicklingError, EOFError) as exc:
+        hint = ""
+        if python_major_mismatch:
+            hint = (
+                f" Bundle was written with python_version={manifest.python_version} but runtime is "
+                f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}."
+            )
+        raise TorchLensIOError(
+            f"Failed to load bundle metadata from {metadata_path}.{hint}"
+        ) from exc
+    except (OSError, AttributeError, EOFError, ImportError, ValueError) as exc:
+        raise TorchLensIOError(f"Failed to load bundle at {bundle_path}.") from exc
+
+    model_log = rehydrate_model_log(
+        scrubbed_state,
+        manifest,
+        bundle_path,
+        lazy=lazy,
+        map_location=map_location,
+        materialize_nested=materialize_nested,
+    )
+    setattr(model_log, "_loaded_from_bundle", True)
+    setattr(model_log, "_source_bundle_manifest_sha256", sha256_of_file(manifest_path))
+    return model_log
+
+
+def cleanup_tmp(path: str | Path, *, force: bool = False) -> list[Path]:
+    """Remove leftover sibling temp bundle directories for one target path.
+
+    Parameters
+    ----------
+    path:
+        Final bundle path whose ``.tmp.*`` siblings should be inspected.
+    force:
+        Whether temp dirs without a ``PARTIAL`` sentinel should also be removed.
+
+    Returns
+    -------
+    list[Path]
+        Removed temp directory paths.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the requested target path or candidate temp dirs are symlinks.
+    """
+
+    bundle_path = Path(path)
+    _reject_symlink_path(bundle_path, context="cleanup target")
+    removed: list[Path] = []
+    pattern = f"{bundle_path.name}.tmp.*"
+    for candidate in bundle_path.parent.glob(pattern):
+        if candidate.is_symlink():
+            raise TorchLensIOError(f"Refusing to clean symlink temp directory {candidate}.")
+        if not candidate.is_dir():
+            continue
+        if force or (candidate / PARTIAL_SENTINEL).exists():
+            shutil.rmtree(candidate)
+            removed.append(candidate)
+            continue
+        warnings.warn(
+            f"Leaving non-partial temp directory {candidate} in place; pass force=True to remove it.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return removed
+
+
+def _scrub_model_log_for_bundle(
+    model_log: ModelLog,
+    *,
+    include_activations: bool,
+    include_gradients: bool,
+    include_captured_args: bool,
+    include_rng_states: bool,
+) -> tuple[dict[str, Any], list[tuple[str, torch.Tensor, str, str]]]:
+    """Scrub a model log while excluding transient load-only private attrs.
+
+    Parameters
+    ----------
+    model_log:
+        Model log being saved.
+    include_activations:
+        Whether activations should be blobified.
+    include_gradients:
+        Whether gradients should be blobified.
+    include_captured_args:
+        Whether nested captured args should be blobified.
+    include_rng_states:
+        Whether nested RNG states should be blobified.
+
+    Returns
+    -------
+    tuple[dict[str, Any], list[tuple[str, torch.Tensor, str, str]]]
+        Scrubbed metadata and blob specs.
+    """
+
+    transient_attrs = {}
+    for attr_name in ("_loaded_from_bundle", "_source_bundle_manifest_sha256"):
+        if hasattr(model_log, attr_name):
+            transient_attrs[attr_name] = getattr(model_log, attr_name)
+            delattr(model_log, attr_name)
+    try:
+        return scrub_for_save(
+            model_log,
+            include_activations=include_activations,
+            include_gradients=include_gradients,
+            include_captured_args=include_captured_args,
+            include_rng_states=include_rng_states,
+        )
+    finally:
+        for attr_name, attr_value in transient_attrs.items():
+            setattr(model_log, attr_name, attr_value)
+
+
+def _write_tensor_blob(
+    *,
+    tmp_path: Path,
+    blob_id: str,
+    tensor: torch.Tensor,
+    kind: str,
+    label: str,
+) -> TensorEntry:
+    """Write one supported tensor blob and build its manifest entry.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary bundle directory root.
+    blob_id:
+        Opaque blob identifier.
+    tensor:
+        Tensor payload to persist.
+    kind:
+        Logical tensor kind.
+    label:
+        Human-readable TorchLens layer label.
+
+    Returns
+    -------
+    TensorEntry
+        Manifest tensor entry for the written blob.
+    """
+
+    contiguous_tensor = tensor.contiguous()
+    relative_path = Path("blobs") / f"{blob_id}.safetensors"
+    blob_path = tmp_path / relative_path
+    save_file({_BLOB_TENSOR_KEY: contiguous_tensor}, str(blob_path))
+    return TensorEntry(
+        blob_id=blob_id,
+        kind=kind,
+        label=label,
+        relative_path=relative_path.as_posix(),
+        backend="safetensors",
+        shape=[int(dim) for dim in contiguous_tensor.shape],
+        dtype=str(contiguous_tensor.dtype).replace("torch.", ""),
+        device_at_save=str(tensor.device),
+        layout=str(contiguous_tensor.layout).replace("torch.", ""),
+        bytes=int(contiguous_tensor.numel() * contiguous_tensor.element_size()),
+        sha256=sha256_of_file(blob_path),
+    )
+
+
+def _build_manifest(
+    *,
+    model_log: ModelLog,
+    tensor_entries: list[TensorEntry],
+    unsupported_tensors: list[dict[str, str]],
+) -> Manifest:
+    """Create a manifest instance for a finished bundle save.
+
+    Parameters
+    ----------
+    model_log:
+        Source model log.
+    tensor_entries:
+        Persisted tensor entries.
+    unsupported_tensors:
+        Unsupported tensor records accumulated under ``strict=False``.
+
+    Returns
+    -------
+    Manifest
+        Fully-populated bundle manifest.
+    """
+
+    n_activation_blobs = sum(1 for entry in tensor_entries if entry.kind == "activation")
+    n_gradient_blobs = sum(1 for entry in tensor_entries if entry.kind == "gradient")
+    n_auxiliary_blobs = len(tensor_entries) - n_activation_blobs - n_gradient_blobs
+    return Manifest(
+        io_format_version=IO_FORMAT_VERSION,
+        torchlens_version=TORCHLENS_VERSION,
+        torch_version=torch.__version__,
+        python_version=(
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        ),
+        platform=f"{platform.system().lower()}-{platform.machine().lower()}",
+        created_at=datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace(
+            "+00:00",
+            "Z",
+        ),
+        bundle_format="directory",
+        n_layers=len(model_log.layer_list),
+        n_activation_blobs=n_activation_blobs,
+        n_gradient_blobs=n_gradient_blobs,
+        n_auxiliary_blobs=n_auxiliary_blobs,
+        tensors=tensor_entries,
+        unsupported_tensors=unsupported_tensors,
+    )
+
+
+def _validate_activation_postfunc_outputs(
+    model_log: ModelLog,
+    *,
+    include_activations: bool,
+) -> None:
+    """Reject portable saves when activation postprocessing produced non-tensors.
+
+    Parameters
+    ----------
+    model_log:
+        Model log being saved.
+    include_activations:
+        Whether activation fields will be saved.
+
+    Raises
+    ------
+    TorchLensIOError
+        If a saved activation is not a plain tensor.
+    """
+
+    if not include_activations or getattr(model_log, "activation_postfunc", None) is None:
+        return
+    for layer in model_log.layer_list:
+        if not getattr(layer, "has_saved_activations", False):
+            continue
+        if layer.activation is None:
+            continue
+        if not isinstance(layer.activation, torch.Tensor):
+            raise TorchLensIOError(
+                "Portable bundle save requires activation_postfunc outputs to be torch.Tensor "
+                f"instances, but layer {layer.layer_label} produced {type(layer.activation).__name__}."
+            )
+
+
+def _apply_skipped_blobs_to_scrubbed_state(
+    scrubbed_state: dict[str, Any],
+    skipped_blob_ids: set[str],
+) -> None:
+    """Replace skipped blob refs with ``None`` in scrubbed metadata.
+
+    Parameters
+    ----------
+    scrubbed_state:
+        Scrubbed metadata dict produced by ``scrub_for_save``.
+    skipped_blob_ids:
+        Blob ids skipped under ``strict=False``.
+    """
+
+    for field_name, field_value in list(scrubbed_state.items()):
+        scrubbed_state[field_name] = _replace_skipped_blob_refs(field_value, skipped_blob_ids)
+
+    layer_list = scrubbed_state.get("layer_list")
+    if isinstance(layer_list, list):
+        activation_labels = [
+            layer.layer_label
+            for layer in layer_list
+            if bool(getattr(layer, "has_saved_activations", False))
+        ]
+        gradient_labels = [
+            layer.layer_label for layer in layer_list if bool(getattr(layer, "has_gradient", False))
+        ]
+        scrubbed_state["layers_with_saved_activations"] = activation_labels
+        scrubbed_state["layers_with_saved_gradients"] = gradient_labels
+        scrubbed_state["num_tensors_saved"] = len(activation_labels)
+        scrubbed_state["saved_activation_memory"] = sum(
+            int(getattr(layer, "tensor_memory", 0) or 0)
+            for layer in layer_list
+            if bool(getattr(layer, "has_saved_activations", False))
+        )
+        scrubbed_state["has_gradients"] = bool(gradient_labels)
+
+
+def _replace_skipped_blob_refs(value: Any, skipped_blob_ids: set[str]) -> Any:
+    """Walk a scrubbed object graph and null out selected blob refs.
+
+    Parameters
+    ----------
+    value:
+        Scrubbed value to inspect.
+    skipped_blob_ids:
+        Blob ids skipped under ``strict=False``.
+
+    Returns
+    -------
+    Any
+        Value with matching ``BlobRef`` instances replaced by ``None``.
+    """
+
+    if isinstance(value, BlobRef):
+        if value.blob_id in skipped_blob_ids:
+            return None
+        return value
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            value[index] = _replace_skipped_blob_refs(item, skipped_blob_ids)
+        return value
+    if isinstance(value, tuple):
+        return tuple(_replace_skipped_blob_refs(item, skipped_blob_ids) for item in value)
+    if isinstance(value, dict):
+        for key, item in list(value.items()):
+            value[key] = _replace_skipped_blob_refs(item, skipped_blob_ids)
+        return value
+
+    spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
+    if spec is None:
+        return value
+
+    for field_name, field_value in list(vars(value).items()):
+        replaced_value = _replace_skipped_blob_refs(field_value, skipped_blob_ids)
+        setattr(value, field_name, replaced_value)
+        if (
+            field_name == "activation"
+            and replaced_value is None
+            and hasattr(value, "has_saved_activations")
+        ):
+            value.has_saved_activations = False
+        if field_name == "gradient" and replaced_value is None and hasattr(value, "has_gradient"):
+            value.has_gradient = False
+    return value
+
+
+def _check_unknown_blob_entries(manifest: Manifest, blobs_path: Path) -> None:
+    """Warn when ``blobs/`` contains files that are not referenced by the manifest.
+
+    Parameters
+    ----------
+    manifest:
+        Parsed bundle manifest.
+    blobs_path:
+        Bundle ``blobs/`` directory path.
+    """
+
+    expected_names = {Path(entry.relative_path).name for entry in manifest.tensors}
+    actual_names: set[str] = set()
+    for child in blobs_path.iterdir():
+        if child.is_symlink():
+            raise TorchLensIOError(f"Refusing to load symlinked blob path {child}.")
+        actual_names.add(child.name)
+    extra_names = sorted(actual_names - expected_names)
+    if extra_names:
+        warnings.warn(
+            f"Bundle contains unreferenced extra files in blobs/: {', '.join(extra_names)}.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def _validate_manifest_blob_paths(manifest: Manifest, bundle_path: Path) -> None:
+    """Ensure every manifest tensor entry points at a real non-symlink blob file.
+
+    Parameters
+    ----------
+    manifest:
+        Parsed bundle manifest.
+    bundle_path:
+        Bundle directory root.
+
+    Raises
+    ------
+    TorchLensIOError
+        If any referenced blob is missing or symlinked.
+    """
+
+    missing_blob_ids: list[str] = []
+    for entry in manifest.tensors:
+        blob_path = bundle_path / entry.relative_path
+        if blob_path.is_symlink():
+            raise TorchLensIOError(f"Refusing to load symlinked blob path {blob_path}.")
+        if not blob_path.exists():
+            missing_blob_ids.append(entry.blob_id)
+    if missing_blob_ids:
+        raise TorchLensIOError(
+            "Bundle manifest references missing blob files for blob_id(s): "
+            f"{', '.join(missing_blob_ids)}."
+        )
+
+
+def _eager_verify_blob_payloads(
+    manifest: Manifest,
+    bundle_path: Path,
+    map_location: str | torch.device,
+) -> None:
+    """Eagerly checksum and decode every blob for ``lazy=False`` loads.
+
+    Parameters
+    ----------
+    manifest:
+        Parsed bundle manifest.
+    bundle_path:
+        Bundle directory root.
+    map_location:
+        Device passed through to ``safetensors`` decoding.
+    """
+
+    for entry in manifest.tensors:
+        blob_path = bundle_path / entry.relative_path
+        observed_sha256 = sha256_of_file(blob_path)
+        if observed_sha256 != entry.sha256:
+            raise TorchLensIOError(f"Checksum mismatch for blob_id={entry.blob_id} at {blob_path}.")
+        tensor_map = _load_safetensors_file(blob_path, map_location)
+        if _BLOB_TENSOR_KEY not in tensor_map:
+            raise TorchLensIOError(
+                f"Blob {blob_path} does not contain the expected {_BLOB_TENSOR_KEY!r} tensor entry."
+            )
+
+
+def _python_major_mismatch(manifest: Manifest) -> bool:
+    """Return whether the manifest's Python major version differs from runtime.
+
+    Parameters
+    ----------
+    manifest:
+        Parsed bundle manifest.
+
+    Returns
+    -------
+    bool
+        True when manifest and runtime major versions differ.
+    """
+
+    try:
+        return int(manifest.python_version.split(".", maxsplit=1)[0]) != sys.version_info.major
+    except ValueError:
+        return False
+
+
+def _load_safetensors_file(
+    blob_path: Path,
+    map_location: str | torch.device,
+) -> dict[str, torch.Tensor]:
+    """Load one safetensors blob with a TorchLens-specific install hint.
+
+    Parameters
+    ----------
+    blob_path:
+        Blob file path to load.
+    map_location:
+        Target device for decoded tensors.
+
+    Returns
+    -------
+    dict[str, torch.Tensor]
+        Loaded tensor mapping from the safetensors file.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the safetensors backend is unavailable.
+    """
+
+    try:
+        return load_file(blob_path, device=str(map_location))
+    except ImportError as exc:
+        raise TorchLensIOError(
+            "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
+        ) from exc
+
+
+def _reject_symlink_path(path: Path, *, context: str) -> None:
+    """Raise when a bundle path that must stay local is a symlink.
+
+    Parameters
+    ----------
+    path:
+        Path to validate.
+    context:
+        Human-readable context used in the error message.
+    """
+
+    if path.is_symlink():
+        raise TorchLensIOError(f"Refusing symlinked {context}: {path}.")
+
+
+def _make_tmp_bundle_path(bundle_path: Path) -> Path:
+    """Create the deterministic sibling temp path for one bundle target.
+
+    Parameters
+    ----------
+    bundle_path:
+        Final bundle directory path.
+
+    Returns
+    -------
+    Path
+        Temporary working directory path.
+    """
+
+    return bundle_path.parent / f"{bundle_path.name}.tmp.{uuid.uuid4().hex}"
+
+
+def _make_backup_path(bundle_path: Path) -> Path:
+    """Create the sibling backup path used during overwrite replacement.
+
+    Parameters
+    ----------
+    bundle_path:
+        Final bundle directory path.
+
+    Returns
+    -------
+    Path
+        Backup directory path.
+    """
+
+    return bundle_path.parent / f"{bundle_path.name}.bak.{uuid.uuid4().hex}"
+
+
+def _mark_partial(tmp_path: Path, *, reason: str | None = None) -> None:
+    """Best-effort mark a temp bundle directory as partial after failure.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary bundle directory path.
+    reason:
+        Optional failure reason string to persist alongside the sentinel.
+    """
+
+    try:
+        if tmp_path.exists():
+            (tmp_path / PARTIAL_SENTINEL).write_text("", encoding="utf-8")
+            if reason is not None:
+                (tmp_path / REASON_SENTINEL).write_text(reason, encoding="utf-8")
+    except OSError:
+        return
+
+
+def _remove_path(path: Path) -> None:
+    """Remove a backup path after a successful overwrite replacement.
+
+    Parameters
+    ----------
+    path:
+        Path to remove.
+    """
+
+    if not path.exists():
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _restore_backup(backup_path: Path, bundle_path: Path) -> None:
+    """Best-effort restore an overwritten bundle after a failed replacement.
+
+    Parameters
+    ----------
+    backup_path:
+        Backup path holding the previous bundle contents.
+    bundle_path:
+        Final bundle path to restore.
+    """
+
+    try:
+        backup_path.rename(bundle_path)
+    except OSError:
+        return

--- a/torchlens/_io/lazy.py
+++ b/torchlens/_io/lazy.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 import torch
+from safetensors import SafetensorError
 from safetensors.torch import load_file
 
 from . import TorchLensIOError
@@ -93,7 +94,7 @@ class LazyActivationRef:
             raise TorchLensIOError(
                 "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
             ) from exc
-        except (OSError, ValueError) as exc:
+        except (OSError, SafetensorError, ValueError) as exc:
             raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
 
         if len(tensor_map) != 1:

--- a/torchlens/_io/lazy.py
+++ b/torchlens/_io/lazy.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Literal
 
 import torch
+from safetensors.torch import load_file
+
+from . import TorchLensIOError
+from .manifest import sha256_of_file
 
 
 @dataclass(frozen=True)
@@ -25,6 +29,8 @@ class LazyActivationRef:
         Original device string recorded at save time.
     source_bundle_path:
         Final bundle directory containing the blob.
+    relative_path:
+        Bundle-relative path to the persisted safetensors blob.
     kind:
         Logical tensor kind.
     expected_sha256:
@@ -36,8 +42,20 @@ class LazyActivationRef:
     dtype: torch.dtype
     device_at_save: str
     source_bundle_path: Path
+    relative_path: str
     kind: Literal["activation", "gradient"]
     expected_sha256: str
+
+    def blob_path(self) -> Path:
+        """Return the absolute path to the referenced blob file.
+
+        Returns
+        -------
+        Path
+            Absolute safetensors blob path.
+        """
+
+        return self.source_bundle_path / self.relative_path
 
     def materialize(self, *, map_location: str | torch.device = "cpu") -> torch.Tensor:
         """Materialize the referenced tensor from disk.
@@ -54,8 +72,30 @@ class LazyActivationRef:
 
         Raises
         ------
-        NotImplementedError
-            S6 will wire lazy materialization.
+        TorchLensIOError
+            If the referenced blob is missing, corrupt, or checksum-drifted.
         """
 
-        raise NotImplementedError("S6 will wire this")
+        blob_path = self.blob_path()
+        if not blob_path.exists():
+            raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
+
+        observed_sha256 = sha256_of_file(blob_path)
+        if observed_sha256 != self.expected_sha256:
+            raise TorchLensIOError(
+                f"blob at {blob_path} sha256 mismatch; expected {self.expected_sha256} "
+                f"got {observed_sha256}"
+            )
+
+        try:
+            tensor_map = load_file(blob_path, device=str(map_location))
+        except ImportError as exc:
+            raise TorchLensIOError(
+                "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
+            ) from exc
+        except (OSError, ValueError) as exc:
+            raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
+
+        if len(tensor_map) != 1:
+            raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")
+        return next(iter(tensor_map.values()))

--- a/torchlens/_io/lazy.py
+++ b/torchlens/_io/lazy.py
@@ -1,0 +1,61 @@
+"""Lazy activation reference placeholders for portable TorchLens bundles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import torch
+
+
+@dataclass(frozen=True)
+class LazyActivationRef:
+    """Reference to one activation or gradient blob stored in a bundle.
+
+    Parameters
+    ----------
+    blob_id:
+        Opaque zero-padded blob identifier.
+    shape:
+        Tensor shape recorded at save time.
+    dtype:
+        Tensor dtype recorded at save time.
+    device_at_save:
+        Original device string recorded at save time.
+    source_bundle_path:
+        Final bundle directory containing the blob.
+    kind:
+        Logical tensor kind.
+    expected_sha256:
+        Expected blob checksum from the manifest.
+    """
+
+    blob_id: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    device_at_save: str
+    source_bundle_path: Path
+    kind: Literal["activation", "gradient"]
+    expected_sha256: str
+
+    def materialize(self, *, map_location: str | torch.device = "cpu") -> torch.Tensor:
+        """Materialize the referenced tensor from disk.
+
+        Parameters
+        ----------
+        map_location:
+            Requested target device for the materialized tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Materialized tensor payload.
+
+        Raises
+        ------
+        NotImplementedError
+            S6 will wire lazy materialization.
+        """
+
+        raise NotImplementedError("S6 will wire this")

--- a/torchlens/_io/lazy.py
+++ b/torchlens/_io/lazy.py
@@ -1,4 +1,10 @@
-"""Lazy activation reference placeholders for portable TorchLens bundles."""
+"""Lazy activation reference placeholders for portable TorchLens bundles.
+
+This module defines the lightweight references attached to lazy-loaded
+activations and gradients. Each ref stores the bundle path, tensor metadata,
+and expected checksum so materialization can open a blob file on demand,
+verify integrity, return a tensor, and close the file immediately.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/lazy.py
+++ b/torchlens/_io/lazy.py
@@ -9,15 +9,19 @@ verify integrity, return a tensor, and close the file immediately.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 from typing import Literal
 
 import torch
 from safetensors import SafetensorError
-from safetensors.torch import load_file
+from safetensors.torch import load, load_file
 
 from . import TorchLensIOError
 from .manifest import sha256_of_file
+from .paths import resolve_bundle_blob_path
+
+_INLINE_LOAD_MAX_BYTES = 500 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -62,7 +66,7 @@ class LazyActivationRef:
             Absolute safetensors blob path.
         """
 
-        return self.source_bundle_path / self.relative_path
+        return resolve_bundle_blob_path(self.source_bundle_path, self.relative_path)
 
     def materialize(self, *, map_location: str | torch.device = "cpu") -> torch.Tensor:
         """Materialize the referenced tensor from disk.
@@ -84,25 +88,57 @@ class LazyActivationRef:
         """
 
         blob_path = self.blob_path()
-        if not blob_path.exists():
-            raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
-
-        observed_sha256 = sha256_of_file(blob_path)
-        if observed_sha256 != self.expected_sha256:
-            raise TorchLensIOError(
-                f"blob at {blob_path} sha256 mismatch; expected {self.expected_sha256} "
-                f"got {observed_sha256}"
-            )
 
         try:
-            tensor_map = load_file(blob_path, device=str(map_location))
-        except ImportError as exc:
-            raise TorchLensIOError(
-                "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
-            ) from exc
-        except (OSError, SafetensorError, ValueError) as exc:
-            raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
+            blob_size = blob_path.stat().st_size
+        except FileNotFoundError as exc:
+            raise TorchLensIOError(f"Tensor blob not found at {blob_path}.") from exc
+        except OSError as exc:
+            raise TorchLensIOError(f"Failed to access blob at {blob_path}.") from exc
+
+        if blob_size <= _INLINE_LOAD_MAX_BYTES:
+            try:
+                blob_bytes = blob_path.read_bytes()
+            except FileNotFoundError as exc:
+                raise TorchLensIOError(f"Tensor blob not found at {blob_path}.") from exc
+            except OSError as exc:
+                raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
+
+            observed_sha256 = sha256(blob_bytes).hexdigest()
+            if observed_sha256 != self.expected_sha256:
+                raise TorchLensIOError(
+                    f"blob at {blob_path} sha256 mismatch; expected {self.expected_sha256} "
+                    f"got {observed_sha256}"
+                )
+
+            try:
+                tensor_map = load(blob_bytes)
+            except ImportError as exc:
+                raise TorchLensIOError(
+                    "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
+                ) from exc
+            except (OSError, SafetensorError, ValueError) as exc:
+                raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
+        else:
+            observed_sha256 = sha256_of_file(blob_path)
+            if observed_sha256 != self.expected_sha256:
+                raise TorchLensIOError(
+                    f"blob at {blob_path} sha256 mismatch; expected {self.expected_sha256} "
+                    f"got {observed_sha256}"
+                )
+
+            try:
+                tensor_map = load_file(blob_path, device=str(map_location))
+            except ImportError as exc:
+                raise TorchLensIOError(
+                    "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
+                ) from exc
+            except (OSError, SafetensorError, ValueError) as exc:
+                raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
 
         if len(tensor_map) != 1:
             raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")
-        return next(iter(tensor_map.values()))
+        tensor = next(iter(tensor_map.values()))
+        if blob_size <= _INLINE_LOAD_MAX_BYTES:
+            return tensor.to(map_location)
+        return tensor

--- a/torchlens/_io/manifest.py
+++ b/torchlens/_io/manifest.py
@@ -1,4 +1,11 @@
-"""Portable bundle manifest schema and compatibility policy."""
+"""Portable bundle manifest schema and compatibility policy.
+
+This module defines the authoritative ``manifest.json`` structure for
+TorchLens bundles, along with version and integrity helpers used by both save
+and load paths. It records bundle-level metadata, one entry per persisted
+tensor blob, and the compatibility checks that run before ``metadata.pkl`` is
+trusted.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/manifest.py
+++ b/torchlens/_io/manifest.py
@@ -1,0 +1,545 @@
+"""Portable bundle manifest schema and compatibility policy."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import warnings
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+import torch
+from packaging.version import InvalidVersion, Version
+
+from . import IO_FORMAT_VERSION, TorchLensIOError
+from .. import __version__ as TORCHLENS_VERSION
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TensorEntry:
+    """One persisted tensor blob entry in ``manifest.json``.
+
+    Parameters
+    ----------
+    blob_id:
+        Opaque zero-padded blob identifier.
+    kind:
+        Logical tensor kind, for example ``"activation"``.
+    label:
+        Human-readable TorchLens layer label associated with the blob.
+    relative_path:
+        Bundle-relative path to the blob file.
+    backend:
+        Storage backend name. S4 supports ``"safetensors"`` only.
+    shape:
+        Tensor shape recorded at save time.
+    dtype:
+        Tensor dtype string recorded at save time.
+    device_at_save:
+        Original tensor device string.
+    layout:
+        Tensor layout string recorded at save time.
+    bytes:
+        Persisted tensor byte size after any ``.contiguous()`` conversion.
+    sha256:
+        SHA-256 digest of the written blob file bytes.
+    """
+
+    blob_id: str
+    kind: str
+    label: str
+    relative_path: str
+    backend: str
+    shape: list[int]
+    dtype: str
+    device_at_save: str
+    layout: str
+    bytes: int
+    sha256: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TensorEntry:
+        """Validate and build a ``TensorEntry`` from JSON-decoded data.
+
+        Parameters
+        ----------
+        data:
+            Raw decoded JSON mapping.
+
+        Returns
+        -------
+        TensorEntry
+            Validated tensor entry.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the entry is missing required fields or uses invalid types.
+        """
+
+        required_str_fields = (
+            "blob_id",
+            "kind",
+            "label",
+            "relative_path",
+            "backend",
+            "dtype",
+            "device_at_save",
+            "layout",
+            "sha256",
+        )
+        for field_name in required_str_fields:
+            field_value = data.get(field_name)
+            if not isinstance(field_value, str) or field_value == "":
+                raise TorchLensIOError(
+                    f"Manifest tensor entry must include non-empty string {field_name!r}."
+                )
+
+        shape = data.get("shape")
+        if not isinstance(shape, list) or any(not isinstance(dim, int) for dim in shape):
+            raise TorchLensIOError("Manifest tensor entry 'shape' must be a list of ints.")
+
+        num_bytes = data.get("bytes")
+        if not isinstance(num_bytes, int) or num_bytes < 0:
+            raise TorchLensIOError("Manifest tensor entry 'bytes' must be a non-negative int.")
+
+        return cls(
+            blob_id=data["blob_id"],
+            kind=data["kind"],
+            label=data["label"],
+            relative_path=data["relative_path"],
+            backend=data["backend"],
+            shape=shape,
+            dtype=data["dtype"],
+            device_at_save=data["device_at_save"],
+            layout=data["layout"],
+            bytes=num_bytes,
+            sha256=data["sha256"],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the entry into JSON-serializable data.
+
+        Returns
+        -------
+        dict[str, Any]
+            JSON-ready manifest entry.
+        """
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Structured representation of ``manifest.json`` for portable bundles.
+
+    Parameters
+    ----------
+    io_format_version:
+        Portable I/O schema version for TorchLens bundle metadata.
+    torchlens_version:
+        TorchLens runtime version that wrote the bundle.
+    torch_version:
+        PyTorch runtime version that wrote the bundle.
+    python_version:
+        Python runtime version that wrote the bundle.
+    platform:
+        Platform identifier string recorded at save time.
+    created_at:
+        UTC timestamp string for bundle creation.
+    bundle_format:
+        Bundle container format. S4 supports ``"directory"`` only.
+    n_layers:
+        Total number of ``LayerPassLog`` entries in the saved log.
+    n_activation_blobs:
+        Count of persisted activation tensor blobs.
+    n_gradient_blobs:
+        Count of persisted gradient tensor blobs.
+    n_auxiliary_blobs:
+        Count of persisted non-activation, non-gradient tensor blobs.
+    tensors:
+        Persisted tensor entries.
+    unsupported_tensors:
+        Best-effort records for tensors skipped under ``strict=False``.
+    """
+
+    io_format_version: int
+    torchlens_version: str
+    torch_version: str
+    python_version: str
+    platform: str
+    created_at: str
+    bundle_format: str
+    n_layers: int
+    n_activation_blobs: int
+    n_gradient_blobs: int
+    n_auxiliary_blobs: int
+    tensors: list[TensorEntry]
+    unsupported_tensors: list[dict[str, str]]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Manifest:
+        """Validate decoded JSON data and build a manifest instance.
+
+        Parameters
+        ----------
+        data:
+            Raw JSON-decoded mapping.
+
+        Returns
+        -------
+        Manifest
+            Validated manifest.
+
+        Raises
+        ------
+        TorchLensIOError
+            If required fields are missing or have invalid types.
+        """
+
+        required_int_fields = (
+            "io_format_version",
+            "n_layers",
+            "n_activation_blobs",
+            "n_gradient_blobs",
+            "n_auxiliary_blobs",
+        )
+        required_str_fields = (
+            "torchlens_version",
+            "torch_version",
+            "python_version",
+            "platform",
+            "created_at",
+            "bundle_format",
+        )
+
+        for field_name in required_int_fields:
+            field_value = data.get(field_name)
+            if not isinstance(field_value, int) or field_value < 0:
+                raise TorchLensIOError(
+                    f"Manifest field {field_name!r} must be a non-negative integer."
+                )
+
+        for field_name in required_str_fields:
+            field_value = data.get(field_name)
+            if not isinstance(field_value, str) or field_value == "":
+                raise TorchLensIOError(f"Manifest field {field_name!r} must be a non-empty string.")
+
+        if data["bundle_format"] != "directory":
+            raise TorchLensIOError(
+                f"Unsupported bundle_format={data['bundle_format']!r}; expected 'directory'."
+            )
+
+        raw_tensors = data.get("tensors")
+        if not isinstance(raw_tensors, list):
+            raise TorchLensIOError("Manifest field 'tensors' must be a list.")
+        tensors = [TensorEntry.from_dict(entry) for entry in raw_tensors]
+
+        unsupported_tensors = _validate_unsupported_tensors(data.get("unsupported_tensors"))
+        manifest = cls(
+            io_format_version=data["io_format_version"],
+            torchlens_version=data["torchlens_version"],
+            torch_version=data["torch_version"],
+            python_version=data["python_version"],
+            platform=data["platform"],
+            created_at=data["created_at"],
+            bundle_format=data["bundle_format"],
+            n_layers=data["n_layers"],
+            n_activation_blobs=data["n_activation_blobs"],
+            n_gradient_blobs=data["n_gradient_blobs"],
+            n_auxiliary_blobs=data["n_auxiliary_blobs"],
+            tensors=tensors,
+            unsupported_tensors=unsupported_tensors,
+        )
+        manifest._validate_counts()
+        return manifest
+
+    @classmethod
+    def read(cls, path: str | Path) -> Manifest:
+        """Read, parse, and validate ``manifest.json``.
+
+        Parameters
+        ----------
+        path:
+            Path to the manifest file.
+
+        Returns
+        -------
+        Manifest
+            Validated manifest instance.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the file cannot be read or does not decode into a valid manifest.
+        """
+
+        manifest_path = Path(path)
+        try:
+            with manifest_path.open("r", encoding="utf-8") as handle:
+                raw_data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise TorchLensIOError(f"Failed to read manifest at {manifest_path}.") from exc
+        if not isinstance(raw_data, dict):
+            raise TorchLensIOError("Manifest root must be a JSON object.")
+        return cls.from_dict(raw_data)
+
+    def write(self, path: str | Path) -> None:
+        """Write the manifest to disk using pretty-printed JSON.
+
+        Parameters
+        ----------
+        path:
+            Destination path for ``manifest.json``.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the file cannot be written.
+        """
+
+        manifest_path = Path(path)
+        try:
+            with manifest_path.open("w", encoding="utf-8") as handle:
+                json.dump(self.to_dict(), handle, indent=2, sort_keys=False)
+                handle.write("\n")
+        except OSError as exc:
+            raise TorchLensIOError(f"Failed to write manifest at {manifest_path}.") from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the manifest into JSON-serializable data.
+
+        Returns
+        -------
+        dict[str, Any]
+            JSON-ready manifest mapping.
+        """
+
+        data = asdict(self)
+        data["tensors"] = [entry.to_dict() for entry in self.tensors]
+        return data
+
+    def _validate_counts(self) -> None:
+        """Ensure manifest tensor counts match the declared summary fields.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the declared counts disagree with the tensor entries.
+        """
+
+        n_activation_blobs = sum(1 for entry in self.tensors if entry.kind == "activation")
+        n_gradient_blobs = sum(1 for entry in self.tensors if entry.kind == "gradient")
+        n_auxiliary_blobs = len(self.tensors) - n_activation_blobs - n_gradient_blobs
+        if self.n_activation_blobs != n_activation_blobs:
+            raise TorchLensIOError("Manifest n_activation_blobs does not match tensor entries.")
+        if self.n_gradient_blobs != n_gradient_blobs:
+            raise TorchLensIOError("Manifest n_gradient_blobs does not match tensor entries.")
+        if self.n_auxiliary_blobs != n_auxiliary_blobs:
+            raise TorchLensIOError("Manifest n_auxiliary_blobs does not match tensor entries.")
+
+
+def sha256_of_file(path: str | Path) -> str:
+    """Compute the SHA-256 digest of one file's bytes.
+
+    Parameters
+    ----------
+    path:
+        File path to hash.
+
+    Returns
+    -------
+    str
+        Lowercase hexadecimal digest.
+    """
+
+    digest = sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def enforce_version_policy(manifest: Manifest) -> None:
+    """Apply the Fork F compatibility policy for a loaded bundle manifest.
+
+    Parameters
+    ----------
+    manifest:
+        Parsed manifest to validate against the current runtime.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the bundle targets a newer I/O format or an incompatible torch
+        major version.
+    """
+
+    if manifest.io_format_version > IO_FORMAT_VERSION:
+        raise TorchLensIOError(
+            "Bundle uses io_format_version="
+            f"{manifest.io_format_version}, but this runtime only supports "
+            f"{IO_FORMAT_VERSION}."
+        )
+    if manifest.io_format_version < IO_FORMAT_VERSION:
+        warnings.warn(
+            "Bundle io_format_version="
+            f"{manifest.io_format_version} is older than runtime "
+            f"io_format_version={IO_FORMAT_VERSION}; missing portable fields may "
+            "default-fill during load.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    runtime_torch = _parse_version(torch.__version__, label="runtime torch")
+    manifest_torch = _parse_version(manifest.torch_version, label="manifest torch")
+    if runtime_torch is not None and manifest_torch is not None:
+        if runtime_torch.major != manifest_torch.major:
+            raise TorchLensIOError(
+                "Bundle torch_version="
+                f"{manifest.torch_version} is incompatible with runtime torch_version="
+                f"{torch.__version__} (major version mismatch)."
+            )
+        if runtime_torch.minor != manifest_torch.minor:
+            warnings.warn(
+                "Bundle torch_version="
+                f"{manifest.torch_version} differs from runtime torch_version="
+                f"{torch.__version__} (minor version mismatch).",
+                UserWarning,
+                stacklevel=2,
+            )
+    elif manifest.torch_version != torch.__version__:
+        raise TorchLensIOError(
+            "Bundle torch_version="
+            f"{manifest.torch_version} could not be parsed compatibly with runtime "
+            f"torch_version={torch.__version__}; refusing load."
+        )
+
+    runtime_torchlens = _parse_version(TORCHLENS_VERSION, label="runtime torchlens")
+    manifest_torchlens = _parse_version(manifest.torchlens_version, label="manifest torchlens")
+    if runtime_torchlens is not None and manifest_torchlens is not None:
+        if manifest_torchlens > runtime_torchlens:
+            warnings.warn(
+                "Bundle torchlens_version="
+                f"{manifest.torchlens_version} is newer than runtime torchlens_version="
+                f"{TORCHLENS_VERSION}.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif manifest_torchlens < runtime_torchlens:
+            LOGGER.info(
+                "Bundle torchlens_version=%s is older than runtime torchlens_version=%s.",
+                manifest.torchlens_version,
+                TORCHLENS_VERSION,
+            )
+    elif manifest.torchlens_version != TORCHLENS_VERSION:
+        warnings.warn(
+            "Bundle torchlens_version="
+            f"{manifest.torchlens_version} differs from runtime torchlens_version="
+            f"{TORCHLENS_VERSION} and could not be parsed under PEP 440.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    runtime_python = _parse_version(_runtime_python_version(), label="runtime python")
+    manifest_python = _parse_version(manifest.python_version, label="manifest python")
+    if runtime_python is not None and manifest_python is not None:
+        if runtime_python.major != manifest_python.major:
+            warnings.warn(
+                "Bundle python_version="
+                f"{manifest.python_version} differs from runtime python_version="
+                f"{_runtime_python_version()} (major version mismatch).",
+                UserWarning,
+                stacklevel=2,
+            )
+    elif manifest.python_version != _runtime_python_version():
+        warnings.warn(
+            "Bundle python_version="
+            f"{manifest.python_version} differs from runtime python_version="
+            f"{_runtime_python_version()} and could not be parsed under PEP 440.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def _parse_version(version_text: str, *, label: str) -> Version | None:
+    """Parse a version string under PEP 440 with warning fallback.
+
+    Parameters
+    ----------
+    version_text:
+        Raw version string to parse.
+    label:
+        Human-readable label for warnings.
+
+    Returns
+    -------
+    Version | None
+        Parsed version object, or ``None`` when parsing fails.
+    """
+
+    try:
+        return Version(version_text)
+    except InvalidVersion:
+        warnings.warn(
+            f"Could not parse {label} version {version_text!r} under PEP 440; "
+            "falling back to string comparison.",
+            UserWarning,
+            stacklevel=3,
+        )
+        return None
+
+
+def _runtime_python_version() -> str:
+    """Return the current runtime Python version string.
+
+    Returns
+    -------
+    str
+        ``major.minor.micro`` string for the active interpreter.
+    """
+
+    return f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
+def _validate_unsupported_tensors(raw_value: Any) -> list[dict[str, str]]:
+    """Validate the ``unsupported_tensors`` manifest field.
+
+    Parameters
+    ----------
+    raw_value:
+        Raw decoded JSON value.
+
+    Returns
+    -------
+    list[dict[str, str]]
+        Validated unsupported tensor records.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the value is not a list of string-only mappings.
+    """
+
+    if raw_value is None:
+        return []
+    if not isinstance(raw_value, list):
+        raise TorchLensIOError("Manifest field 'unsupported_tensors' must be a list.")
+    validated: list[dict[str, str]] = []
+    for entry in raw_value:
+        if not isinstance(entry, dict):
+            raise TorchLensIOError("Manifest unsupported_tensors entries must be objects.")
+        validated_entry: dict[str, str] = {}
+        for key, value in entry.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise TorchLensIOError(
+                    "Manifest unsupported_tensors entries must use string keys and values."
+                )
+            validated_entry[key] = value
+        validated.append(validated_entry)
+    return validated

--- a/torchlens/_io/paths.py
+++ b/torchlens/_io/paths.py
@@ -1,0 +1,48 @@
+"""Path validation helpers for portable TorchLens bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import TorchLensIOError
+
+
+def resolve_bundle_blob_path(bundle_root: Path, relative_path: str) -> Path:
+    """Resolve one manifest-supplied blob path under ``<bundle>/blobs``.
+
+    Parameters
+    ----------
+    bundle_root:
+        Root directory of the portable bundle.
+    relative_path:
+        Manifest-provided blob path relative to the bundle root.
+
+    Returns
+    -------
+    Path
+        Absolute resolved blob path.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the path is absolute, contains ``".."``, or resolves outside the
+        bundle's ``blobs/`` directory.
+    """
+
+    candidate_path = Path(relative_path)
+    if candidate_path.is_absolute():
+        raise TorchLensIOError(f"Bundle rejected absolute relative_path {relative_path!r}.")
+    if ".." in candidate_path.parts:
+        raise TorchLensIOError(
+            f"Bundle rejected parent traversal in relative_path {relative_path!r}."
+        )
+
+    candidate = (bundle_root / candidate_path).resolve()
+    allowed_root = (bundle_root / "blobs").resolve()
+    try:
+        candidate.relative_to(allowed_root)
+    except ValueError as exc:
+        raise TorchLensIOError(
+            f"Bundle rejected path traversal outside blobs/: {relative_path!r}."
+        ) from exc
+    return candidate

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 import torch
 from safetensors.torch import load_file
@@ -12,7 +12,7 @@ from safetensors.torch import load_file
 from . import BlobRef, FieldPolicy, TorchLensIOError
 from .accessor_rebuild import rebuild_model_log_accessors
 from .lazy import LazyActivationRef
-from .manifest import Manifest, TensorEntry
+from .manifest import Manifest, TensorEntry, sha256_of_file
 from ..data_classes.model_log import ModelLog
 
 
@@ -200,14 +200,16 @@ def _rehydrate_object(
         policy = spec[field_name]
         if policy == FieldPolicy.BLOB:
             if isinstance(field_value, BlobRef):
-                if field_name == "activation":
-                    activation_ref = _build_lazy_activation_ref(
+                ref_field_name = _lazy_ref_field_name(field_name)
+                if ref_field_name is not None:
+                    tensor_ref = _build_lazy_tensor_ref(
                         field_value,
                         manifest_index,
                         bundle_path,
+                        kind=field_name,
                     )
-                    if activation_ref is not None:
-                        setattr(value, "activation_ref", activation_ref)
+                    if tensor_ref is not None:
+                        setattr(value, ref_field_name, tensor_ref)
                     if lazy:
                         setattr(value, field_name, None)
                     else:
@@ -342,7 +344,33 @@ def _materialize_blob_ref(
     bundle_path: Path,
     map_location: str | torch.device,
 ) -> torch.Tensor:
-    """Load one tensor blob from disk using safetensors."""
+    """Load one tensor blob from disk using safetensors.
+
+    Parameters
+    ----------
+    blob_ref:
+        Portable blob reference to materialize.
+    manifest_index:
+        Manifest tensor entries indexed by blob id.
+    bundle_path:
+        Root bundle directory containing the blob files.
+    map_location:
+        Target device for decoded tensors.
+
+    Returns
+    -------
+    torch.Tensor
+        Materialized tensor.
+    """
+
+    tensor_ref = _build_lazy_tensor_ref(
+        blob_ref,
+        manifest_index,
+        bundle_path,
+        kind=_lazy_ref_kind(blob_ref.kind),
+    )
+    if tensor_ref is not None:
+        return tensor_ref.materialize(map_location=map_location)
 
     if blob_ref.blob_id not in manifest_index:
         raise TorchLensIOError(f"Manifest is missing blob_id={blob_ref.blob_id}.")
@@ -355,16 +383,23 @@ def _materialize_blob_ref(
     blob_path = bundle_path / relative_path
     if not blob_path.exists():
         raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
-    tensor_map = load_file(blob_path, device=_normalize_map_location(map_location))
-    if len(tensor_map) != 1:
-        raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")
-    return next(iter(tensor_map.values()))
+
+    observed_sha256 = sha256_of_file(blob_path)
+    expected_sha256 = entry.sha256 if isinstance(entry, TensorEntry) else entry.get("sha256")
+    if expected_sha256 is not None and observed_sha256 != expected_sha256:
+        raise TorchLensIOError(
+            f"blob at {blob_path} sha256 mismatch; expected {expected_sha256} got {observed_sha256}"
+        )
+
+    return _load_safetensors_tensor(blob_path, map_location)
 
 
-def _build_lazy_activation_ref(
+def _build_lazy_tensor_ref(
     blob_ref: BlobRef,
     manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
     bundle_path: Path,
+    *,
+    kind: Literal["activation", "gradient"],
 ) -> LazyActivationRef | None:
     """Build a ``LazyActivationRef`` from one manifest entry.
 
@@ -376,6 +411,8 @@ def _build_lazy_activation_ref(
         Manifest tensor entries indexed by blob id.
     bundle_path:
         Root bundle directory.
+    kind:
+        Logical tensor kind for the lazy ref.
 
     Returns
     -------
@@ -393,9 +430,50 @@ def _build_lazy_activation_ref(
         dtype=_dtype_from_manifest_string(entry.dtype),
         device_at_save=entry.device_at_save,
         source_bundle_path=bundle_path,
-        kind="activation",
+        relative_path=entry.relative_path,
+        kind=kind,
         expected_sha256=entry.sha256,
     )
+
+
+def _lazy_ref_field_name(field_name: str) -> str | None:
+    """Return the corresponding lazy-ref field for a direct blob field.
+
+    Parameters
+    ----------
+    field_name:
+        Direct blob field name on the owning data class.
+
+    Returns
+    -------
+    str | None
+        Matching lazy-ref field name, or ``None`` when not applicable.
+    """
+
+    if field_name == "activation":
+        return "activation_ref"
+    if field_name == "gradient":
+        return "gradient_ref"
+    return None
+
+
+def _lazy_ref_kind(blob_kind: str) -> Literal["activation", "gradient"]:
+    """Normalize a blob kind into a lazy direct-tensor kind.
+
+    Parameters
+    ----------
+    blob_kind:
+        Blob kind stored in the portable manifest.
+
+    Returns
+    -------
+    str
+        Direct tensor kind expected by ``LazyActivationRef``.
+    """
+
+    if blob_kind == "gradient":
+        return "gradient"
+    return "activation"
 
 
 def _manifest_entry_for_blob_ref(
@@ -471,3 +549,254 @@ def _normalize_map_location(map_location: str | torch.device) -> str:
     """Normalize ``map_location`` to the string form expected by safetensors."""
 
     return str(map_location)
+
+
+def _load_safetensors_tensor(
+    blob_path: Path,
+    map_location: str | torch.device,
+) -> torch.Tensor:
+    """Load a single tensor from one safetensors blob.
+
+    Parameters
+    ----------
+    blob_path:
+        Blob file path to decode.
+    map_location:
+        Target device for the decoded tensor.
+
+    Returns
+    -------
+    torch.Tensor
+        Decoded tensor payload.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the blob does not contain exactly one tensor.
+    """
+
+    try:
+        tensor_map = load_file(blob_path, device=_normalize_map_location(map_location))
+    except ImportError as exc:
+        raise TorchLensIOError(
+            "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
+        ) from exc
+    except (OSError, ValueError) as exc:
+        raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
+
+    if len(tensor_map) != 1:
+        raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")
+    return next(iter(tensor_map.values()))
+
+
+def rehydrate_nested(
+    model_log: ModelLog,
+    *,
+    map_location: str | torch.device = "cpu",
+) -> None:
+    """Materialize nested portable blob refs in place on a loaded ``ModelLog``.
+
+    Parameters
+    ----------
+    model_log:
+        Model log loaded from a portable bundle.
+    map_location:
+        Target device for the materialized tensors.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the source bundle is unavailable or has drifted since load.
+    """
+
+    bundle_path = _source_bundle_path_for_model_log(model_log)
+    manifest_path = bundle_path / "manifest.json"
+    if not manifest_path.exists():
+        raise TorchLensIOError(f"Source bundle manifest not found at {manifest_path}.")
+
+    expected_manifest_sha256 = getattr(model_log, "_source_bundle_manifest_sha256", None)
+    if expected_manifest_sha256 is not None:
+        observed_manifest_sha256 = sha256_of_file(manifest_path)
+        if observed_manifest_sha256 != expected_manifest_sha256:
+            raise TorchLensIOError(
+                "source bundle manifest has changed since load; materialize refs and retry"
+            )
+
+    manifest = Manifest.read(manifest_path)
+    manifest_index = _build_manifest_index(manifest)
+    _rehydrate_nested_object(
+        model_log,
+        manifest_index=manifest_index,
+        bundle_path=bundle_path,
+        map_location=map_location,
+        seen=set(),
+    )
+
+
+def _rehydrate_nested_object(
+    value: Any,
+    *,
+    manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
+    bundle_path: Path,
+    map_location: str | torch.device,
+    seen: set[int],
+) -> Any:
+    """Walk an object graph and materialize only nested ``BlobRef`` fields.
+
+    Parameters
+    ----------
+    value:
+        Object graph node to inspect.
+    manifest_index:
+        Manifest tensor entries indexed by blob id.
+    bundle_path:
+        Root bundle directory containing the blob files.
+    map_location:
+        Target device for decoded tensors.
+    seen:
+        Identity set used to avoid infinite recursion on shared objects.
+
+    Returns
+    -------
+    Any
+        Original value, potentially with nested fields replaced in place.
+    """
+
+    if isinstance(value, (str, int, float, bool, type(None), torch.dtype, torch.device, BlobRef)):
+        return value
+    if isinstance(value, tuple):
+        return tuple(
+            _rehydrate_nested_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+                seen=seen,
+            )
+            for item in value
+        )
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            value[index] = _rehydrate_nested_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, OrderedDict):
+        for key, item in list(value.items()):
+            value[key] = _rehydrate_nested_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, defaultdict):
+        for key, item in list(value.items()):
+            value[key] = _rehydrate_nested_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, dict):
+        for key, item in list(value.items()):
+            value[key] = _rehydrate_nested_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, set):
+        return {
+            _rehydrate_nested_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+                seen=seen,
+            )
+            for item in value
+        }
+
+    spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
+    if spec is None:
+        return value
+
+    obj_id = id(value)
+    if obj_id in seen:
+        return value
+    seen.add(obj_id)
+
+    for field_name, field_value in list(vars(value).items()):
+        if field_name not in spec:
+            continue
+        policy = spec[field_name]
+        if policy == FieldPolicy.BLOB_RECURSIVE:
+            setattr(
+                value,
+                field_name,
+                _materialize_recursive_blob_refs(
+                    field_value,
+                    manifest_index=manifest_index,
+                    bundle_path=bundle_path,
+                    map_location=map_location,
+                ),
+            )
+        elif policy == FieldPolicy.KEEP:
+            setattr(
+                value,
+                field_name,
+                _rehydrate_nested_object(
+                    field_value,
+                    manifest_index=manifest_index,
+                    bundle_path=bundle_path,
+                    map_location=map_location,
+                    seen=seen,
+                ),
+            )
+    return value
+
+
+def _source_bundle_path_for_model_log(model_log: ModelLog) -> Path:
+    """Resolve the source bundle path recorded on a portable-loaded ``ModelLog``.
+
+    Parameters
+    ----------
+    model_log:
+        Model log whose source bundle should be resolved.
+
+    Returns
+    -------
+    Path
+        Source bundle directory.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the model log does not retain a source bundle reference.
+    """
+
+    bundle_path = getattr(model_log, "_source_bundle_path", None)
+    if isinstance(bundle_path, Path):
+        return bundle_path
+
+    for layer in getattr(model_log, "layer_list", []):
+        activation_ref = getattr(layer, "activation_ref", None)
+        if isinstance(activation_ref, LazyActivationRef):
+            return activation_ref.source_bundle_path
+        gradient_ref = getattr(layer, "gradient_ref", None)
+        if isinstance(gradient_ref, LazyActivationRef):
+            return gradient_ref.source_bundle_path
+
+    raise TorchLensIOError(
+        "ModelLog does not retain a source bundle path for nested blob rehydration."
+    )

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -4,19 +4,20 @@ from __future__ import annotations
 
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 import torch
 from safetensors.torch import load_file
 
 from . import BlobRef, FieldPolicy, TorchLensIOError
 from .accessor_rebuild import rebuild_model_log_accessors
+from .manifest import Manifest, TensorEntry
 from ..data_classes.model_log import ModelLog
 
 
 def rehydrate_model_log(
     scrubbed_state: dict[str, Any],
-    manifest: dict[str, Any],
+    manifest: Manifest | dict[str, Any],
     bundle_path: str | Path,
     *,
     lazy: bool,
@@ -74,8 +75,13 @@ def rehydrate_model_log(
     return model_log
 
 
-def _build_manifest_index(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def _build_manifest_index(
+    manifest: Manifest | dict[str, Any],
+) -> Mapping[str, dict[str, Any] | TensorEntry]:
     """Index manifest tensor entries by blob id."""
+
+    if isinstance(manifest, Manifest):
+        return {entry.blob_id: entry for entry in manifest.tensors}
 
     tensors = manifest.get("tensors", [])
     if not isinstance(tensors, list):
@@ -92,7 +98,7 @@ def _build_manifest_index(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]
 def _rehydrate_object(
     value: Any,
     *,
-    manifest_index: dict[str, dict[str, Any]],
+    manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
     bundle_path: Path,
     lazy: bool,
     map_location: str | torch.device,
@@ -231,7 +237,7 @@ def _rehydrate_object(
 def _materialize_recursive_blob_refs(
     value: Any,
     *,
-    manifest_index: dict[str, dict[str, Any]],
+    manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
     bundle_path: Path,
     map_location: str | torch.device,
 ) -> Any:
@@ -307,7 +313,7 @@ def _materialize_recursive_blob_refs(
 
 def _materialize_blob_ref(
     blob_ref: BlobRef,
-    manifest_index: dict[str, dict[str, Any]],
+    manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
     bundle_path: Path,
     map_location: str | torch.device,
 ) -> torch.Tensor:
@@ -316,10 +322,16 @@ def _materialize_blob_ref(
     if blob_ref.blob_id not in manifest_index:
         raise TorchLensIOError(f"Manifest is missing blob_id={blob_ref.blob_id}.")
     entry = manifest_index[blob_ref.blob_id]
-    relative_path = entry.get("relative_path", f"blobs/{blob_ref.blob_id}.safetensors")
+    relative_path = (
+        entry.relative_path
+        if isinstance(entry, TensorEntry)
+        else entry.get("relative_path", f"blobs/{blob_ref.blob_id}.safetensors")
+    )
     blob_path = bundle_path / relative_path
     if not blob_path.exists():
         raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
+    # TODO(io-s6): replace direct blob materialization with LazyActivationRef
+    # placeholders when lazy=True so activation/gradient loads can be deferred.
     tensor_map = load_file(blob_path, device=_normalize_map_location(map_location))
     if len(tensor_map) != 1:
         raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping
 
 import torch
+from safetensors import SafetensorError
 from safetensors.torch import load_file
 
 from . import BlobRef, FieldPolicy, TorchLensIOError
@@ -581,7 +582,7 @@ def _load_safetensors_tensor(
         raise TorchLensIOError(
             "Portable bundle load requires the safetensors backend. Install safetensors>=0.4."
         ) from exc
-    except (OSError, ValueError) as exc:
+    except (OSError, SafetensorError, ValueError) as exc:
         raise TorchLensIOError(f"Failed to materialize blob at {blob_path}.") from exc
 
     if len(tensor_map) != 1:

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -1,4 +1,10 @@
-"""Portable state rehydration for TorchLens model logs."""
+"""Portable state rehydration for TorchLens model logs.
+
+This module restores scrubbed portable metadata into working TorchLens object
+graphs. It rebuilds eager or lazy tensor fields from ``BlobRef`` placeholders,
+reconstructs accessors, and supports the expert nested-materialization flow
+used by ``torchlens.load(..., materialize_nested=False)``.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -11,6 +11,7 @@ from safetensors.torch import load_file
 
 from . import BlobRef, FieldPolicy, TorchLensIOError
 from .accessor_rebuild import rebuild_model_log_accessors
+from .lazy import LazyActivationRef
 from .manifest import Manifest, TensorEntry
 from ..data_classes.model_log import ModelLog
 
@@ -198,12 +199,36 @@ def _rehydrate_object(
             continue
         policy = spec[field_name]
         if policy == FieldPolicy.BLOB:
-            if isinstance(field_value, BlobRef) and not lazy:
-                setattr(
-                    value,
-                    field_name,
-                    _materialize_blob_ref(field_value, manifest_index, bundle_path, map_location),
-                )
+            if isinstance(field_value, BlobRef):
+                if field_name == "activation":
+                    activation_ref = _build_lazy_activation_ref(
+                        field_value,
+                        manifest_index,
+                        bundle_path,
+                    )
+                    if activation_ref is not None:
+                        setattr(value, "activation_ref", activation_ref)
+                    if lazy:
+                        setattr(value, field_name, None)
+                    else:
+                        setattr(
+                            value,
+                            field_name,
+                            _materialize_blob_ref(
+                                field_value,
+                                manifest_index,
+                                bundle_path,
+                                map_location,
+                            ),
+                        )
+                elif not lazy:
+                    setattr(
+                        value,
+                        field_name,
+                        _materialize_blob_ref(
+                            field_value, manifest_index, bundle_path, map_location
+                        ),
+                    )
         elif policy == FieldPolicy.BLOB_RECURSIVE:
             if lazy and not materialize_nested:
                 continue
@@ -330,12 +355,116 @@ def _materialize_blob_ref(
     blob_path = bundle_path / relative_path
     if not blob_path.exists():
         raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
-    # TODO(io-s6): replace direct blob materialization with LazyActivationRef
-    # placeholders when lazy=True so activation/gradient loads can be deferred.
     tensor_map = load_file(blob_path, device=_normalize_map_location(map_location))
     if len(tensor_map) != 1:
         raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")
     return next(iter(tensor_map.values()))
+
+
+def _build_lazy_activation_ref(
+    blob_ref: BlobRef,
+    manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
+    bundle_path: Path,
+) -> LazyActivationRef | None:
+    """Build a ``LazyActivationRef`` from one manifest entry.
+
+    Parameters
+    ----------
+    blob_ref:
+        Activation blob reference from scrubbed metadata.
+    manifest_index:
+        Manifest tensor entries indexed by blob id.
+    bundle_path:
+        Root bundle directory.
+
+    Returns
+    -------
+    LazyActivationRef | None
+        Lazy activation placeholder, or ``None`` when the manifest entry uses the
+        older minimal schema that does not include enough metadata yet.
+    """
+
+    entry = _manifest_entry_for_blob_ref(blob_ref, manifest_index)
+    if entry is None:
+        return None
+    return LazyActivationRef(
+        blob_id=entry.blob_id,
+        shape=tuple(entry.shape),
+        dtype=_dtype_from_manifest_string(entry.dtype),
+        device_at_save=entry.device_at_save,
+        source_bundle_path=bundle_path,
+        kind="activation",
+        expected_sha256=entry.sha256,
+    )
+
+
+def _manifest_entry_for_blob_ref(
+    blob_ref: BlobRef,
+    manifest_index: Mapping[str, dict[str, Any] | TensorEntry],
+) -> TensorEntry | None:
+    """Return the manifest entry corresponding to one ``BlobRef``.
+
+    Parameters
+    ----------
+    blob_ref:
+        Blob reference to resolve.
+    manifest_index:
+        Manifest tensor entries indexed by blob id.
+
+    Returns
+    -------
+    TensorEntry | None
+        Resolved manifest entry, or ``None`` when the manifest only contains the
+        older minimal tensor schema.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the blob id is missing from the manifest.
+    """
+
+    if blob_ref.blob_id not in manifest_index:
+        raise TorchLensIOError(f"Manifest is missing blob_id={blob_ref.blob_id}.")
+    entry = manifest_index[blob_ref.blob_id]
+    if isinstance(entry, TensorEntry):
+        return entry
+    required_fields = {
+        "backend",
+        "shape",
+        "dtype",
+        "device_at_save",
+        "layout",
+        "bytes",
+        "sha256",
+    }
+    if not required_fields.issubset(entry.keys()):
+        return None
+    return TensorEntry.from_dict(entry)
+
+
+def _dtype_from_manifest_string(dtype_name: str) -> torch.dtype:
+    """Resolve a manifest dtype string into a ``torch.dtype``.
+
+    Parameters
+    ----------
+    dtype_name:
+        Manifest dtype name without the ``torch.`` prefix.
+
+    Returns
+    -------
+    torch.dtype
+        Resolved dtype object.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the dtype string is unknown to the runtime.
+    """
+
+    dtype_obj = getattr(torch, dtype_name, None)
+    if not isinstance(dtype_obj, torch.dtype):
+        raise TorchLensIOError(f"Unsupported dtype string in manifest: {dtype_name}.")
+    return dtype_obj
 
 
 def _normalize_map_location(map_location: str | torch.device) -> str:

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -1,0 +1,332 @@
+"""Portable state rehydration for TorchLens model logs."""
+
+from __future__ import annotations
+
+from collections import OrderedDict, defaultdict
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file
+
+from . import BlobRef, FieldPolicy, TorchLensIOError
+from .accessor_rebuild import rebuild_model_log_accessors
+from ..data_classes.model_log import ModelLog
+
+
+def rehydrate_model_log(
+    scrubbed_state: dict[str, Any],
+    manifest: dict[str, Any],
+    bundle_path: str | Path,
+    *,
+    lazy: bool,
+    map_location: str | torch.device,
+    materialize_nested: bool,
+) -> ModelLog:
+    """Restore a scrubbed portable ``ModelLog`` state.
+
+    Parameters
+    ----------
+    scrubbed_state:
+        Scrubbed metadata dict returned by :func:`scrub_for_save`.
+    manifest:
+        Portable manifest describing the on-disk tensor blobs.
+    bundle_path:
+        Root bundle directory containing the ``blobs/`` subdirectory.
+    lazy:
+        Whether direct activation/gradient blob refs should remain lazy.
+    map_location:
+        Target device passed through to ``safetensors`` materialization.
+    materialize_nested:
+        Whether nested blob refs inside containers should be materialized when
+        ``lazy=True``.
+
+    Returns
+    -------
+    ModelLog
+        Rehydrated model log.
+    """
+
+    state_for_load = dict(scrubbed_state)
+    module_accessor_state = state_for_load.pop("_io_module_accessor_state", None)
+
+    model_log = ModelLog.__new__(ModelLog)
+    model_log.__setstate__(state_for_load)
+
+    if module_accessor_state is not None:
+        rebuild_model_log_accessors(
+            model_log,
+            module_accessor_state._dict,
+            module_accessor_state._list,
+            module_accessor_state._pass_dict,
+        )
+
+    manifest_index = _build_manifest_index(manifest)
+    _rehydrate_object(
+        model_log,
+        manifest_index=manifest_index,
+        bundle_path=Path(bundle_path),
+        lazy=lazy,
+        map_location=map_location,
+        materialize_nested=materialize_nested,
+        seen=set(),
+    )
+    return model_log
+
+
+def _build_manifest_index(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Index manifest tensor entries by blob id."""
+
+    tensors = manifest.get("tensors", [])
+    if not isinstance(tensors, list):
+        raise TorchLensIOError("Portable manifest must contain a list under 'tensors'.")
+    index: dict[str, dict[str, Any]] = {}
+    for entry in tensors:
+        blob_id = entry.get("blob_id")
+        if not isinstance(blob_id, str):
+            raise TorchLensIOError("Portable manifest tensor entries must include string blob_id.")
+        index[blob_id] = entry
+    return index
+
+
+def _rehydrate_object(
+    value: Any,
+    *,
+    manifest_index: dict[str, dict[str, Any]],
+    bundle_path: Path,
+    lazy: bool,
+    map_location: str | torch.device,
+    materialize_nested: bool,
+    seen: set[int],
+) -> Any:
+    """Walk a rehydrated object graph and materialize blob refs in place."""
+
+    if isinstance(value, (str, int, float, bool, type(None), torch.dtype, torch.device, BlobRef)):
+        return value
+    if isinstance(value, tuple):
+        return tuple(
+            _rehydrate_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                lazy=lazy,
+                map_location=map_location,
+                materialize_nested=materialize_nested,
+                seen=seen,
+            )
+            for item in value
+        )
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            value[index] = _rehydrate_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                lazy=lazy,
+                map_location=map_location,
+                materialize_nested=materialize_nested,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, OrderedDict):
+        for key, item in list(value.items()):
+            value[key] = _rehydrate_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                lazy=lazy,
+                map_location=map_location,
+                materialize_nested=materialize_nested,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, defaultdict):
+        for key, item in list(value.items()):
+            value[key] = _rehydrate_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                lazy=lazy,
+                map_location=map_location,
+                materialize_nested=materialize_nested,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, dict):
+        for key, item in list(value.items()):
+            value[key] = _rehydrate_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                lazy=lazy,
+                map_location=map_location,
+                materialize_nested=materialize_nested,
+                seen=seen,
+            )
+        return value
+    if isinstance(value, set):
+        return {
+            _rehydrate_object(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                lazy=lazy,
+                map_location=map_location,
+                materialize_nested=materialize_nested,
+                seen=seen,
+            )
+            for item in value
+        }
+
+    spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
+    if spec is None:
+        return value
+
+    obj_id = id(value)
+    if obj_id in seen:
+        return value
+    seen.add(obj_id)
+
+    for field_name, field_value in list(vars(value).items()):
+        if field_name not in spec:
+            continue
+        policy = spec[field_name]
+        if policy == FieldPolicy.BLOB:
+            if isinstance(field_value, BlobRef) and not lazy:
+                setattr(
+                    value,
+                    field_name,
+                    _materialize_blob_ref(field_value, manifest_index, bundle_path, map_location),
+                )
+        elif policy == FieldPolicy.BLOB_RECURSIVE:
+            if lazy and not materialize_nested:
+                continue
+            setattr(
+                value,
+                field_name,
+                _materialize_recursive_blob_refs(
+                    field_value,
+                    manifest_index=manifest_index,
+                    bundle_path=bundle_path,
+                    map_location=map_location,
+                ),
+            )
+        elif policy == FieldPolicy.KEEP:
+            setattr(
+                value,
+                field_name,
+                _rehydrate_object(
+                    field_value,
+                    manifest_index=manifest_index,
+                    bundle_path=bundle_path,
+                    lazy=lazy,
+                    map_location=map_location,
+                    materialize_nested=materialize_nested,
+                    seen=seen,
+                ),
+            )
+    return value
+
+
+def _materialize_recursive_blob_refs(
+    value: Any,
+    *,
+    manifest_index: dict[str, dict[str, Any]],
+    bundle_path: Path,
+    map_location: str | torch.device,
+) -> Any:
+    """Materialize ``BlobRef`` objects inside nested containers."""
+
+    if isinstance(value, BlobRef):
+        return _materialize_blob_ref(value, manifest_index, bundle_path, map_location)
+    if isinstance(value, list):
+        return [
+            _materialize_recursive_blob_refs(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+            )
+            for item in value
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _materialize_recursive_blob_refs(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+            )
+            for item in value
+        )
+    if isinstance(value, OrderedDict):
+        return OrderedDict(
+            (
+                key,
+                _materialize_recursive_blob_refs(
+                    item,
+                    manifest_index=manifest_index,
+                    bundle_path=bundle_path,
+                    map_location=map_location,
+                ),
+            )
+            for key, item in value.items()
+        )
+    if isinstance(value, defaultdict):
+        materialized: defaultdict[Any, Any] = defaultdict(value.default_factory)
+        for key, item in value.items():
+            materialized[key] = _materialize_recursive_blob_refs(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+            )
+        return materialized
+    if isinstance(value, dict):
+        return {
+            key: _materialize_recursive_blob_refs(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, set):
+        return {
+            _materialize_recursive_blob_refs(
+                item,
+                manifest_index=manifest_index,
+                bundle_path=bundle_path,
+                map_location=map_location,
+            )
+            for item in value
+        }
+    return value
+
+
+def _materialize_blob_ref(
+    blob_ref: BlobRef,
+    manifest_index: dict[str, dict[str, Any]],
+    bundle_path: Path,
+    map_location: str | torch.device,
+) -> torch.Tensor:
+    """Load one tensor blob from disk using safetensors."""
+
+    if blob_ref.blob_id not in manifest_index:
+        raise TorchLensIOError(f"Manifest is missing blob_id={blob_ref.blob_id}.")
+    entry = manifest_index[blob_ref.blob_id]
+    relative_path = entry.get("relative_path", f"blobs/{blob_ref.blob_id}.safetensors")
+    blob_path = bundle_path / relative_path
+    if not blob_path.exists():
+        raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
+    tensor_map = load_file(blob_path, device=_normalize_map_location(map_location))
+    if len(tensor_map) != 1:
+        raise TorchLensIOError(f"Expected a single tensor in blob file {blob_path}.")
+    return next(iter(tensor_map.values()))
+
+
+def _normalize_map_location(map_location: str | torch.device) -> str:
+    """Normalize ``map_location`` to the string form expected by safetensors."""
+
+    return str(map_location)

--- a/torchlens/_io/rehydrate.py
+++ b/torchlens/_io/rehydrate.py
@@ -20,6 +20,7 @@ from . import BlobRef, FieldPolicy, TorchLensIOError
 from .accessor_rebuild import rebuild_model_log_accessors
 from .lazy import LazyActivationRef
 from .manifest import Manifest, TensorEntry, sha256_of_file
+from .paths import resolve_bundle_blob_path
 from ..data_classes.model_log import ModelLog
 
 
@@ -387,7 +388,7 @@ def _materialize_blob_ref(
         if isinstance(entry, TensorEntry)
         else entry.get("relative_path", f"blobs/{blob_ref.blob_id}.safetensors")
     )
-    blob_path = bundle_path / relative_path
+    blob_path = resolve_bundle_blob_path(bundle_path, relative_path)
     if not blob_path.exists():
         raise TorchLensIOError(f"Tensor blob not found at {blob_path}.")
 
@@ -601,7 +602,17 @@ def rehydrate_nested(
     *,
     map_location: str | torch.device = "cpu",
 ) -> None:
-    """Materialize nested portable blob refs in place on a loaded ``ModelLog``.
+    """Replace any remaining nested ``BlobRef`` objects with materialized tensors.
+
+    This function is a no-op unless the ``ModelLog`` was loaded with
+    ``lazy=True, materialize_nested=False``. In the default load mode, nested
+    tensors are already materialized.
+
+    Typical workflow:
+
+    >>> import torchlens as tl
+    >>> log = tl.load("demo_bundle", lazy=True, materialize_nested=False)
+    >>> tl.rehydrate_nested(log)
 
     Parameters
     ----------

--- a/torchlens/_io/scrub.py
+++ b/torchlens/_io/scrub.py
@@ -1,4 +1,11 @@
-"""Portable state scrubbing for TorchLens model logs."""
+"""Portable state scrubbing for TorchLens model logs.
+
+This module converts a live ``ModelLog`` object graph into portable metadata
+plus a list of tensor blob specs. It is the save-side counterpart to
+rehydration: every class-specific ``PORTABLE_STATE_SPEC`` is applied here so
+tensor payloads become ``BlobRef`` placeholders and non-portable live objects
+are dropped or stringified before writing ``metadata.pkl``.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/scrub.py
+++ b/torchlens/_io/scrub.py
@@ -259,6 +259,8 @@ def _blobify_recursive_value(
 ) -> Any:
     """Blobify tensors recursively inside nested containers."""
 
+    if isinstance(value, BlobRef):
+        return value
     if isinstance(value, torch.Tensor):
         return _blobify_tensor_field(owner, field_name, value, blob_specs, blob_counter)
     if isinstance(value, list):

--- a/torchlens/_io/scrub.py
+++ b/torchlens/_io/scrub.py
@@ -1,0 +1,385 @@
+"""Portable state scrubbing for TorchLens model logs."""
+
+from __future__ import annotations
+
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import torch
+
+from . import BlobRef, FieldPolicy, IO_FORMAT_VERSION, TorchLensIOError
+from ..data_classes.model_log import ModelLog
+
+BlobSpec: TypeAlias = tuple[str, torch.Tensor, str, str]
+
+_SIMPLE_KEEP_TYPES = (str, int, float, bool, type(None), torch.dtype, torch.device)
+
+
+@dataclass
+class _ScrubOptions:
+    """Flags controlling which optional tensor payloads are preserved."""
+
+    include_activations: bool
+    include_gradients: bool
+    include_captured_args: bool
+    include_rng_states: bool
+
+
+def scrub_for_save(
+    model_log: ModelLog,
+    *,
+    include_activations: bool = True,
+    include_gradients: bool = True,
+    include_captured_args: bool = False,
+    include_rng_states: bool = False,
+) -> tuple[dict[str, Any], list[BlobSpec]]:
+    """Scrub a ``ModelLog`` into portable metadata plus tensor blob specs.
+
+    Parameters
+    ----------
+    model_log:
+        Live model log to scrub.
+    include_activations:
+        Whether saved activations should be replaced with blob references.
+    include_gradients:
+        Whether gradients should be replaced with blob references.
+    include_captured_args:
+        Whether captured args/kwargs and related tensor payloads should be
+        preserved via blob references.
+    include_rng_states:
+        Whether captured RNG state tensors should be preserved via blob
+        references.
+
+    Returns
+    -------
+    tuple[dict[str, Any], list[BlobSpec]]
+        Scrubbed top-level state dict plus a list of blob specs
+        ``(blob_id, tensor, kind, label)``.
+    """
+
+    options = _ScrubOptions(
+        include_activations=include_activations,
+        include_gradients=include_gradients,
+        include_captured_args=include_captured_args,
+        include_rng_states=include_rng_states,
+    )
+    memo: dict[int, Any] = {}
+    blob_specs: list[BlobSpec] = []
+    blob_counter = [0]
+
+    scrubbed_model = _scrub_value(model_log, options, memo, blob_specs, blob_counter)
+    if not isinstance(scrubbed_model, ModelLog):
+        raise TorchLensIOError("Portable scrub expected a scrubbed ModelLog instance.")
+
+    scrubbed_state = dict(scrubbed_model.__dict__)
+    scrubbed_state["io_format_version"] = IO_FORMAT_VERSION
+
+    module_accessor = getattr(model_log, "_module_logs", None)
+    if module_accessor is not None:
+        scrubbed_state["_io_module_accessor_state"] = _scrub_value(
+            module_accessor,
+            options,
+            memo,
+            blob_specs,
+            blob_counter,
+        )
+    else:
+        scrubbed_state["_io_module_accessor_state"] = None
+    return scrubbed_state, blob_specs
+
+
+def _scrub_value(
+    value: Any,
+    options: _ScrubOptions,
+    memo: dict[int, Any],
+    blob_specs: list[BlobSpec],
+    blob_counter: list[int],
+) -> Any:
+    """Recursively scrub a value while preserving shared object identity."""
+
+    if isinstance(value, _SIMPLE_KEEP_TYPES):
+        return value
+    if isinstance(value, torch.Size):
+        return tuple(value)
+    if isinstance(value, BlobRef):
+        return value
+    if isinstance(value, list):
+        return [_scrub_value(item, options, memo, blob_specs, blob_counter) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_value(item, options, memo, blob_specs, blob_counter) for item in value)
+    if isinstance(value, set):
+        return {_scrub_value(item, options, memo, blob_specs, blob_counter) for item in value}
+    if isinstance(value, OrderedDict):
+        return OrderedDict(
+            (
+                key,
+                _scrub_value(item, options, memo, blob_specs, blob_counter),
+            )
+            for key, item in value.items()
+        )
+    if isinstance(value, defaultdict):
+        return {
+            key: _scrub_value(item, options, memo, blob_specs, blob_counter)
+            for key, item in value.items()
+        }
+    if isinstance(value, dict):
+        return {
+            key: _scrub_value(item, options, memo, blob_specs, blob_counter)
+            for key, item in value.items()
+        }
+
+    spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
+    if spec is None:
+        return value
+    obj_id = id(value)
+    if obj_id in memo:
+        return memo[obj_id]
+
+    scrubbed_obj = object.__new__(type(value))
+    memo[obj_id] = scrubbed_obj
+    scrubbed_state: dict[str, Any] = {}
+    for field_name, field_value in vars(value).items():
+        if field_name not in spec:
+            raise TorchLensIOError(
+                f"{type(value).__name__}.{field_name} is missing from PORTABLE_STATE_SPEC."
+            )
+        policy = _effective_policy(value, field_name, spec[field_name], options)
+        scrubbed_state[field_name] = _scrub_field(
+            owner=value,
+            field_name=field_name,
+            field_value=field_value,
+            policy=policy,
+            options=options,
+            memo=memo,
+            blob_specs=blob_specs,
+            blob_counter=blob_counter,
+        )
+
+    if isinstance(value, ModelLog):
+        scrubbed_state["activation_postfunc_repr"] = (
+            repr(value.activation_postfunc) if value.activation_postfunc is not None else None
+        )
+        scrubbed_state["io_format_version"] = IO_FORMAT_VERSION
+
+    scrubbed_obj.__dict__.update(scrubbed_state)
+    return scrubbed_obj
+
+
+def _effective_policy(
+    owner: Any,
+    field_name: str,
+    base_policy: FieldPolicy,
+    options: _ScrubOptions,
+) -> FieldPolicy:
+    """Resolve the runtime policy for a field after include-flag overrides."""
+
+    if field_name == "activation" and not options.include_activations:
+        return FieldPolicy.DROP
+    if field_name == "gradient" and not options.include_gradients:
+        return FieldPolicy.DROP
+    if field_name in {"captured_args", "captured_kwargs", "children_tensor_versions"}:
+        return FieldPolicy.BLOB_RECURSIVE if options.include_captured_args else FieldPolicy.DROP
+    if field_name in {"forward_args", "forward_kwargs"}:
+        return FieldPolicy.BLOB_RECURSIVE if options.include_captured_args else FieldPolicy.DROP
+    if field_name == "func_rng_states":
+        return FieldPolicy.BLOB_RECURSIVE if options.include_rng_states else FieldPolicy.DROP
+    return base_policy
+
+
+def _scrub_field(
+    *,
+    owner: Any,
+    field_name: str,
+    field_value: Any,
+    policy: FieldPolicy,
+    options: _ScrubOptions,
+    memo: dict[int, Any],
+    blob_specs: list[BlobSpec],
+    blob_counter: list[int],
+) -> Any:
+    """Scrub one object field according to its effective field policy."""
+
+    if policy in {FieldPolicy.DROP, FieldPolicy.WEAKREF_STRIP}:
+        return None
+    if policy == FieldPolicy.STRINGIFY:
+        return _stringify_value(field_value)
+    if policy == FieldPolicy.BLOB:
+        return _blobify_tensor_field(owner, field_name, field_value, blob_specs, blob_counter)
+    if policy == FieldPolicy.BLOB_RECURSIVE:
+        return _blobify_recursive_value(
+            owner=owner,
+            field_name=field_name,
+            value=field_value,
+            memo=memo,
+            blob_specs=blob_specs,
+            blob_counter=blob_counter,
+        )
+    return _scrub_value(field_value, options, memo, blob_specs, blob_counter)
+
+
+def _blobify_tensor_field(
+    owner: Any,
+    field_name: str,
+    field_value: Any,
+    blob_specs: list[BlobSpec],
+    blob_counter: list[int],
+) -> Any:
+    """Replace a tensor field with a ``BlobRef`` and record its blob spec."""
+
+    if field_value is None:
+        return None
+    if not isinstance(field_value, torch.Tensor):
+        raise TorchLensIOError(
+            f"{type(owner).__name__}.{field_name} expected a tensor for portable blobification, "
+            f"got {type(field_value).__name__}."
+        )
+    blob_id = _next_blob_id(blob_counter)
+    kind = _blob_kind_for_field(owner, field_name)
+    label = _blob_label_for_owner(owner)
+    blob_specs.append((blob_id, field_value, kind, label))
+    return BlobRef(blob_id=blob_id, kind=kind)
+
+
+def _blobify_recursive_value(
+    *,
+    owner: Any,
+    field_name: str,
+    value: Any,
+    memo: dict[int, Any],
+    blob_specs: list[BlobSpec],
+    blob_counter: list[int],
+) -> Any:
+    """Blobify tensors recursively inside nested containers."""
+
+    if isinstance(value, torch.Tensor):
+        return _blobify_tensor_field(owner, field_name, value, blob_specs, blob_counter)
+    if isinstance(value, list):
+        return [
+            _blobify_recursive_value(
+                owner=owner,
+                field_name=field_name,
+                value=item,
+                memo=memo,
+                blob_specs=blob_specs,
+                blob_counter=blob_counter,
+            )
+            for item in value
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _blobify_recursive_value(
+                owner=owner,
+                field_name=field_name,
+                value=item,
+                memo=memo,
+                blob_specs=blob_specs,
+                blob_counter=blob_counter,
+            )
+            for item in value
+        )
+    if isinstance(value, OrderedDict):
+        return OrderedDict(
+            (
+                key,
+                _blobify_recursive_value(
+                    owner=owner,
+                    field_name=field_name,
+                    value=item,
+                    memo=memo,
+                    blob_specs=blob_specs,
+                    blob_counter=blob_counter,
+                ),
+            )
+            for key, item in value.items()
+        )
+    if isinstance(value, defaultdict):
+        return {
+            key: _blobify_recursive_value(
+                owner=owner,
+                field_name=field_name,
+                value=item,
+                memo=memo,
+                blob_specs=blob_specs,
+                blob_counter=blob_counter,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, dict):
+        return {
+            key: _blobify_recursive_value(
+                owner=owner,
+                field_name=field_name,
+                value=item,
+                memo=memo,
+                blob_specs=blob_specs,
+                blob_counter=blob_counter,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, set):
+        return {
+            _blobify_recursive_value(
+                owner=owner,
+                field_name=field_name,
+                value=item,
+                memo=memo,
+                blob_specs=blob_specs,
+                blob_counter=blob_counter,
+            )
+            for item in value
+        }
+
+    spec = getattr(type(value), "PORTABLE_STATE_SPEC", None)
+    if spec is not None:
+        return _scrub_value(
+            value, _ScrubOptions(True, True, True, True), memo, blob_specs, blob_counter
+        )
+    return _stringify_value(value)
+
+
+def _stringify_value(value: Any) -> str:
+    """Convert a non-portable object into a stable placeholder string."""
+
+    return f"<scrubbed:{type(value).__name__}>"
+
+
+def _next_blob_id(blob_counter: list[int]) -> str:
+    """Allocate the next monotonically increasing zero-padded blob id."""
+
+    blob_counter[0] += 1
+    return f"{blob_counter[0]:010d}"
+
+
+def _blob_kind_for_field(owner: Any, field_name: str) -> str:
+    """Map an object field name to the portable manifest tensor kind."""
+
+    if field_name == "activation":
+        return "activation"
+    if field_name == "gradient":
+        return "gradient"
+    if field_name in {"captured_args", "captured_kwargs"}:
+        return "captured_arg"
+    if field_name == "children_tensor_versions":
+        return "child_version"
+    if field_name == "func_rng_states":
+        return "rng_state"
+    if field_name in {"forward_args", "forward_kwargs"}:
+        return "module_arg"
+    if field_name == "func_config":
+        return "func_config"
+    if field_name == "extra_attributes":
+        return "module_meta"
+    raise TorchLensIOError(f"No blob kind mapping defined for {type(owner).__name__}.{field_name}.")
+
+
+def _blob_label_for_owner(owner: Any) -> str:
+    """Return the human-readable label stored alongside a blob spec."""
+
+    if hasattr(owner, "layer_label_w_pass") and getattr(owner, "layer_label_w_pass") is not None:
+        return str(getattr(owner, "layer_label_w_pass"))
+    if hasattr(owner, "pass_label") and getattr(owner, "pass_label") is not None:
+        return str(getattr(owner, "pass_label"))
+    if hasattr(owner, "address") and getattr(owner, "address") is not None:
+        return str(getattr(owner, "address"))
+    return type(owner).__name__

--- a/torchlens/_io/streaming.py
+++ b/torchlens/_io/streaming.py
@@ -1,4 +1,12 @@
-"""Streaming bundle writer used during forward-pass activation capture."""
+"""Streaming bundle writer used during forward-pass activation capture.
+
+This module implements the strict streaming writer behind
+``log_forward_pass(save_activations_to=...)``. It writes one safetensors blob
+per saved activation into a temporary bundle during the forward pass, then
+finalizes ``manifest.json`` and ``metadata.pkl`` at postprocess time so the
+returned log can stay memory-backed or disk-backed with the same on-disk
+bundle.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/streaming.py
+++ b/torchlens/_io/streaming.py
@@ -1,0 +1,387 @@
+"""Streaming bundle writer used during forward-pass activation capture."""
+
+from __future__ import annotations
+
+import pickle
+import platform
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import save_file
+
+from . import IO_FORMAT_VERSION, TorchLensIOError
+from .manifest import Manifest, TensorEntry, sha256_of_file
+from .tensor_policy import FailReason, Ok, SkipReason, is_supported_for_save
+from .._state import pause_logging
+from .. import __version__ as TORCHLENS_VERSION
+
+PARTIAL_SENTINEL = "PARTIAL"
+REASON_SENTINEL = "REASON.txt"
+_BLOB_TENSOR_KEY = "data"
+BlobSpec = tuple[str, torch.Tensor, str, str]
+
+
+def next_blob_id(blob_index: int) -> str:
+    """Return the canonical zero-padded blob id for one monotonic counter.
+
+    Parameters
+    ----------
+    blob_index:
+        One-based blob counter.
+
+    Returns
+    -------
+    str
+        Zero-padded blob id.
+    """
+
+    return f"{blob_index:010d}"
+
+
+class BundleStreamWriter:
+    """Persist activation blobs incrementally into a temp TorchLens bundle.
+
+    Parameters
+    ----------
+    path:
+        Final bundle directory path.
+    strict:
+        Streaming bundles are always strict. Passing ``False`` is rejected.
+    """
+
+    def __init__(self, path: str | Path, *, strict: bool = True) -> None:
+        """Create the temp bundle directory used for streaming writes.
+
+        Parameters
+        ----------
+        path:
+            Final bundle directory path.
+        strict:
+            Streaming bundles are always strict. Passing ``False`` is rejected.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the target path is invalid or the temp directory cannot be created.
+        """
+
+        if not strict:
+            raise TorchLensIOError("Streaming activation save is always strict.")
+
+        self.final_path = Path(path)
+        if self.final_path.is_symlink():
+            raise TorchLensIOError(f"Refusing symlinked save target: {self.final_path}.")
+        if self.final_path.exists():
+            raise TorchLensIOError(f"Bundle path already exists: {self.final_path}")
+
+        self.tmp_path = self.final_path.parent / f"{self.final_path.name}.tmp.{uuid.uuid4().hex}"
+        self.blobs_path = self.tmp_path / "blobs"
+        self._blob_counter = 0
+        self._saw_first_payload = False
+        self._closed = False
+        self._finalized = False
+        self._tensor_entries: list[TensorEntry] = []
+        self._entries_by_blob_id: dict[str, TensorEntry] = {}
+
+        try:
+            self.tmp_path.parent.mkdir(parents=True, exist_ok=True)
+            self.tmp_path.mkdir()
+            self.blobs_path.mkdir()
+        except OSError as exc:
+            raise TorchLensIOError(
+                f"Failed to create streaming temp bundle at {self.tmp_path}."
+            ) from exc
+
+    def next_blob_id(self) -> str:
+        """Return the next monotonic blob id for this writer.
+
+        Returns
+        -------
+        str
+            Zero-padded blob id.
+        """
+
+        self._blob_counter += 1
+        return next_blob_id(self._blob_counter)
+
+    def write_blob(
+        self,
+        blob_id: str,
+        tensor: torch.Tensor,
+        *,
+        kind: str,
+        label: str,
+    ) -> TensorEntry:
+        """Write one tensor blob into ``blobs/`` and record its manifest entry.
+
+        Parameters
+        ----------
+        blob_id:
+            Opaque zero-padded blob identifier.
+        tensor:
+            Tensor payload to persist.
+        kind:
+            Logical tensor kind.
+        label:
+            Human-readable or provisional label for the tensor owner.
+
+        Returns
+        -------
+        TensorEntry
+            Recorded manifest entry.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the tensor is unsupported or writing fails.
+        """
+
+        self._ensure_writable()
+        if not isinstance(tensor, torch.Tensor):
+            reason = (
+                "Streaming activation save requires activation_postfunc outputs to be torch.Tensor "
+                f"instances, but blob_id={blob_id} ({label}) received {type(tensor).__name__}."
+            )
+            self.abort(reason)
+            raise TorchLensIOError(reason)
+
+        self._saw_first_payload = True
+        decision = is_supported_for_save(tensor, strict=True)
+        if not isinstance(decision, Ok):
+            if isinstance(decision, (SkipReason, FailReason)):
+                reason_text = decision.text
+            else:
+                reason_text = "unsupported tensor"
+            reason = (
+                f"Unsupported tensor for streaming activation save at {label} "
+                f"(blob_id={blob_id}, kind={kind}): {reason_text}"
+            )
+            self.abort(reason)
+            raise TorchLensIOError(reason)
+        if blob_id in self._entries_by_blob_id:
+            reason = f"Duplicate streaming blob_id={blob_id} for {label}."
+            self.abort(reason)
+            raise TorchLensIOError(reason)
+
+        try:
+            entry = self._write_tensor_blob(blob_id=blob_id, tensor=tensor, kind=kind, label=label)
+        except OSError as exc:
+            reason = f"Failed to write streaming blob_id={blob_id} for {label}: {exc}"
+            self.abort(reason)
+            raise TorchLensIOError(reason) from exc
+
+        self._tensor_entries.append(entry)
+        self._entries_by_blob_id[blob_id] = entry
+        return entry
+
+    def finalize(
+        self,
+        scrubbed_state: dict[str, Any],
+        blob_specs: list[BlobSpec],
+        unsupported: list[dict[str, str]],
+    ) -> Path:
+        """Finish the bundle by writing remaining blobs, manifest, and metadata.
+
+        Parameters
+        ----------
+        scrubbed_state:
+            Portable scrubbed metadata state.
+        blob_specs:
+            Remaining blob specs that were not already streamed during the pass.
+        unsupported:
+            Unsupported tensor records for the manifest.
+
+        Returns
+        -------
+        Path
+            Final bundle directory path.
+
+        Raises
+        ------
+        TorchLensIOError
+            If finalization fails.
+        """
+
+        self._ensure_writable()
+        try:
+            for blob_id, tensor, kind, label in blob_specs:
+                if blob_id in self._entries_by_blob_id:
+                    continue
+                self.write_blob(blob_id, tensor, kind=kind, label=label)
+
+            manifest = self._build_manifest(scrubbed_state=scrubbed_state, unsupported=unsupported)
+            manifest.write(self.tmp_path / "manifest.json")
+            with (self.tmp_path / "metadata.pkl").open("wb") as handle:
+                pickle.dump(scrubbed_state, handle, protocol=pickle.HIGHEST_PROTOCOL)
+        except TorchLensIOError:
+            raise
+        except (OSError, ValueError, pickle.PickleError) as exc:
+            reason = f"Failed to finalize streaming bundle at {self.tmp_path}: {exc}"
+            self.abort(reason)
+            raise TorchLensIOError(reason) from exc
+
+        try:
+            self.tmp_path.rename(self.final_path)
+        except OSError as exc:
+            self._closed = True
+            raise TorchLensIOError(
+                f"Failed to atomically rename {self.tmp_path} to {self.final_path}."
+            ) from exc
+
+        self._closed = True
+        self._finalized = True
+        return self.final_path
+
+    def abort(self, reason: str) -> None:
+        """Mark the temp bundle as partial and stop accepting writes.
+
+        Parameters
+        ----------
+        reason:
+            Human-readable failure reason written to ``REASON.txt``.
+        """
+
+        if self._finalized:
+            return
+        self._closed = True
+        self._mark_partial(reason)
+
+    def relabel_blob(self, blob_id: str, label: str) -> None:
+        """Update the manifest label for an already-written blob.
+
+        Parameters
+        ----------
+        blob_id:
+            Blob identifier to relabel.
+        label:
+            Final human-readable label.
+        """
+
+        entry = self._entries_by_blob_id.get(blob_id)
+        if entry is None:
+            return
+        updated_entry = TensorEntry(
+            blob_id=entry.blob_id,
+            kind=entry.kind,
+            label=label,
+            relative_path=entry.relative_path,
+            backend=entry.backend,
+            shape=entry.shape,
+            dtype=entry.dtype,
+            device_at_save=entry.device_at_save,
+            layout=entry.layout,
+            bytes=entry.bytes,
+            sha256=entry.sha256,
+        )
+        self._entries_by_blob_id[blob_id] = updated_entry
+        for index, existing_entry in enumerate(self._tensor_entries):
+            if existing_entry.blob_id == blob_id:
+                self._tensor_entries[index] = updated_entry
+                break
+
+    def get_entry(self, blob_id: str) -> TensorEntry:
+        """Return the manifest entry recorded for one blob id.
+
+        Parameters
+        ----------
+        blob_id:
+            Blob identifier to look up.
+
+        Returns
+        -------
+        TensorEntry
+            Recorded manifest entry.
+
+        Raises
+        ------
+        TorchLensIOError
+            If the blob id is unknown.
+        """
+
+        if blob_id not in self._entries_by_blob_id:
+            raise TorchLensIOError(f"Streaming bundle is missing blob_id={blob_id}.")
+        return self._entries_by_blob_id[blob_id]
+
+    def _write_tensor_blob(
+        self,
+        *,
+        blob_id: str,
+        tensor: torch.Tensor,
+        kind: str,
+        label: str,
+    ) -> TensorEntry:
+        """Write one supported tensor blob and return its manifest entry."""
+
+        with pause_logging():
+            contiguous_tensor = tensor.contiguous()
+        relative_path = Path("blobs") / f"{blob_id}.safetensors"
+        blob_path = self.tmp_path / relative_path
+        save_file({_BLOB_TENSOR_KEY: contiguous_tensor}, str(blob_path))
+        return TensorEntry(
+            blob_id=blob_id,
+            kind=kind,
+            label=label,
+            relative_path=relative_path.as_posix(),
+            backend="safetensors",
+            shape=[int(dim) for dim in contiguous_tensor.shape],
+            dtype=str(contiguous_tensor.dtype).replace("torch.", ""),
+            device_at_save=str(tensor.device),
+            layout=str(contiguous_tensor.layout).replace("torch.", ""),
+            bytes=int(contiguous_tensor.numel() * contiguous_tensor.element_size()),
+            sha256=sha256_of_file(blob_path),
+        )
+
+    def _build_manifest(
+        self,
+        *,
+        scrubbed_state: dict[str, Any],
+        unsupported: list[dict[str, str]],
+    ) -> Manifest:
+        """Build the final manifest for the streamed bundle."""
+
+        tensor_entries = list(self._tensor_entries)
+        n_activation_blobs = sum(1 for entry in tensor_entries if entry.kind == "activation")
+        n_gradient_blobs = sum(1 for entry in tensor_entries if entry.kind == "gradient")
+        n_auxiliary_blobs = len(tensor_entries) - n_activation_blobs - n_gradient_blobs
+        layer_list = scrubbed_state.get("layer_list", [])
+        n_layers = len(layer_list) if isinstance(layer_list, list) else 0
+        return Manifest(
+            io_format_version=IO_FORMAT_VERSION,
+            torchlens_version=TORCHLENS_VERSION,
+            torch_version=torch.__version__,
+            python_version=(
+                f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+            ),
+            platform=f"{platform.system().lower()}-{platform.machine().lower()}",
+            created_at=datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            bundle_format="directory",
+            n_layers=n_layers,
+            n_activation_blobs=n_activation_blobs,
+            n_gradient_blobs=n_gradient_blobs,
+            n_auxiliary_blobs=n_auxiliary_blobs,
+            tensors=tensor_entries,
+            unsupported_tensors=unsupported,
+        )
+
+    def _ensure_writable(self) -> None:
+        """Raise if the writer has already been closed."""
+
+        if self._closed:
+            raise TorchLensIOError("Streaming bundle writer is already closed.")
+
+    def _mark_partial(self, reason: str) -> None:
+        """Best-effort write the partial sentinel and human-readable reason."""
+
+        try:
+            if self.tmp_path.exists():
+                (self.tmp_path / PARTIAL_SENTINEL).write_text("", encoding="utf-8")
+                (self.tmp_path / REASON_SENTINEL).write_text(reason, encoding="utf-8")
+        except OSError:
+            return

--- a/torchlens/_io/tensor_policy.py
+++ b/torchlens/_io/tensor_policy.py
@@ -1,4 +1,10 @@
-"""Compatibility checks for tensors saved into portable bundles."""
+"""Compatibility checks for tensors saved into portable bundles.
+
+This module codifies which tensor layouts and dtypes the portable bundle path
+accepts in this sprint. Save code calls these helpers to decide whether a
+tensor should be written, skipped under ``strict=False``, or rejected with a
+hard ``TorchLensIOError`` under the default strict policy.
+"""
 
 from __future__ import annotations
 

--- a/torchlens/_io/tensor_policy.py
+++ b/torchlens/_io/tensor_policy.py
@@ -1,0 +1,142 @@
+"""Compatibility checks for tensors saved into portable bundles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union
+
+import torch
+
+
+@dataclass(frozen=True)
+class Ok:
+    """Successful tensor policy decision."""
+
+
+@dataclass(frozen=True)
+class SkipReason:
+    """Best-effort skip decision for unsupported tensors under ``strict=False``."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class FailReason:
+    """Hard-fail decision for unsupported tensors under ``strict=True``."""
+
+    text: str
+
+
+TensorPolicyDecision = Union[Ok, SkipReason, FailReason]
+
+_SPARSE_LAYOUTS = {
+    torch.sparse_coo,
+    getattr(torch, "sparse_csr", object()),
+    getattr(torch, "sparse_csc", object()),
+    getattr(torch, "sparse_bsr", object()),
+    getattr(torch, "sparse_bsc", object()),
+}
+_SUPPORTED_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.float64,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+    torch.bool,
+    torch.complex64,
+    torch.complex128,
+}
+
+
+def is_supported_for_save(
+    tensor: torch.Tensor,
+    *,
+    strict: bool = True,
+) -> TensorPolicyDecision:
+    """Decide whether a tensor can be persisted in a portable bundle.
+
+    Parameters
+    ----------
+    tensor:
+        Tensor candidate to validate.
+    strict:
+        Whether unsupported tensors should return ``FailReason`` (default) or
+        ``SkipReason`` for best-effort bundle creation.
+
+    Returns
+    -------
+    TensorPolicyDecision
+        ``Ok`` for supported tensors, otherwise ``FailReason`` or
+        ``SkipReason`` depending on ``strict``.
+    """
+
+    reason = _unsupported_reason(tensor)
+    if reason is None:
+        return Ok()
+    if strict:
+        return FailReason(reason)
+    return SkipReason(reason)
+
+
+def _unsupported_reason(tensor: torch.Tensor) -> str | None:
+    """Return the first incompatibility reason for a tensor, if any.
+
+    Parameters
+    ----------
+    tensor:
+        Tensor candidate to inspect.
+
+    Returns
+    -------
+    str | None
+        Unsupported reason text, or ``None`` when the tensor is supported.
+    """
+
+    if type(tensor) is not torch.Tensor:
+        return f"tensor subclass {type(tensor).__name__} is not supported this release"
+    if tensor.layout in _SPARSE_LAYOUTS or tensor.is_sparse:
+        return f"{str(tensor.layout).replace('torch.', '')} layout is not supported this release"
+    if tensor.is_quantized:
+        return "quantized tensors are not supported this release"
+    if tensor.device.type == "meta":
+        return "meta tensors do not have materialized data to save"
+    if bool(getattr(tensor, "is_nested", False)):
+        return "nested tensors are not supported this release"
+    if _is_distributed_shard_tensor(tensor):
+        return "DTensor/FSDP shard tensors are not supported this release"
+    complex32_dtype = getattr(torch, "complex32", None)
+    if complex32_dtype is not None and tensor.dtype == complex32_dtype:
+        return "complex32 tensors are not supported this release"
+    if tensor.device.type not in {"cpu", "cuda"}:
+        return f"{tensor.device.type} tensors are not supported this release"
+    if tensor.dtype not in _SUPPORTED_DTYPES:
+        return f"dtype {tensor.dtype} is not supported this release"
+    return None
+
+
+def _is_distributed_shard_tensor(tensor: torch.Tensor) -> bool:
+    """Best-effort detection for DTensor and sharded distributed tensors.
+
+    Parameters
+    ----------
+    tensor:
+        Tensor candidate to inspect.
+
+    Returns
+    -------
+    bool
+        True when the tensor appears to be a DTensor or sharded tensor.
+    """
+
+    tensor_type = type(tensor)
+    module_name = tensor_type.__module__.lower()
+    type_name = tensor_type.__name__.lower()
+    return (
+        "dtensor" in type_name
+        or "shardedtensor" in type_name
+        or ("distributed" in module_name and ("dtensor" in module_name or "shard" in module_name))
+    )

--- a/torchlens/capture/trace.py
+++ b/torchlens/capture/trace.py
@@ -84,6 +84,7 @@ def save_new_activations(
     """
     # Switch to fast mode: reuse graph structure, only capture new activations.
     self.logging_mode = "fast"
+    self._in_exhaustive_pass = False
 
     # Clear all existing activations from the previous pass.
     for layer_log_entry in self:

--- a/torchlens/constants.py
+++ b/torchlens/constants.py
@@ -33,6 +33,7 @@ from torch.overrides import get_ignored_functions, get_testing_overrides
 MODEL_LOG_FIELD_ORDER = [
     # General info
     "model_name",
+    "io_format_version",
     "_pass_finished",
     "logging_mode",
     "_all_layers_logged",
@@ -51,6 +52,7 @@ MODEL_LOG_FIELD_ORDER = [
     "verbose",
     "has_gradients",
     "activation_postfunc",
+    "activation_postfunc_repr",
     "mark_input_output_distances",
     # Model structure info (is_recurrent, max_recurrent_loops,
     # is_branching, has_conditional_branching are computed @properties)

--- a/torchlens/constants.py
+++ b/torchlens/constants.py
@@ -379,6 +379,30 @@ PARAM_LOG_FIELD_ORDER = [
     "grad_shape",
     "grad_dtype",
     "grad_memory",
+    "grad_memory_str",
+]
+
+# Per-buffer metadata exported by BufferAccessor (one row per buffer address).
+BUFFER_LOG_FIELD_ORDER = [
+    "buffer_address",
+    "name",
+    "module_address",
+    "buffer_pass",
+    "layer_label",
+    "pass_num",
+    "tensor_shape",
+    "tensor_dtype",
+    "tensor_memory",
+    "tensor_memory_str",
+    "has_saved_activations",
+    "has_gradient",
+    "grad_shape",
+    "grad_dtype",
+    "grad_memory",
+    "grad_memory_str",
+    "buffer_parent",
+    "containing_module",
+    "containing_modules",
 ]
 
 # Per-pass module execution data (one ModulePassLog per forward call to a module).
@@ -392,6 +416,8 @@ MODULE_PASS_LOG_FIELD_ORDER = [
     "num_layers",
     "input_layers",
     "output_layers",
+    "forward_args_summary",
+    "forward_kwargs_summary",
     "forward_args",
     "forward_kwargs",
     "call_parent",

--- a/torchlens/data_classes/_summary.py
+++ b/torchlens/data_classes/_summary.py
@@ -1,0 +1,31 @@
+"""Summary helpers for compact formatting of captured call arguments."""
+
+from typing import Any
+
+import torch
+
+
+def format_call_arg(value: Any) -> str:
+    """Render a compact recursive summary for a captured call argument.
+
+    Parameters
+    ----------
+    value:
+        Arbitrary Python value captured from a module's positional or keyword
+        arguments.
+
+    Returns
+    -------
+    str
+        Recursive string summary following the IO sprint Fork C rules.
+    """
+    if isinstance(value, torch.Tensor):
+        dtype_name = str(value.dtype).removeprefix("torch.")
+        return f"Tensor(shape={tuple(value.shape)}, dtype={dtype_name})"
+    if isinstance(value, (bool, int, float, str)) or value is None:
+        return repr(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(format_call_arg(v) for v in value) + "]"
+    if isinstance(value, dict):
+        return "{" + ", ".join(f"{k}: {format_call_arg(v)}" for k, v in value.items()) + "}"
+    return f"<{type(value).__name__}>"

--- a/torchlens/data_classes/buffer_log.py
+++ b/torchlens/data_classes/buffer_log.py
@@ -13,10 +13,30 @@ can access these fields via ``__getattr__`` delegation.
 """
 
 import weakref
-from typing import Dict, List, Optional, Union
+from os import PathLike
+from typing import Any, Dict, List, Optional, Union
 
-from .layer_pass_log import LayerPassLog
+import pandas as pd
+
+from ..constants import BUFFER_LOG_FIELD_ORDER
 from ..utils.display import human_readable_size
+from .layer_pass_log import LayerPassLog
+
+
+def _buffer_log_to_row(buffer_log: "BufferLog") -> Dict[str, Any]:
+    """Convert a BufferLog into one DataFrame row.
+
+    Parameters
+    ----------
+    buffer_log:
+        Buffer metadata entry to export.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Mapping from canonical field name to exported value.
+    """
+    return {field: getattr(buffer_log, field) for field in BUFFER_LOG_FIELD_ORDER}
 
 
 class BufferLog(LayerPassLog):
@@ -130,3 +150,62 @@ class BufferAccessor:
             items.append(f"'{bl.buffer_address}': BufferLog {shape_str} {dtype_str}")
         inner = ",\n ".join(items)
         return "{" + inner + "}"
+
+    def to_pandas(self) -> "pd.DataFrame":
+        """Export buffer metadata as a pandas DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per buffer, ordered by ``BUFFER_LOG_FIELD_ORDER``.
+        """
+        rows = [_buffer_log_to_row(buffer_log) for buffer_log in self._list]
+        return pd.DataFrame(rows, columns=BUFFER_LOG_FIELD_ORDER)
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the buffer table to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the buffer table to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "pyarrow is required for parquet export; install with 'pip install torchlens[io]'."
+            ) from exc
+        self.to_pandas().to_parquet(filepath, index=False, **kwargs)
+
+    def to_json(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the buffer table to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        kwargs.setdefault("orient", "records")
+        self.to_pandas().to_json(filepath, **kwargs)

--- a/torchlens/data_classes/buffer_log.py
+++ b/torchlens/data_classes/buffer_log.py
@@ -14,7 +14,7 @@ can access these fields via ``__getattr__`` delegation.
 
 import weakref
 from os import PathLike
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import pandas as pd
 
@@ -210,19 +210,26 @@ class BufferAccessor:
             import pyarrow  # noqa: F401
         except ImportError as exc:
             raise ImportError(
-                "pyarrow is required for parquet export; install with 'pip install torchlens[io]'."
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
             ) from exc
-        self.to_pandas().to_parquet(filepath, index=False, **kwargs)
+        self.to_pandas().to_parquet(filepath, **kwargs)
 
-    def to_json(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
         """Write the buffer table to JSON.
 
         Parameters
         ----------
         filepath:
             Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
         **kwargs:
             Additional keyword arguments forwarded to ``DataFrame.to_json``.
         """
-        kwargs.setdefault("orient", "records")
-        self.to_pandas().to_json(filepath, **kwargs)
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)

--- a/torchlens/data_classes/buffer_log.py
+++ b/torchlens/data_classes/buffer_log.py
@@ -13,8 +13,9 @@ can access these fields via ``__getattr__`` delegation.
 """
 
 import weakref
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
+from .._io import FieldPolicy
 from .layer_pass_log import LayerPassLog
 from ..utils.display import human_readable_size
 
@@ -31,6 +32,8 @@ class BufferLog(LayerPassLog):
     from the ``buffer_address`` field in the fields_dict passed to
     the parent ``LayerPassLog.__init__``.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = dict(LayerPassLog.PORTABLE_STATE_SPEC)
 
     @property
     def name(self) -> str:
@@ -68,6 +71,14 @@ class BufferLog(LayerPassLog):
             lines.append(f"  layer_label: {self.layer_label}")
         return "\n".join(lines)
 
+    def __getstate__(self) -> Dict[str, Any]:
+        """Return pickle state for this buffer log."""
+        return super().__getstate__()
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore pickle state for this buffer log."""
+        super().__setstate__(state)
+
 
 class BufferAccessor:
     """Dict-like accessor for BufferLog objects.
@@ -79,6 +90,12 @@ class BufferAccessor:
 
     Available as ``model_log.buffers`` and ``module_log.buffers``.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "_dict": FieldPolicy.KEEP,
+        "_list": FieldPolicy.KEEP,
+        "_source_ref": FieldPolicy.WEAKREF_STRIP,
+    }
 
     def __init__(
         self,

--- a/torchlens/data_classes/cleanup.py
+++ b/torchlens/data_classes/cleanup.py
@@ -43,8 +43,9 @@ def cleanup(self) -> None:
     """Delete all log entries, break circular references, and free GPU memory.
 
     Called explicitly by the user or automatically at the end of a logging
-    session.  After cleanup, the ModelLog is effectively empty and should
-    not be used further.
+    session. After cleanup, the ModelLog is effectively empty and should
+    not be used further. No long-lived safetensors handles need to be
+    closed here because lazy materialization opens and closes files per call.
     """
     # GC-1: Release parameter references to allow model GC.
     if hasattr(self, "param_logs"):
@@ -77,6 +78,9 @@ def cleanup(self) -> None:
         "layer_dict_main_keys",
         "orphan_layers",
         "unlogged_layers",
+        "_loaded_from_bundle",
+        "_source_bundle_manifest_sha256",
+        "_source_bundle_path",
     ]:
         if hasattr(self, attr):
             delattr(self, attr)
@@ -85,6 +89,10 @@ def cleanup(self) -> None:
 
 def _clear_entry_attributes(log_entry: LayerPassLog) -> None:
     """Clear all instance attributes from a LayerPassLog entry."""
+    if hasattr(log_entry, "activation_ref"):
+        log_entry.activation_ref = None
+    if hasattr(log_entry, "gradient_ref"):
+        log_entry.gradient_ref = None
     for attr in list(log_entry.__dict__):
         delattr(log_entry, attr)
 

--- a/torchlens/data_classes/func_call_location.py
+++ b/torchlens/data_classes/func_call_location.py
@@ -26,7 +26,9 @@ actual ``None`` value in the lazy-loading placeholders.
 
 import inspect
 import linecache
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
+
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 
 # Sentinel object to distinguish "not yet loaded" from an actual None value.
 # Used as the default for lazy-loading placeholders so we can tell the
@@ -49,6 +51,27 @@ class FuncCallLocation:
     source-context keyword arguments directly. Values are stored directly
     with no lazy loading.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "file": FieldPolicy.KEEP,
+        "line_number": FieldPolicy.KEEP,
+        "func_name": FieldPolicy.KEEP,
+        "code_firstlineno": FieldPolicy.KEEP,
+        "code_qualname": FieldPolicy.KEEP,
+        "col_offset": FieldPolicy.KEEP,
+        "source_loading_enabled": FieldPolicy.KEEP,
+        "_num_context_lines_requested": FieldPolicy.KEEP,
+        "_frame_func_obj": FieldPolicy.DROP,
+        "_source_loaded": FieldPolicy.KEEP,
+        "_code_context": FieldPolicy.KEEP,
+        "_source_context": FieldPolicy.KEEP,
+        "_code_context_labeled": FieldPolicy.KEEP,
+        "_call_line": FieldPolicy.KEEP,
+        "_num_context_lines": FieldPolicy.KEEP,
+        "_func_signature": FieldPolicy.KEEP,
+        "_func_docstring": FieldPolicy.KEEP,
+        "_linecache_entry": FieldPolicy.DROP,
+    }
 
     def __init__(
         self,
@@ -290,3 +313,16 @@ class FuncCallLocation:
         if self.code_context is None:
             return 0
         return len(self.code_context)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Return pickle state with live frame references stripped."""
+        state = self.__dict__.copy()
+        state["_frame_func_obj"] = None
+        state["io_format_version"] = IO_FORMAT_VERSION
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore pickle state without reviving frame references."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(state, defaults={"_frame_func_obj": None})
+        self.__dict__.update(state)

--- a/torchlens/data_classes/interface.py
+++ b/torchlens/data_classes/interface.py
@@ -23,7 +23,8 @@ For slice keys: returns a list slice of ``layer_list``.
 """
 
 import random
-from typing import List, Tuple, TYPE_CHECKING, Union
+from os import PathLike
+from typing import TYPE_CHECKING, Any, List, Literal, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -539,3 +540,61 @@ def to_pandas(self) -> pd.DataFrame:
     model_df["bool_conditional_id"] = model_df["bool_conditional_id"].astype("Int64")
 
     return model_df
+
+
+def to_csv(self: "ModelLog", filepath: str | PathLike[str], **kwargs: Any) -> None:
+    """Write the layer table to CSV.
+
+    Parameters
+    ----------
+    filepath:
+        Output CSV path.
+    **kwargs:
+        Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+    """
+    self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+
+def to_parquet(self: "ModelLog", filepath: str | PathLike[str], **kwargs: Any) -> None:
+    """Write the layer table to Parquet.
+
+    Parameters
+    ----------
+    filepath:
+        Output Parquet path.
+    **kwargs:
+        Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+    Raises
+    ------
+    ImportError
+        If ``pyarrow`` is unavailable.
+    """
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
+        ) from exc
+    self.to_pandas().to_parquet(filepath, **kwargs)
+
+
+def to_json(
+    self: "ModelLog",
+    filepath: str | PathLike[str],
+    *,
+    orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+    **kwargs: Any,
+) -> None:
+    """Write the layer table to JSON.
+
+    Parameters
+    ----------
+    filepath:
+        Output JSON path.
+    orient:
+        JSON orientation passed to ``DataFrame.to_json``.
+    **kwargs:
+        Additional keyword arguments forwarded to ``DataFrame.to_json``.
+    """
+    self.to_pandas().to_json(filepath, orient=orient, **kwargs)

--- a/torchlens/data_classes/layer_log.py
+++ b/torchlens/data_classes/layer_log.py
@@ -31,7 +31,8 @@ All other 78+ fields use the first pass's values only.
 """
 
 import weakref
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from os import PathLike
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..utils.display import human_readable_size
@@ -763,3 +764,58 @@ class LayerAccessor:
                 }
             )
         return pd.DataFrame(rows)
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the layer table to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the layer table to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
+            ) from exc
+        self.to_pandas().to_parquet(filepath, **kwargs)
+
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
+        """Write the layer table to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)

--- a/torchlens/data_classes/layer_log.py
+++ b/torchlens/data_classes/layer_log.py
@@ -31,8 +31,9 @@ All other 78+ fields use the first pass's values only.
 """
 
 import weakref
-from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..utils.display import human_readable_size
 
 if TYPE_CHECKING:
@@ -57,6 +58,74 @@ class LayerLog:
     ``__getattr__`` delegation (e.g. ``layer_log.activation`` transparently
     reads from ``passes[1].activation``).
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "layer_label": FieldPolicy.KEEP,
+        "layer_label_short": FieldPolicy.KEEP,
+        "layer_type": FieldPolicy.KEEP,
+        "layer_type_num": FieldPolicy.KEEP,
+        "layer_total_num": FieldPolicy.KEEP,
+        "num_passes": FieldPolicy.KEEP,
+        "_source_model_log_ref": FieldPolicy.WEAKREF_STRIP,
+        "func_applied": FieldPolicy.DROP,
+        "func_name": FieldPolicy.KEEP,
+        "func_is_inplace": FieldPolicy.KEEP,
+        "grad_fn_name": FieldPolicy.KEEP,
+        "func_argnames": FieldPolicy.KEEP,
+        "num_args": FieldPolicy.KEEP,
+        "num_positional_args": FieldPolicy.KEEP,
+        "num_keyword_args": FieldPolicy.KEEP,
+        "is_part_of_iterable_output": FieldPolicy.KEEP,
+        "iterable_output_index": FieldPolicy.KEEP,
+        "tensor_shape": FieldPolicy.KEEP,
+        "tensor_dtype": FieldPolicy.KEEP,
+        "tensor_memory": FieldPolicy.KEEP,
+        "output_device": FieldPolicy.KEEP,
+        "activation_postfunc": FieldPolicy.DROP,
+        "detach_saved_tensor": FieldPolicy.KEEP,
+        "save_gradients": FieldPolicy.KEEP,
+        "flops_forward": FieldPolicy.KEEP,
+        "flops_backward": FieldPolicy.KEEP,
+        "parent_param_barcodes": FieldPolicy.KEEP,
+        "parent_param_logs": FieldPolicy.KEEP,
+        "parent_param_shapes": FieldPolicy.KEEP,
+        "num_params_total": FieldPolicy.KEEP,
+        "num_params_trainable": FieldPolicy.KEEP,
+        "num_params_frozen": FieldPolicy.KEEP,
+        "params_memory": FieldPolicy.KEEP,
+        "func_config": FieldPolicy.BLOB_RECURSIVE,
+        "operation_equivalence_type": FieldPolicy.KEEP,
+        "equivalent_operations": FieldPolicy.KEEP,
+        "is_input_layer": FieldPolicy.KEEP,
+        "is_output_layer": FieldPolicy.KEEP,
+        "is_final_output": FieldPolicy.KEEP,
+        "is_buffer_layer": FieldPolicy.KEEP,
+        "buffer_address": FieldPolicy.KEEP,
+        "buffer_parent": FieldPolicy.KEEP,
+        "is_internally_initialized": FieldPolicy.KEEP,
+        "is_internally_terminated": FieldPolicy.KEEP,
+        "is_terminal_bool_layer": FieldPolicy.KEEP,
+        "is_scalar_bool": FieldPolicy.KEEP,
+        "scalar_bool_value": FieldPolicy.KEEP,
+        "in_cond_branch": FieldPolicy.KEEP,
+        "conditional_branch_stacks": FieldPolicy.KEEP,
+        "conditional_branch_stack_passes": FieldPolicy.KEEP,
+        "cond_branch_children_by_cond": FieldPolicy.KEEP,
+        "containing_module": FieldPolicy.KEEP,
+        "containing_modules": FieldPolicy.KEEP,
+        "modules_exited": FieldPolicy.KEEP,
+        "module_passes_exited": FieldPolicy.KEEP,
+        "cond_branch_start_children": FieldPolicy.KEEP,
+        "cond_branch_then_children": FieldPolicy.KEEP,
+        "cond_branch_elif_children": FieldPolicy.KEEP,
+        "cond_branch_else_children": FieldPolicy.KEEP,
+        "has_input_ancestor": FieldPolicy.KEEP,
+        "io_role": FieldPolicy.KEEP,
+        "buffer_pass": FieldPolicy.KEEP,
+        "is_leaf_module_output": FieldPolicy.KEEP,
+        "passes": FieldPolicy.KEEP,
+        "pass_labels": FieldPolicy.KEEP,
+    }
 
     def __init__(self, first_pass: "LayerPassLog"):
         """Initialize from the first pass of this layer.
@@ -213,14 +282,17 @@ class LayerLog:
     def source_model_log(self, value):
         self._source_model_log_ref = weakref.ref(value) if value is not None else None
 
-    def __getstate__(self) -> Dict:
+    def __getstate__(self) -> Dict[str, Any]:
         """Return pickle state with weakrefs stripped."""
         state = self.__dict__.copy()
         state["_source_model_log_ref"] = None
+        state["io_format_version"] = IO_FORMAT_VERSION
         return state
 
-    def __setstate__(self, state: Dict) -> None:
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         """Restore pickle state produced by ``__getstate__``."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(state, defaults={"_source_model_log_ref": None})
         self.__dict__.update(state)
 
     # ********************************************
@@ -607,6 +679,12 @@ class LayerAccessor:
 
     Available as ``model_log.layers``.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "_dict": FieldPolicy.KEEP,
+        "_list": FieldPolicy.KEEP,
+        "_source_ref": FieldPolicy.WEAKREF_STRIP,
+    }
 
     def __init__(
         self,

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -11,25 +11,25 @@ aggregate view across passes is provided by :class:`LayerLog`.
 
 Field categories (matching the LAYER_PASS_LOG_FIELD_ORDER in constants.py):
 
-1. **General info** — raw/final labels, operation numbering, back-reference
+1. **General info** - raw/final labels, operation numbering, back-reference
    to the owning ModelLog.
-2. **Label info** — human-readable labels in various formats (with/without
+2. **Label info** - human-readable labels in various formats (with/without
    pass qualifier, short form, etc.).
-3. **Saved tensor info** — the tensor contents, shape, dtype, size, device
+3. **Saved tensor info** - the tensor contents, shape, dtype, size, device
    transfer settings, activation postfunc, and function arguments.
-4. **Child tensor variations** — tracks per-child input values for
+4. **Child tensor variations** - tracks per-child input values for
    validation replay (``children_tensor_versions`` stores RAW values
    because validation compares against ``captured_args``).
-5. **Gradient info** — gradient tensor and metadata (stored as a bare
+5. **Gradient info** - gradient tensor and metadata (stored as a bare
    reference via ``log_tensor_grad``, not deep-copied).
-6. **Function call info** — the applied function, call stack, timing,
+6. **Function call info** - the applied function, call stack, timing,
    FLOPs, RNG state, arg metadata, grad_fn, inplace flag.
-7. **Param info** — which parameters were used, their shapes and sizes.
-8. **Equivalence info** — loop-detection equivalence type and groups.
-9. **Graph info** — parent/child/sibling/spouse edges, input/output
+7. **Param info** - which parameters were used, their shapes and sizes.
+8. **Equivalence info** - loop-detection equivalence type and groups.
+9. **Graph info** - parent/child/sibling/spouse edges, input/output
    ancestry, distances, buffer/internal-init status.
-10. **Conditional info** — boolean branching metadata.
-11. **Module info** — module entry/exit tracking, nesting depth,
+10. **Conditional info** - boolean branching metadata.
+11. **Module info** - module entry/exit tracking, nesting depth,
     bottom-level submodule output status.
 """
 
@@ -282,13 +282,13 @@ class LayerPassLog:
         self.tensor_dtype = fields_dict["tensor_dtype"]
         self.tensor_memory = fields_dict["tensor_memory"]
 
-        # Child tensor variation tracking — stores the raw tensor values that
+        # Child tensor variation tracking - stores the raw tensor values that
         # each child operation received as input.  Must store RAW values (not
         # postprocessed) because validation compares these against captured_args.
         self.has_child_tensor_variations = fields_dict["has_child_tensor_variations"]
         self.children_tensor_versions = fields_dict["children_tensor_versions"]
 
-        # Saved gradient info — gradient is stored as a bare clone (not deep-copied)
+        # Saved gradient info - gradient is stored as a bare clone (not deep-copied)
         # via log_tensor_grad().  gradient is populated by a backward hook.
         self.gradient = fields_dict["gradient"]
         self.save_gradients = fields_dict["save_gradients"]
@@ -401,11 +401,11 @@ class LayerPassLog:
         self.module_entry_exit_threads_inputs = fields_dict["module_entry_exit_threads_inputs"]
         self.module_entry_exit_thread_output = fields_dict["module_entry_exit_thread_output"]
 
-        # Function config — lightweight hyperparameters always captured.
+        # Function config - lightweight hyperparameters always captured.
         self.func_config = fields_dict["func_config"]
 
         # Back-reference to the aggregate LayerLog that groups all passes of
-        # this layer.  Set during postprocessing by _build_layer_logs — NOT
+        # this layer.  Set during postprocessing by _build_layer_logs - NOT
         # part of fields_dict or FIELD_ORDER (it's a structural link, not
         # captured data).
         self.activation_ref: Optional["LazyActivationRef"] = None
@@ -569,6 +569,14 @@ class LayerPassLog:
         ------
         TorchLensIOError
             If no activation ref is available for this layer.
+
+        Examples
+        --------
+        >>> import torchlens as tl
+        >>> model_log = tl.load("demo_bundle", lazy=True)
+        >>> tensor = model_log["linear_1_1"].materialize_activation()
+        >>> tensor.shape
+        torch.Size([2, 3])
         """
 
         if isinstance(self.activation, torch.Tensor):
@@ -599,6 +607,14 @@ class LayerPassLog:
         ------
         TorchLensIOError
             If no gradient ref is available for this layer.
+
+        Examples
+        --------
+        >>> import torchlens as tl
+        >>> model_log = tl.load("demo_bundle", lazy=True)
+        >>> grad = model_log["linear_1_1"].materialize_gradient()
+        >>> grad.shape
+        torch.Size([2, 3])
         """
 
         if isinstance(self.gradient, torch.Tensor):
@@ -653,13 +669,13 @@ class LayerPassLog:
         Most fields are ``copy.deepcopy``'d so the clone is fully independent.
         However, certain fields are shallow-copied (shared by reference) because:
 
-        * ``func_applied``, ``grad_fn_name`` — function objects, immutable/shared.
-        * ``source_model_log`` — must point to the same ModelLog instance.
-        * ``func_rng_states`` — large state dicts, not mutated after capture.
-        * ``captured_args``, ``captured_kwargs`` — may contain large tensors;
+        * ``func_applied``, ``grad_fn_name`` - function objects, immutable/shared.
+        * ``source_model_log`` - must point to the same ModelLog instance.
+        * ``func_rng_states`` - large state dicts, not mutated after capture.
+        * ``captured_args``, ``captured_kwargs`` - may contain large tensors;
           deep-copying them is expensive and unnecessary.
-        * ``parent_params`` — references to nn.Parameters, must stay shared.
-        * ``activation``, ``children_tensor_versions`` — large tensors;
+        * ``parent_params`` - references to nn.Parameters, must stay shared.
+        * ``activation``, ``children_tensor_versions`` - large tensors;
           shared references are safe since they're replaced (not mutated).
 
         Returns:
@@ -762,7 +778,7 @@ class LayerPassLog:
         """Save the gradient tensor for this layer's output.
 
         Called by the backward hook registered during the forward pass.
-        The gradient is ``detach().clone()``'d — a bare copy, not deep-copied —
+        The gradient is ``detach().clone()``'d - a bare copy, not deep-copied -
         so it's independent of the autograd graph but cheap to store.
 
         Args:

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -218,6 +218,7 @@ class LayerPassLog:
         "module_entry_exit_thread_output": FieldPolicy.KEEP,
         "func_config": FieldPolicy.BLOB_RECURSIVE,
         "activation_ref": FieldPolicy.DROP,
+        "gradient_ref": FieldPolicy.DROP,
         "_pending_blob_id": FieldPolicy.DROP,
         "parent_layer_log": FieldPolicy.DROP,
     }
@@ -408,6 +409,7 @@ class LayerPassLog:
         # part of fields_dict or FIELD_ORDER (it's a structural link, not
         # captured data).
         self.activation_ref: Optional["LazyActivationRef"] = None
+        self.gradient_ref: Optional["LazyActivationRef"] = None
         self._pending_blob_id: Optional[str] = None
         self.parent_layer_log: Optional["LayerLog"] = None
 
@@ -546,6 +548,66 @@ class LayerPassLog:
     def source_model_log(self, value):
         self._source_model_log_ref = weakref.ref(value) if value is not None else None
 
+    def materialize_activation(
+        self,
+        *,
+        map_location: str | torch.device = "cpu",
+    ) -> torch.Tensor:
+        """Materialize this layer's saved activation from a lazy bundle ref.
+
+        Parameters
+        ----------
+        map_location:
+            Target device for the materialized tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Materialized activation tensor.
+
+        Raises
+        ------
+        TorchLensIOError
+            If no activation ref is available for this layer.
+        """
+
+        if isinstance(self.activation, torch.Tensor):
+            return self.activation
+        if self.activation_ref is None:
+            raise TorchLensIOError("no activation_ref to materialize from")
+        self.activation = self.activation_ref.materialize(map_location=map_location)
+        return self.activation
+
+    def materialize_gradient(
+        self,
+        *,
+        map_location: str | torch.device = "cpu",
+    ) -> torch.Tensor:
+        """Materialize this layer's saved gradient from a lazy bundle ref.
+
+        Parameters
+        ----------
+        map_location:
+            Target device for the materialized tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Materialized gradient tensor.
+
+        Raises
+        ------
+        TorchLensIOError
+            If no gradient ref is available for this layer.
+        """
+
+        if isinstance(self.gradient, torch.Tensor):
+            return self.gradient
+        if self.gradient_ref is None:
+            raise TorchLensIOError("no gradient_ref to materialize from")
+        self.gradient = self.gradient_ref.materialize(map_location=map_location)
+        return self.gradient
+
     def __getstate__(self) -> Dict[str, Any]:
         """Return pickle state with weakrefs stripped."""
         state = self.__dict__.copy()
@@ -562,6 +624,7 @@ class LayerPassLog:
                 "_source_model_log_ref": None,
                 "parent_layer_log": None,
                 "activation_ref": None,
+                "gradient_ref": None,
                 "_pending_blob_id": None,
             },
         )

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -39,7 +39,13 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Un
 
 import torch
 
-from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
+from .._io import (
+    FieldPolicy,
+    IO_FORMAT_VERSION,
+    TorchLensIOError,
+    default_fill_state,
+    read_io_format_version,
+)
 from ..constants import LAYER_PASS_LOG_FIELD_ORDER
 from .._state import pause_logging
 from ..utils.tensor_utils import get_tensor_memory_amount, print_override, safe_copy, safe_to
@@ -60,6 +66,7 @@ def _recursive_safe_copy(val):
 
 
 if TYPE_CHECKING:
+    from .._io.lazy import LazyActivationRef
     from .func_call_location import FuncCallLocation
     from .layer_log import LayerLog
     from .param_log import ParamLog
@@ -210,6 +217,8 @@ class LayerPassLog:
         "module_entry_exit_threads_inputs": FieldPolicy.KEEP,
         "module_entry_exit_thread_output": FieldPolicy.KEEP,
         "func_config": FieldPolicy.BLOB_RECURSIVE,
+        "activation_ref": FieldPolicy.DROP,
+        "_pending_blob_id": FieldPolicy.DROP,
         "parent_layer_log": FieldPolicy.DROP,
     }
 
@@ -398,6 +407,8 @@ class LayerPassLog:
         # this layer.  Set during postprocessing by _build_layer_logs — NOT
         # part of fields_dict or FIELD_ORDER (it's a structural link, not
         # captured data).
+        self.activation_ref: Optional["LazyActivationRef"] = None
+        self._pending_blob_id: Optional[str] = None
         self.parent_layer_log: Optional["LayerLog"] = None
 
     @property
@@ -501,6 +512,26 @@ class LayerPassLog:
         return human_readable_size(self.params_memory)
 
     @property
+    def _streaming_label(self) -> str:
+        """Best available label for sink/writer callbacks during or after postprocess.
+
+        Returns
+        -------
+        str
+            Pass-qualified label when available, otherwise the current layer label.
+        """
+
+        for candidate in (
+            self.layer_label_w_pass,
+            self.layer_label,
+            self.layer_label_raw,
+            self.tensor_label_raw,
+        ):
+            if candidate is not None:
+                return str(candidate)
+        return "<unknown>"
+
+    @property
     def source_model_log(self) -> "ModelLog":
         """Back-reference to the owning ModelLog (stored as weakref)."""
         ref = self.__dict__.get("_source_model_log_ref")
@@ -527,7 +558,12 @@ class LayerPassLog:
         read_io_format_version(state, cls_name=type(self).__name__)
         default_fill_state(
             state,
-            defaults={"_source_model_log_ref": None, "parent_layer_log": None},
+            defaults={
+                "_source_model_log_ref": None,
+                "parent_layer_log": None,
+                "activation_ref": None,
+                "_pending_blob_id": None,
+            },
         )
         self.__dict__.update(state)
 
@@ -593,7 +629,7 @@ class LayerPassLog:
         t_kwargs: Dict,
         save_function_args: bool,
         activation_postfunc: Optional[Callable] = None,
-    ):
+    ) -> None:
         """Save the output tensor (and optionally args) for this operation.
 
         Flow:
@@ -612,18 +648,43 @@ class LayerPassLog:
             activation_postfunc: Optional transform applied to the tensor
                 before storing (e.g. detach, to-numpy, normalize).
         """
-        # Clone the tensor, optionally detaching from autograd graph.
-        self.activation = safe_copy(t, self.detach_saved_tensor)
-        # Move to the user-requested output device if needed.
-        if self.output_device not in [str(self.activation.device), "same"]:
-            self.activation = safe_to(self.activation, self.output_device)
-        # Apply user's postfunc with logging paused so postfunc's own ops
-        # (e.g. .mean(), .float()) don't get logged as model operations.
-        if activation_postfunc is not None:
-            with pause_logging():
-                self.activation = activation_postfunc(self.activation)
+        model_log = self.source_model_log
+        writer = getattr(model_log, "_activation_writer", None) if model_log is not None else None
+        try:
+            # Clone the tensor, optionally detaching from autograd graph.
+            self.activation = safe_copy(t, self.detach_saved_tensor)
+            # Move to the user-requested output device if needed.
+            if self.output_device not in [str(self.activation.device), "same"]:
+                self.activation = safe_to(self.activation, self.output_device)
+            # Apply user's postfunc with logging paused so postfunc's own ops
+            # (e.g. .mean(), .float()) don't get logged as model operations.
+            if activation_postfunc is not None:
+                with pause_logging():
+                    self.activation = activation_postfunc(self.activation)
+        except Exception as exc:
+            if writer is not None:
+                writer.abort(f"Failed while saving activation for {self._streaming_label}: {exc}")
+                raise TorchLensIOError(
+                    f"Streaming activation save failed for {self._streaming_label}."
+                ) from exc
+            raise
 
         self.has_saved_activations = True
+
+        if model_log is not None:
+            activation_sink = getattr(model_log, "_activation_sink", None)
+            if activation_sink is not None and isinstance(self.activation, torch.Tensor):
+                activation_sink(self._streaming_label, self.activation)
+
+            if writer is not None and getattr(model_log, "_in_exhaustive_pass", False):
+                blob_id = writer.next_blob_id()
+                self._pending_blob_id = blob_id
+                writer.write_blob(
+                    blob_id,
+                    self.activation,
+                    kind="activation",
+                    label=self._streaming_label,
+                )
 
         # Tensor args and kwargs:
         if save_function_args:

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -35,10 +35,11 @@ Field categories (matching the LAYER_PASS_LOG_FIELD_ORDER in constants.py):
 
 import copy
 import weakref
-from typing import Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
 
 import torch
 
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..constants import LAYER_PASS_LOG_FIELD_ORDER
 from .._state import pause_logging
 from ..utils.tensor_utils import get_tensor_memory_amount, print_override, safe_copy, safe_to
@@ -84,6 +85,133 @@ class LayerPassLog:
       that owns this pass.  It is set *outside* fields_dict during
       ``_build_layer_logs`` and is intentionally absent from FIELD_ORDER.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "tensor_label_raw": FieldPolicy.KEEP,
+        "layer_label_raw": FieldPolicy.KEEP,
+        "operation_num": FieldPolicy.KEEP,
+        "creation_order": FieldPolicy.KEEP,
+        "_source_model_log_ref": FieldPolicy.WEAKREF_STRIP,
+        "_pass_finished": FieldPolicy.KEEP,
+        "layer_label": FieldPolicy.KEEP,
+        "layer_label_short": FieldPolicy.KEEP,
+        "layer_label_w_pass": FieldPolicy.KEEP,
+        "layer_label_w_pass_short": FieldPolicy.KEEP,
+        "layer_label_no_pass": FieldPolicy.KEEP,
+        "layer_label_no_pass_short": FieldPolicy.KEEP,
+        "layer_type": FieldPolicy.KEEP,
+        "layer_type_num": FieldPolicy.KEEP,
+        "layer_total_num": FieldPolicy.KEEP,
+        "pass_num": FieldPolicy.KEEP,
+        "num_passes": FieldPolicy.KEEP,
+        "lookup_keys": FieldPolicy.KEEP,
+        "activation": FieldPolicy.BLOB,
+        "has_saved_activations": FieldPolicy.KEEP,
+        "output_device": FieldPolicy.KEEP,
+        "activation_postfunc": FieldPolicy.DROP,
+        "detach_saved_tensor": FieldPolicy.KEEP,
+        "args_captured": FieldPolicy.KEEP,
+        "captured_args": FieldPolicy.BLOB_RECURSIVE,
+        "captured_kwargs": FieldPolicy.BLOB_RECURSIVE,
+        "tensor_shape": FieldPolicy.KEEP,
+        "tensor_dtype": FieldPolicy.KEEP,
+        "tensor_memory": FieldPolicy.KEEP,
+        "has_child_tensor_variations": FieldPolicy.KEEP,
+        "children_tensor_versions": FieldPolicy.BLOB_RECURSIVE,
+        "gradient": FieldPolicy.BLOB,
+        "save_gradients": FieldPolicy.KEEP,
+        "has_gradient": FieldPolicy.KEEP,
+        "grad_shape": FieldPolicy.KEEP,
+        "grad_dtype": FieldPolicy.KEEP,
+        "grad_memory": FieldPolicy.KEEP,
+        "func_applied": FieldPolicy.DROP,
+        "func_name": FieldPolicy.KEEP,
+        "func_call_stack": FieldPolicy.KEEP,
+        "func_time": FieldPolicy.KEEP,
+        "flops_forward": FieldPolicy.KEEP,
+        "flops_backward": FieldPolicy.KEEP,
+        "func_rng_states": FieldPolicy.BLOB_RECURSIVE,
+        "func_autocast_state": FieldPolicy.KEEP,
+        "func_argnames": FieldPolicy.KEEP,
+        "num_args": FieldPolicy.KEEP,
+        "num_positional_args": FieldPolicy.KEEP,
+        "num_keyword_args": FieldPolicy.KEEP,
+        "func_positional_args_non_tensor": FieldPolicy.KEEP,
+        "func_kwargs_non_tensor": FieldPolicy.KEEP,
+        "func_non_tensor_args": FieldPolicy.KEEP,
+        "func_is_inplace": FieldPolicy.KEEP,
+        "grad_fn_name": FieldPolicy.KEEP,
+        "is_part_of_iterable_output": FieldPolicy.KEEP,
+        "iterable_output_index": FieldPolicy.KEEP,
+        "parent_params": FieldPolicy.KEEP,
+        "parent_param_barcodes": FieldPolicy.KEEP,
+        "parent_param_passes": FieldPolicy.KEEP,
+        "parent_param_logs": FieldPolicy.KEEP,
+        "parent_param_shapes": FieldPolicy.KEEP,
+        "num_params_total": FieldPolicy.KEEP,
+        "num_params_trainable": FieldPolicy.KEEP,
+        "num_params_frozen": FieldPolicy.KEEP,
+        "params_memory": FieldPolicy.KEEP,
+        "operation_equivalence_type": FieldPolicy.KEEP,
+        "equivalent_operations": FieldPolicy.KEEP,
+        "recurrent_group": FieldPolicy.KEEP,
+        "parent_layers": FieldPolicy.KEEP,
+        "parent_layer_arg_locs": FieldPolicy.KEEP,
+        "root_ancestors": FieldPolicy.KEEP,
+        "child_layers": FieldPolicy.KEEP,
+        "has_children": FieldPolicy.KEEP,
+        "is_input_layer": FieldPolicy.KEEP,
+        "has_input_ancestor": FieldPolicy.KEEP,
+        "input_ancestors": FieldPolicy.KEEP,
+        "min_distance_from_input": FieldPolicy.KEEP,
+        "max_distance_from_input": FieldPolicy.KEEP,
+        "is_output_layer": FieldPolicy.KEEP,
+        "feeds_output": FieldPolicy.KEEP,
+        "is_final_output": FieldPolicy.KEEP,
+        "is_output_ancestor": FieldPolicy.KEEP,
+        "output_descendants": FieldPolicy.KEEP,
+        "min_distance_from_output": FieldPolicy.KEEP,
+        "max_distance_from_output": FieldPolicy.KEEP,
+        "io_role": FieldPolicy.KEEP,
+        "is_buffer_layer": FieldPolicy.KEEP,
+        "buffer_address": FieldPolicy.KEEP,
+        "buffer_pass": FieldPolicy.KEEP,
+        "buffer_parent": FieldPolicy.KEEP,
+        "is_internally_initialized": FieldPolicy.KEEP,
+        "has_internally_initialized_ancestor": FieldPolicy.KEEP,
+        "internally_initialized_parents": FieldPolicy.KEEP,
+        "internally_initialized_ancestors": FieldPolicy.KEEP,
+        "is_internally_terminated": FieldPolicy.KEEP,
+        "is_terminal_bool_layer": FieldPolicy.KEEP,
+        "bool_is_branch": FieldPolicy.KEEP,
+        "bool_context_kind": FieldPolicy.KEEP,
+        "bool_wrapper_kind": FieldPolicy.KEEP,
+        "bool_conditional_id": FieldPolicy.KEEP,
+        "is_scalar_bool": FieldPolicy.KEEP,
+        "scalar_bool_value": FieldPolicy.KEEP,
+        "in_cond_branch": FieldPolicy.KEEP,
+        "conditional_branch_stack": FieldPolicy.KEEP,
+        "conditional_branch_depth": FieldPolicy.KEEP,
+        "cond_branch_start_children": FieldPolicy.KEEP,
+        "cond_branch_then_children": FieldPolicy.KEEP,
+        "cond_branch_elif_children": FieldPolicy.KEEP,
+        "cond_branch_else_children": FieldPolicy.KEEP,
+        "cond_branch_children_by_cond": FieldPolicy.KEEP,
+        "containing_module": FieldPolicy.KEEP,
+        "containing_modules": FieldPolicy.KEEP,
+        "modules_entered": FieldPolicy.KEEP,
+        "modules_entered_argnames": FieldPolicy.KEEP,
+        "module_passes_entered": FieldPolicy.KEEP,
+        "modules_exited": FieldPolicy.KEEP,
+        "module_passes_exited": FieldPolicy.KEEP,
+        "is_submodule_output": FieldPolicy.KEEP,
+        "is_leaf_module_output": FieldPolicy.KEEP,
+        "leaf_module_pass": FieldPolicy.KEEP,
+        "module_entry_exit_threads_inputs": FieldPolicy.KEEP,
+        "module_entry_exit_thread_output": FieldPolicy.KEEP,
+        "func_config": FieldPolicy.BLOB_RECURSIVE,
+        "parent_layer_log": FieldPolicy.DROP,
+    }
 
     def __init__(self, fields_dict: Dict):
         """Initialise from a complete fields dictionary.
@@ -387,14 +515,20 @@ class LayerPassLog:
     def source_model_log(self, value):
         self._source_model_log_ref = weakref.ref(value) if value is not None else None
 
-    def __getstate__(self) -> Dict:
+    def __getstate__(self) -> Dict[str, Any]:
         """Return pickle state with weakrefs stripped."""
         state = self.__dict__.copy()
         state["_source_model_log_ref"] = None
+        state["io_format_version"] = IO_FORMAT_VERSION
         return state
 
-    def __setstate__(self, state: Dict) -> None:
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         """Restore pickle state produced by ``__getstate__``."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(
+            state,
+            defaults={"_source_model_log_ref": None, "parent_layer_log": None},
+        )
         self.__dict__.update(state)
 
     # ********************************************

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -7,7 +7,7 @@ bookkeeping.
 
 Key design patterns:
 
-* **_pass_finished behavioural switch** — Many methods (``__len__``, ``__getitem__``,
+* **_pass_finished behavioural switch** - Many methods (``__len__``, ``__getitem__``,
   ``__str__``, ``__iter__``) behave differently during logging vs after
   postprocessing.  While logging is active (``_pass_finished=False``), the
   model's tensors are keyed by their raw internal barcodes in
@@ -17,13 +17,13 @@ Key design patterns:
   persists across the fast pass on purpose: fast-path postprocessing
   relies on the fully-populated lookup dicts from the exhaustive pass.
 
-* **Method importation** — Several heavy methods (``render_graph``,
+* **Method importation** - Several heavy methods (``render_graph``,
   ``save_new_activations``, ``validate_saved_activations``, etc.) are
   defined in other modules and bound to ModelLog as class attributes at
   the bottom of this file.  This keeps the class body small while giving
   users ``model_log.render_graph(...)`` syntax.
 
-* **_module_build_data** — A transient dict that accumulates module hierarchy
+* **_module_build_data** - A transient dict that accumulates module hierarchy
   information during the forward pass.  Consumed by ``_build_module_logs``
   (postprocessing step 17) and then cleared.  Initialised via
   ``_init_module_build_data()``.
@@ -264,7 +264,7 @@ class ModelLog:
                 have optimizers attached.
             verbose: If True, print timed progress messages at each major pipeline stage.
         """
-        # Callables are effectively immutable — deepcopy is unnecessary.
+        # Callables are effectively immutable - deepcopy is unnecessary.
 
         # General info
         self.model_name = model_name
@@ -307,7 +307,7 @@ class ModelLog:
         # Model structure info (computed @properties: is_recurrent,
         # max_recurrent_loops, is_branching, has_conditional_branching)
 
-        # Tensor Tracking — post-processed (populated after _pass_finished=True):
+        # Tensor Tracking - post-processed (populated after _pass_finished=True):
         self.layer_list: List[LayerPassLog] = []  # ordered list of all layer passes
         self.layer_dict_main_keys: Dict[str, LayerPassLog] = OrderedDict()  # primary label -> entry
         self.layer_dict_all_keys: Dict[str, LayerPassLog] = (
@@ -318,7 +318,7 @@ class ModelLog:
         self.layer_labels_w_pass: List[str] = []  # pass-qualified labels (e.g. "conv2d_1_1:1")
         self.layer_labels_no_pass: List[str] = []  # pass-stripped labels (e.g. "conv2d_1_1")
         self.layer_num_passes: Dict[str, int] = OrderedDict()  # no-pass label -> pass count
-        # Tensor Tracking — raw (populated during the forward pass, before postprocessing):
+        # Tensor Tracking - raw (populated during the forward pass, before postprocessing):
         self._raw_layer_dict: Dict[str, LayerPassLog] = OrderedDict()  # raw barcode -> entry
         self._raw_layer_labels_list: List[str] = []
         self._layer_nums_to_save: List[int] = []  # ordinal positions of layers to save
@@ -379,7 +379,7 @@ class ModelLog:
 
         # Session-scoped per-module tracking dicts (keyed by id(module)).
         # These replace the old tl_* attrs that were set directly on nn.Module
-        # instances. Lives on ModelLog so they're GC'd with the log — no cleanup
+        # instances. Lives on ModelLog so they're GC'd with the log - no cleanup
         # iteration over modules needed.
         self._mod_pass_num: Dict[int, int] = {}  # id(module) -> pass count
         self._mod_pass_labels: Dict[int, list] = {}  # id(module) -> [(addr, pass_num), ...]
@@ -449,15 +449,7 @@ class ModelLog:
             return iter(list(self._raw_layer_dict.values()))
 
     def save(self, path: str | Path, **kwargs: Any) -> None:
-        """Persist this log via ``torchlens.save``.
-
-        Parameters
-        ----------
-        path:
-            Output bundle directory path.
-        **kwargs:
-            Keyword arguments forwarded to ``torchlens.save``.
-        """
+        """Call :func:`torchlens.save` for this model log."""
 
         from .._io.bundle import save as save_bundle
 
@@ -465,20 +457,7 @@ class ModelLog:
 
     @classmethod
     def load(cls, path: str | Path, **kwargs: Any) -> "ModelLog":
-        """Load a portable bundle via ``torchlens.load``.
-
-        Parameters
-        ----------
-        path:
-            Input bundle directory path.
-        **kwargs:
-            Keyword arguments forwarded to ``torchlens.load``.
-
-        Returns
-        -------
-        ModelLog
-            Loaded model log.
-        """
+        """Call :func:`torchlens.load` and return the loaded model log."""
 
         from .._io.bundle import load as load_bundle
 

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -31,6 +31,7 @@ Key design patterns:
 
 import copy
 from collections import OrderedDict, defaultdict
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, TYPE_CHECKING, Tuple
 
@@ -432,6 +433,43 @@ class ModelLog:
             return iter(self.layer_list)
         else:
             return iter(list(self._raw_layer_dict.values()))
+
+    def save(self, path: str | Path, **kwargs: Any) -> None:
+        """Persist this log via ``torchlens.save``.
+
+        Parameters
+        ----------
+        path:
+            Output bundle directory path.
+        **kwargs:
+            Keyword arguments forwarded to ``torchlens.save``.
+        """
+
+        from .._io.bundle import save as save_bundle
+
+        save_bundle(self, path, **kwargs)
+
+    @classmethod
+    def load(cls, path: str | Path, **kwargs: Any) -> "ModelLog":
+        """Load a portable bundle via ``torchlens.load``.
+
+        Parameters
+        ----------
+        path:
+            Input bundle directory path.
+        **kwargs:
+            Keyword arguments forwarded to ``torchlens.load``.
+
+        Returns
+        -------
+        ModelLog
+            Loaded model log.
+        """
+
+        from .._io.bundle import load as load_bundle
+
+        loaded = load_bundle(path, **kwargs)
+        return loaded
 
     def __getstate__(self) -> Dict[str, Any]:
         """Return pickle state with non-picklable weakref-backed accessors stripped."""

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from .buffer_log import BufferAccessor
     from .layer_log import LayerAccessor
 
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from .cleanup import _remove_log_entry, _batch_remove_log_entries, cleanup, release_param_refs
 from .module_log import ModuleAccessor
 from .param_log import ParamAccessor
@@ -122,6 +123,100 @@ class ModelLog:
     integer index, layer label, module address, or substring.
     """
 
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "model_name": FieldPolicy.KEEP,
+        "num_context_lines": FieldPolicy.KEEP,
+        "_optimizer": FieldPolicy.DROP,
+        "io_format_version": FieldPolicy.KEEP,
+        "_pass_finished": FieldPolicy.KEEP,
+        "logging_mode": FieldPolicy.KEEP,
+        "_all_layers_logged": FieldPolicy.KEEP,
+        "_all_layers_saved": FieldPolicy.KEEP,
+        "keep_unsaved_layers": FieldPolicy.KEEP,
+        "activation_postfunc": FieldPolicy.DROP,
+        "activation_postfunc_repr": FieldPolicy.KEEP,
+        "current_function_call_barcode": FieldPolicy.KEEP,
+        "random_seed_used": FieldPolicy.KEEP,
+        "output_device": FieldPolicy.KEEP,
+        "detach_saved_tensors": FieldPolicy.KEEP,
+        "save_function_args": FieldPolicy.KEEP,
+        "save_gradients": FieldPolicy.KEEP,
+        "save_source_context": FieldPolicy.KEEP,
+        "save_rng_states": FieldPolicy.KEEP,
+        "detect_loops": FieldPolicy.KEEP,
+        "verbose": FieldPolicy.KEEP,
+        "has_gradients": FieldPolicy.KEEP,
+        "mark_input_output_distances": FieldPolicy.KEEP,
+        "layer_list": FieldPolicy.KEEP,
+        "layer_dict_main_keys": FieldPolicy.KEEP,
+        "layer_dict_all_keys": FieldPolicy.KEEP,
+        "layer_logs": FieldPolicy.KEEP,
+        "layer_labels": FieldPolicy.KEEP,
+        "layer_labels_w_pass": FieldPolicy.KEEP,
+        "layer_labels_no_pass": FieldPolicy.KEEP,
+        "layer_num_passes": FieldPolicy.KEEP,
+        "_raw_layer_dict": FieldPolicy.KEEP,
+        "_raw_layer_labels_list": FieldPolicy.KEEP,
+        "_layer_nums_to_save": FieldPolicy.KEEP,
+        "_layer_counter": FieldPolicy.KEEP,
+        "num_operations": FieldPolicy.KEEP,
+        "_raw_layer_type_counter": FieldPolicy.KEEP,
+        "_unsaved_layers_lookup_keys": FieldPolicy.KEEP,
+        "_raw_to_final_layer_labels": FieldPolicy.KEEP,
+        "_final_to_raw_layer_labels": FieldPolicy.KEEP,
+        "_lookup_keys_to_layer_num_dict": FieldPolicy.KEEP,
+        "_layer_num_to_lookup_keys_dict": FieldPolicy.KEEP,
+        "input_layers": FieldPolicy.KEEP,
+        "output_layers": FieldPolicy.KEEP,
+        "buffer_layers": FieldPolicy.KEEP,
+        "buffer_num_passes": FieldPolicy.KEEP,
+        "_buffer_accessor": FieldPolicy.DROP,
+        "internally_initialized_layers": FieldPolicy.KEEP,
+        "_layers_where_internal_branches_merge_with_input": FieldPolicy.KEEP,
+        "internally_terminated_layers": FieldPolicy.KEEP,
+        "internally_terminated_bool_layers": FieldPolicy.KEEP,
+        "conditional_branch_edges": FieldPolicy.KEEP,
+        "conditional_then_edges": FieldPolicy.KEEP,
+        "conditional_elif_edges": FieldPolicy.KEEP,
+        "conditional_else_edges": FieldPolicy.KEEP,
+        "conditional_events": FieldPolicy.KEEP,
+        "conditional_arm_edges": FieldPolicy.KEEP,
+        "conditional_edge_passes": FieldPolicy.KEEP,
+        "layers_with_saved_activations": FieldPolicy.KEEP,
+        "orphan_layers": FieldPolicy.KEEP,
+        "unlogged_layers": FieldPolicy.KEEP,
+        "layers_with_saved_gradients": FieldPolicy.KEEP,
+        "_saved_gradients_set": FieldPolicy.DROP,
+        "layers_with_params": FieldPolicy.KEEP,
+        "equivalent_operations": FieldPolicy.KEEP,
+        "total_activation_memory": FieldPolicy.KEEP,
+        "num_tensors_saved": FieldPolicy.KEEP,
+        "saved_activation_memory": FieldPolicy.KEEP,
+        "param_logs": FieldPolicy.KEEP,
+        "total_param_tensors": FieldPolicy.KEEP,
+        "total_param_layers": FieldPolicy.KEEP,
+        "total_params": FieldPolicy.KEEP,
+        "total_params_trainable": FieldPolicy.KEEP,
+        "total_params_frozen": FieldPolicy.KEEP,
+        "total_params_memory": FieldPolicy.KEEP,
+        "_mod_pass_num": FieldPolicy.DROP,
+        "_mod_pass_labels": FieldPolicy.DROP,
+        "_mod_entered": FieldPolicy.DROP,
+        "_mod_exited": FieldPolicy.DROP,
+        "_module_build_data": FieldPolicy.DROP,
+        "_module_logs": FieldPolicy.DROP,
+        "_module_metadata": FieldPolicy.DROP,
+        "_module_forward_args": FieldPolicy.DROP,
+        "_param_logs_by_module": FieldPolicy.DROP,
+        "_pre_forward_rng_states": FieldPolicy.DROP,
+        "pass_start_time": FieldPolicy.KEEP,
+        "pass_end_time": FieldPolicy.KEEP,
+        "time_setup": FieldPolicy.KEEP,
+        "time_forward_pass": FieldPolicy.KEEP,
+        "time_cleanup": FieldPolicy.KEEP,
+        "time_function_calls": FieldPolicy.KEEP,
+    }
+
     def __init__(
         self,
         model_name: str,
@@ -164,6 +259,7 @@ class ModelLog:
         self.model_name = model_name
         self.num_context_lines = num_context_lines
         self._optimizer = optimizer
+        self.io_format_version = IO_FORMAT_VERSION
         # _pass_finished is the master behavioural switch: False during logging,
         # True after postprocessing.  Many methods (len, getitem, str, iter)
         # branch on this flag to choose raw-barcode vs final-label access.
@@ -177,6 +273,9 @@ class ModelLog:
         self._all_layers_saved = False
         self.keep_unsaved_layers = keep_unsaved_layers
         self.activation_postfunc = activation_postfunc
+        self.activation_postfunc_repr = (
+            repr(activation_postfunc) if activation_postfunc is not None else None
+        )
         self.current_function_call_barcode = None
         self.random_seed_used = None
         self.output_device = output_device
@@ -341,10 +440,25 @@ class ModelLog:
         state["_buffer_accessor"] = None
         state["_module_build_data"] = None
         state["_raw_layer_type_counter"] = dict(self._raw_layer_type_counter)
+        state["activation_postfunc_repr"] = (
+            repr(self.activation_postfunc) if self.activation_postfunc is not None else None
+        )
+        state["io_format_version"] = IO_FORMAT_VERSION
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         """Restore pickle state and rebuild weakref-backed links."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(
+            state,
+            defaults={
+                "io_format_version": IO_FORMAT_VERSION,
+                "activation_postfunc_repr": None,
+                "_buffer_accessor": None,
+                "_module_logs": None,
+                "_module_build_data": None,
+            },
+        )
         self.__dict__.update(state)
         if self.__dict__.get("_module_logs") is None:
             self._module_logs = ModuleAccessor({})

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -48,6 +48,9 @@ from .interface import (
     _getitem_during_pass,
     _str_after_pass,
     _str_during_pass,
+    to_csv,
+    to_json,
+    to_parquet,
     to_pandas,
     print_all_fields,
 )
@@ -662,6 +665,9 @@ class ModelLog:
     visualization_field_audit = build_render_audit
     print_all_fields = print_all_fields
     to_pandas = to_pandas
+    to_csv = to_csv
+    to_parquet = to_parquet
+    to_json = to_json
     save_new_activations = save_new_activations
     validate_saved_activations = validate_saved_activations
     validate_forward_pass = validate_saved_activations  # user-facing alias

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -35,7 +35,10 @@ from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, TYPE_CHECKING, Tuple
 
+import torch
+
 if TYPE_CHECKING:
+    from .._io.streaming import BundleStreamWriter
     from .buffer_log import BufferAccessor
     from .layer_log import LayerAccessor
 
@@ -213,6 +216,10 @@ class ModelLog:
         "_module_forward_args": FieldPolicy.DROP,
         "_param_logs_by_module": FieldPolicy.DROP,
         "_pre_forward_rng_states": FieldPolicy.DROP,
+        "_activation_writer": FieldPolicy.DROP,
+        "_keep_activations_in_memory": FieldPolicy.DROP,
+        "_activation_sink": FieldPolicy.DROP,
+        "_in_exhaustive_pass": FieldPolicy.DROP,
         "pass_start_time": FieldPolicy.KEEP,
         "pass_end_time": FieldPolicy.KEEP,
         "time_setup": FieldPolicy.KEEP,
@@ -292,6 +299,10 @@ class ModelLog:
         self.verbose = verbose
         self.has_gradients = False
         self.mark_input_output_distances = mark_input_output_distances
+        self._activation_writer: Optional["BundleStreamWriter"] = None
+        self._keep_activations_in_memory: bool = True
+        self._activation_sink: Optional[Callable[[str, torch.Tensor], None]] = None
+        self._in_exhaustive_pass: bool = True
 
         # Model structure info (computed @properties: is_recurrent,
         # max_recurrent_loops, is_branching, has_conditional_branching)
@@ -498,6 +509,10 @@ class ModelLog:
                 "_buffer_accessor": None,
                 "_module_logs": None,
                 "_module_build_data": None,
+                "_activation_writer": None,
+                "_keep_activations_in_memory": True,
+                "_activation_sink": None,
+                "_in_exhaustive_pass": False,
             },
         )
         self.__dict__.update(state)

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -449,7 +449,13 @@ class ModelLog:
             return iter(list(self._raw_layer_dict.values()))
 
     def save(self, path: str | Path, **kwargs: Any) -> None:
-        """Call :func:`torchlens.save` for this model log."""
+        """Call :func:`torchlens.save` for this model log.
+
+        Warning
+        -------
+        Portable bundles contain a pickle file. Only load bundles from trusted
+        sources. Loading an untrusted bundle can execute arbitrary code.
+        """
 
         from .._io.bundle import save as save_bundle
 
@@ -457,7 +463,13 @@ class ModelLog:
 
     @classmethod
     def load(cls, path: str | Path, **kwargs: Any) -> "ModelLog":
-        """Call :func:`torchlens.load` and return the loaded model log."""
+        """Call :func:`torchlens.load` and return the loaded model log.
+
+        Warning
+        -------
+        Portable bundles contain a pickle file. Only load bundles from trusted
+        sources. Loading an untrusted bundle can execute arbitrary code.
+        """
 
         from .._io.bundle import load as load_bundle
 

--- a/torchlens/data_classes/module_log.py
+++ b/torchlens/data_classes/module_log.py
@@ -25,7 +25,7 @@ This matches each accessor's natural granularity.
 import pandas as pd
 import weakref
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..constants import MODULE_PASS_LOG_FIELD_ORDER
@@ -178,22 +178,29 @@ class ModulePassLog:
             import pyarrow  # noqa: F401
         except ImportError as exc:
             raise ImportError(
-                "pyarrow is required for parquet export; install with 'pip install torchlens[io]'."
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
             ) from exc
-        self.to_pandas().to_parquet(filepath, index=False, **kwargs)
+        self.to_pandas().to_parquet(filepath, **kwargs)
 
-    def to_json(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
         """Write this module-pass row to JSON.
 
         Parameters
         ----------
         filepath:
             Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
         **kwargs:
             Additional keyword arguments forwarded to ``DataFrame.to_json``.
         """
-        kwargs.setdefault("orient", "records")
-        self.to_pandas().to_json(filepath, **kwargs)
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)
 
     def __getstate__(self) -> Dict[str, Any]:
         """Return pickle state annotated with the current I/O format version."""
@@ -565,6 +572,13 @@ class ModuleLog:
         return iter(self._source_model_log[label] for label in self.all_layers)
 
     def to_pandas(self) -> "pd.DataFrame":
+        """Export this module's layers as a pandas DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per layer belonging to this module.
+        """
         if self._source_model_log is None:
             raise RuntimeError("No source ModelLog reference; cannot build DataFrame.")
         rows = []
@@ -581,6 +595,61 @@ class ModuleLog:
                 }
             )
         return pd.DataFrame(rows)
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write this module's layer table to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write this module's layer table to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
+            ) from exc
+        self.to_pandas().to_parquet(filepath, **kwargs)
+
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
+        """Write this module's layer table to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)
 
 
 class ModuleAccessor:
@@ -669,6 +738,13 @@ class ModuleAccessor:
         return f"ModuleAccessor({len(self)} modules):\n{inner}"
 
     def to_pandas(self) -> "pd.DataFrame":
+        """Export module metadata as a pandas DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per module in address order.
+        """
         rows = []
         for ml in self._list:
             rows.append(
@@ -683,6 +759,61 @@ class ModuleAccessor:
                 }
             )
         return pd.DataFrame(rows)
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the module table to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the module table to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
+            ) from exc
+        self.to_pandas().to_parquet(filepath, **kwargs)
+
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
+        """Write the module table to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)
 
     def summary(self) -> str:
         if len(self) == 0:

--- a/torchlens/data_classes/module_log.py
+++ b/torchlens/data_classes/module_log.py
@@ -22,12 +22,12 @@ ModuleLog vs ModulePassLog label convention:
 This matches each accessor's natural granularity.
 """
 
-import weakref
-from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
-
-from ..utils.display import human_readable_size
-
 import pandas as pd
+import weakref
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
+from ..utils.display import human_readable_size
 
 if TYPE_CHECKING:
     from .param_log import ParamAccessor
@@ -43,6 +43,20 @@ class ModulePassLog:
     ``layers`` stores **pass-qualified** labels (e.g. ``"conv2d_1_1:1"``)
     that resolve to individual LayerPassLog entries.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "module_address": FieldPolicy.KEEP,
+        "pass_num": FieldPolicy.KEEP,
+        "pass_label": FieldPolicy.KEEP,
+        "layers": FieldPolicy.KEEP,
+        "input_layers": FieldPolicy.KEEP,
+        "output_layers": FieldPolicy.KEEP,
+        "forward_args": FieldPolicy.BLOB_RECURSIVE,
+        "forward_kwargs": FieldPolicy.BLOB_RECURSIVE,
+        "call_parent": FieldPolicy.KEEP,
+        "call_children": FieldPolicy.KEEP,
+        "all_module_addresses": FieldPolicy.KEEP,
+    }
 
     def __init__(
         self,
@@ -100,6 +114,18 @@ class ModulePassLog:
         """Return the number of layers in this pass."""
         return self.num_layers
 
+    def __getstate__(self) -> Dict[str, Any]:
+        """Return pickle state annotated with the current I/O format version."""
+        state = self.__dict__.copy()
+        state["io_format_version"] = IO_FORMAT_VERSION
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore pickle state with version-aware default filling."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(state, defaults={"all_module_addresses": [state["module_address"]]})
+        self.__dict__.update(state)
+
 
 class ModuleLog:
     """Aggregate metadata for one nn.Module across all its invocations.
@@ -116,6 +142,44 @@ class ModuleLog:
     ``output_layers``, ``forward_args``, ``forward_kwargs``) are accessible
     directly via ``_single_pass_or_error()`` delegation to ``passes[1]``.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "address": FieldPolicy.KEEP,
+        "all_addresses": FieldPolicy.KEEP,
+        "name": FieldPolicy.KEEP,
+        "module_class_name": FieldPolicy.KEEP,
+        "source_file": FieldPolicy.KEEP,
+        "source_line": FieldPolicy.KEEP,
+        "class_docstring": FieldPolicy.KEEP,
+        "init_signature": FieldPolicy.KEEP,
+        "init_docstring": FieldPolicy.KEEP,
+        "forward_signature": FieldPolicy.KEEP,
+        "forward_docstring": FieldPolicy.KEEP,
+        "address_parent": FieldPolicy.KEEP,
+        "address_children": FieldPolicy.KEEP,
+        "address_depth": FieldPolicy.KEEP,
+        "call_parent": FieldPolicy.KEEP,
+        "call_children": FieldPolicy.KEEP,
+        "nesting_depth": FieldPolicy.KEEP,
+        "num_passes": FieldPolicy.KEEP,
+        "passes": FieldPolicy.KEEP,
+        "pass_labels": FieldPolicy.KEEP,
+        "all_layers": FieldPolicy.KEEP,
+        "params": FieldPolicy.KEEP,
+        "num_params": FieldPolicy.KEEP,
+        "num_params_trainable": FieldPolicy.KEEP,
+        "num_params_frozen": FieldPolicy.KEEP,
+        "params_memory": FieldPolicy.KEEP,
+        "requires_grad": FieldPolicy.KEEP,
+        "buffer_layers": FieldPolicy.KEEP,
+        "_buffer_accessor": FieldPolicy.DROP,
+        "is_training": FieldPolicy.KEEP,
+        "has_forward_hooks": FieldPolicy.KEEP,
+        "has_backward_hooks": FieldPolicy.KEEP,
+        "extra_attributes": FieldPolicy.BLOB_RECURSIVE,
+        "methods": FieldPolicy.KEEP,
+        "_source_model_log_ref": FieldPolicy.WEAKREF_STRIP,
+    }
 
     def __init__(
         self,
@@ -241,6 +305,22 @@ class ModuleLog:
     @_source_model_log.setter
     def _source_model_log(self, value):
         self._source_model_log_ref = weakref.ref(value) if value is not None else None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Return pickle state with weakrefs stripped."""
+        state = self.__dict__.copy()
+        state["_source_model_log_ref"] = None
+        state["_buffer_accessor"] = None
+        state["io_format_version"] = IO_FORMAT_VERSION
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore pickle state without touching disk."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(
+            state, defaults={"_buffer_accessor": None, "_source_model_log_ref": None}
+        )
+        self.__dict__.update(state)
 
     # --- Per-call delegating properties ---
     # Mirror the LayerLog delegation pattern: single-pass modules transparently
@@ -427,6 +507,13 @@ class ModuleAccessor:
 
     Available as ``model_log.modules``.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "_dict": FieldPolicy.KEEP,
+        "_list": FieldPolicy.KEEP,
+        "_pass_dict": FieldPolicy.KEEP,
+        "_alias_dict": FieldPolicy.KEEP,
+    }
 
     def __init__(
         self,

--- a/torchlens/data_classes/module_log.py
+++ b/torchlens/data_classes/module_log.py
@@ -22,15 +22,32 @@ ModuleLog vs ModulePassLog label convention:
 This matches each accessor's natural granularity.
 """
 
-import weakref
-from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
-
-from ..utils.display import human_readable_size
-
 import pandas as pd
+import weakref
+from os import PathLike
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from ..constants import MODULE_PASS_LOG_FIELD_ORDER
+from ..utils.display import human_readable_size
 
 if TYPE_CHECKING:
     from .param_log import ParamAccessor
+
+
+def _module_pass_log_to_row(module_pass_log: "ModulePassLog") -> Dict[str, Any]:
+    """Convert a ModulePassLog into one DataFrame row.
+
+    Parameters
+    ----------
+    module_pass_log:
+        Module-pass metadata entry to export.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Mapping from canonical field name to exported value.
+    """
+    return {field: getattr(module_pass_log, field) for field in MODULE_PASS_LOG_FIELD_ORDER}
 
 
 class ModulePassLog:
@@ -57,7 +74,7 @@ class ModulePassLog:
         call_parent: Optional[str] = None,
         call_children: Optional[List[str]] = None,
         all_module_addresses: Optional[List[str]] = None,
-    ):
+    ) -> None:
         self.module_address = module_address
         self.pass_num = pass_num
         self.pass_label = pass_label  # e.g. "features.0:1"
@@ -66,6 +83,8 @@ class ModulePassLog:
         self.output_layers = output_layers
         self.forward_args = forward_args
         self.forward_kwargs = forward_kwargs
+        self.forward_args_summary = ""
+        self.forward_kwargs_summary = ""
         self.call_parent = call_parent
         self.call_children = call_children if call_children is not None else []
         self.all_module_addresses = (
@@ -99,6 +118,65 @@ class ModulePassLog:
     def __len__(self) -> int:
         """Return the number of layers in this pass."""
         return self.num_layers
+
+    def to_pandas(self) -> "pd.DataFrame":
+        """Export this module pass as a one-row pandas DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            Single-row DataFrame ordered by ``MODULE_PASS_LOG_FIELD_ORDER``.
+        """
+        row = _module_pass_log_to_row(self)
+        return pd.DataFrame([row], columns=MODULE_PASS_LOG_FIELD_ORDER)
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write this module-pass row to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write this module-pass row to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "pyarrow is required for parquet export; install with 'pip install torchlens[io]'."
+            ) from exc
+        self.to_pandas().to_parquet(filepath, index=False, **kwargs)
+
+    def to_json(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write this module-pass row to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        kwargs.setdefault("orient", "records")
+        self.to_pandas().to_json(filepath, **kwargs)
 
 
 class ModuleLog:

--- a/torchlens/data_classes/param_log.py
+++ b/torchlens/data_classes/param_log.py
@@ -20,7 +20,7 @@ The check is one-shot: once ``_has_grad`` is True, no further checks are made.
 """
 
 from os import PathLike
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import pandas as pd
 import torch
@@ -350,19 +350,26 @@ class ParamAccessor:
             import pyarrow  # noqa: F401
         except ImportError as exc:
             raise ImportError(
-                "pyarrow is required for parquet export; install with 'pip install torchlens[io]'."
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
             ) from exc
-        self.to_pandas().to_parquet(filepath, index=False, **kwargs)
+        self.to_pandas().to_parquet(filepath, **kwargs)
 
-    def to_json(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
         """Write the parameter table to JSON.
 
         Parameters
         ----------
         filepath:
             Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
         **kwargs:
             Additional keyword arguments forwarded to ``DataFrame.to_json``.
         """
-        kwargs.setdefault("orient", "records")
-        self.to_pandas().to_json(filepath, **kwargs)
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)

--- a/torchlens/data_classes/param_log.py
+++ b/torchlens/data_classes/param_log.py
@@ -19,11 +19,30 @@ after a ``loss.backward()`` call) to be reflected without re-logging.
 The check is one-shot: once ``_has_grad`` is True, no further checks are made.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from os import PathLike
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+import pandas as pd
 import torch
 
+from ..constants import PARAM_LOG_FIELD_ORDER
 from ..utils.display import human_readable_size
+
+
+def _param_log_to_row(param_log: "ParamLog") -> Dict[str, Any]:
+    """Convert a ParamLog into one DataFrame row.
+
+    Parameters
+    ----------
+    param_log:
+        Parameter metadata entry to export.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Mapping from canonical field name to exported value.
+    """
+    return {field: getattr(param_log, field) for field in PARAM_LOG_FIELD_ORDER}
 
 
 class ParamLog:
@@ -246,3 +265,62 @@ class ParamAccessor:
             items.append(f"'{pl.address}': ParamLog {pl.shape} {pl.dtype} {status}")
         inner = ",\n ".join(items)
         return "{" + inner + "}"
+
+    def to_pandas(self) -> "pd.DataFrame":
+        """Export parameter metadata as a pandas DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per parameter, ordered by ``PARAM_LOG_FIELD_ORDER``.
+        """
+        rows = [_param_log_to_row(param_log) for param_log in self._list]
+        return pd.DataFrame(rows, columns=PARAM_LOG_FIELD_ORDER)
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the parameter table to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the parameter table to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "pyarrow is required for parquet export; install with 'pip install torchlens[io]'."
+            ) from exc
+        self.to_pandas().to_parquet(filepath, index=False, **kwargs)
+
+    def to_json(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the parameter table to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        kwargs.setdefault("orient", "records")
+        self.to_pandas().to_json(filepath, **kwargs)

--- a/torchlens/data_classes/param_log.py
+++ b/torchlens/data_classes/param_log.py
@@ -19,10 +19,11 @@ after a ``loss.backward()`` call) to be reflected without re-logging.
 The check is one-shot: once ``_has_grad`` is True, no further checks are made.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..utils.display import human_readable_size
 
 
@@ -33,6 +34,29 @@ class ParamLog:
     and links to the module that owns it.  Does NOT store the parameter tensor
     itself -- only a ``_param_ref`` reference for lazy gradient access.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "address": FieldPolicy.KEEP,
+        "name": FieldPolicy.KEEP,
+        "shape": FieldPolicy.KEEP,
+        "dtype": FieldPolicy.KEEP,
+        "num_params": FieldPolicy.KEEP,
+        "memory": FieldPolicy.KEEP,
+        "trainable": FieldPolicy.KEEP,
+        "module_address": FieldPolicy.KEEP,
+        "module_type": FieldPolicy.KEEP,
+        "barcode": FieldPolicy.KEEP,
+        "has_optimizer": FieldPolicy.KEEP,
+        "_param_ref": FieldPolicy.DROP,
+        "num_passes": FieldPolicy.KEEP,
+        "used_by_layers": FieldPolicy.KEEP,
+        "linked_params": FieldPolicy.KEEP,
+        "_has_grad": FieldPolicy.KEEP,
+        "_grad_shape": FieldPolicy.KEEP,
+        "_grad_dtype": FieldPolicy.KEEP,
+        "_grad_memory": FieldPolicy.KEEP,
+        "_grad_memory_str": FieldPolicy.KEEP,
+    }
 
     def __init__(
         self,
@@ -187,6 +211,19 @@ class ParamLog:
         """Return the number of scalar elements in this parameter."""
         return self.num_params
 
+    def __getstate__(self) -> Dict[str, Any]:
+        """Return pickle state with live parameter references stripped."""
+        state = self.__dict__.copy()
+        state["_param_ref"] = None
+        state["io_format_version"] = IO_FORMAT_VERSION
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore pickle state without reviving live parameter references."""
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(state, defaults={"_param_ref": None})
+        self.__dict__.update(state)
+
 
 class ParamAccessor:
     """Dict-like accessor for ParamLog objects.
@@ -198,6 +235,11 @@ class ParamAccessor:
 
     Available as ``model_log.params``, ``layer_log.params``, ``module_log.params``.
     """
+
+    PORTABLE_STATE_SPEC: dict[str, FieldPolicy] = {
+        "_dict": FieldPolicy.KEEP,
+        "_list": FieldPolicy.KEEP,
+    }
 
     def __init__(self, param_logs: Dict[str, "ParamLog"]) -> None:
         self._dict = param_logs  # address -> ParamLog

--- a/torchlens/postprocess/__init__.py
+++ b/torchlens/postprocess/__init__.py
@@ -1,7 +1,7 @@
 """Postprocessing pipeline for cleaning up the model log after the forward pass.
 
 After the forward pass captures raw tensor metadata into a ModelLog, this pipeline
-transforms the raw graph into its user-facing form. The full pipeline has 18 steps,
+transforms the raw graph into its user-facing form. The full pipeline has 20 steps,
 split into thematic submodules:
 
 - graph_traversal (Steps 1-4): Add output nodes, trace ancestry, remove orphans,
@@ -12,8 +12,9 @@ split into thematic submodules:
   same-layer groupings via BFS isomorphic subgraph expansion.
 - labeling (Steps 9-12): Generate final human-readable labels, rename all internal
   references, trim/reorder fields, build lookup keys.
-- finalization (Steps 13-18): Undecorate saved tensors, log timing, finalize
-  ParamLogs, build LayerLog/ModuleLog aggregates, mark pass as finished.
+- finalization (Steps 13-20): Undecorate saved tensors, log timing, finalize
+  ParamLogs, build LayerLog/ModuleLog aggregates, mark pass as finished, then
+  finalize any streamed bundle and optionally evict in-memory activations.
 
 Step ordering invariants:
 - Steps 1-3 MUST precede Step 5 (conditional branch detection needs orphan-free graph).
@@ -47,6 +48,8 @@ from .control_flow import (
 from .finalization import (
     _build_layer_logs,
     _build_module_logs,
+    _evict_streamed_activations,
+    _finalize_streamed_bundle,
     _finalize_param_logs,
     _log_time_elapsed,
     _set_pass_finished,
@@ -193,6 +196,15 @@ def postprocess(
     with _vtimed(self, "  Step 18: Mark pass finished"):
         _set_pass_finished(self)
 
+    should_finalize_streaming = self._activation_writer is not None
+    if should_finalize_streaming:
+        with _vtimed(self, "  Step 19: Finalize streamed bundle"):
+            _finalize_streamed_bundle(self)
+
+    if should_finalize_streaming and not self._keep_activations_in_memory:
+        with _vtimed(self, "  Step 20: Evict streamed activations"):
+            _evict_streamed_activations(self)
+
     if getattr(self, "verbose", False):
         print(f"[torchlens] Postprocessing complete ({time.time() - _post_t0:.2f}s)")
 
@@ -245,3 +257,9 @@ def postprocess_fast(self: "ModelLog") -> None:
     # doesn't change between passes and _module_build_data isn't repopulated
     # in fast mode (Step 10 is skipped). Existing module logs remain valid. (#108)
     _set_pass_finished(self)
+
+    should_finalize_streaming = self._activation_writer is not None
+    if should_finalize_streaming:
+        _finalize_streamed_bundle(self)
+    if should_finalize_streaming and not self._keep_activations_in_memory:
+        _evict_streamed_activations(self)

--- a/torchlens/postprocess/finalization.py
+++ b/torchlens/postprocess/finalization.py
@@ -25,6 +25,7 @@ from typing import Dict, List, NamedTuple, Optional, TYPE_CHECKING, Tuple
 import torch
 
 from ..data_classes.buffer_log import BufferAccessor
+from ..data_classes._summary import format_call_arg
 from ..data_classes.module_log import ModuleAccessor, ModuleLog, ModulePassLog
 from ..utils.introspection import get_vars_of_type_from_obj
 
@@ -691,6 +692,8 @@ def _build_module_logs(self: "ModelLog") -> None:
     # GC-11: Clear forward_args/kwargs from ModulePassLogs to release tensor references.
     # These can hold large tensors from the model's forward() call args.
     for pass_log in pass_dict.values():
+        pass_log.forward_args_summary = format_call_arg(pass_log.forward_args)
+        pass_log.forward_kwargs_summary = format_call_arg(pass_log.forward_kwargs)
         pass_log.forward_args = None
         pass_log.forward_kwargs = None
 

--- a/torchlens/postprocess/finalization.py
+++ b/torchlens/postprocess/finalization.py
@@ -24,8 +24,8 @@ from typing import Dict, List, NamedTuple, Optional, TYPE_CHECKING, Tuple
 
 import torch
 
-from ..data_classes.buffer_log import BufferAccessor
-from ..data_classes.module_log import ModuleAccessor, ModuleLog, ModulePassLog
+from .._io.accessor_rebuild import rebuild_model_log_accessors
+from ..data_classes.module_log import ModuleLog, ModulePassLog
 from ..utils.introspection import get_vars_of_type_from_obj
 
 if TYPE_CHECKING:
@@ -668,17 +668,7 @@ def _build_module_logs(self: "ModelLog") -> None:
     # --- Compute nesting depths ---
     _compute_nesting_depths(module_dict, root_module)
 
-    # Build the user-facing ModuleAccessor (supports log.modules[address] access).
-    self._module_logs = ModuleAccessor(module_dict, module_order, pass_dict)
-
-    # Build BufferAccessor for log.buffers[address] access.
-    buffer_dict = {}
-    for label in self.buffer_layers:
-        if label in self.layer_dict_all_keys:
-            entry = self.layer_dict_all_keys[label]
-            if entry.buffer_address is not None:
-                buffer_dict[entry.buffer_address] = entry
-    self._buffer_accessor = BufferAccessor(buffer_dict, source_model_log=self)  # type: ignore[assignment, arg-type]
+    rebuild_model_log_accessors(self, module_dict, module_order, pass_dict)
 
     # Clean up temporary build state to free memory. These dicts are only
     # needed during construction and are not part of the user-facing API.

--- a/torchlens/postprocess/finalization.py
+++ b/torchlens/postprocess/finalization.py
@@ -28,6 +28,7 @@ import torch
 from .._io import BlobRef, TorchLensIOError
 from .._io.accessor_rebuild import rebuild_model_log_accessors
 from .._io.lazy import LazyActivationRef
+from .._io.manifest import sha256_of_file
 from .._io.streaming import BundleStreamWriter
 from ..data_classes._summary import format_call_arg
 from ..data_classes.module_log import ModuleLog, ModulePassLog
@@ -824,6 +825,12 @@ def _finalize_streamed_bundle(self: "ModelLog") -> None:
     final_path = writer.finalize(
         scrubbed_state=scrubbed_state, blob_specs=blob_specs, unsupported=[]
     )
+    setattr(self, "_source_bundle_path", Path(final_path))
+    setattr(
+        self,
+        "_source_bundle_manifest_sha256",
+        sha256_of_file(Path(final_path) / "manifest.json"),
+    )
     _attach_streamed_activation_refs(
         self, scrubbed_state=scrubbed_state, writer=writer, final_path=final_path
     )
@@ -931,6 +938,7 @@ def _attach_streamed_activation_refs(
             dtype=_dtype_from_manifest_string(manifest_entry.dtype),
             device_at_save=manifest_entry.device_at_save,
             source_bundle_path=Path(final_path),
+            relative_path=manifest_entry.relative_path,
             kind="activation",
             expected_sha256=manifest_entry.sha256,
         )

--- a/torchlens/postprocess/finalization.py
+++ b/torchlens/postprocess/finalization.py
@@ -20,11 +20,15 @@ Step 18 (_set_pass_finished): Marks ModelLog and all LayerPassLogs as finished, 
 
 import time
 from collections import defaultdict, deque
+from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, TYPE_CHECKING, Tuple
 
 import torch
 
+from .._io import BlobRef, TorchLensIOError
 from .._io.accessor_rebuild import rebuild_model_log_accessors
+from .._io.lazy import LazyActivationRef
+from .._io.streaming import BundleStreamWriter
 from ..data_classes._summary import format_call_arg
 from ..data_classes.module_log import ModuleLog, ModulePassLog
 from ..utils.introspection import get_vars_of_type_from_obj
@@ -782,3 +786,176 @@ def _set_pass_finished(self) -> None:
         tensor = self.layer_dict_main_keys[layer_label]
         tensor._pass_finished = True
     self._pass_finished = True
+
+
+def _finalize_streamed_bundle(self: "ModelLog") -> None:
+    """Step 19: Finalize any in-progress streamed activation bundle.
+
+    Parameters
+    ----------
+    self:
+        Model log whose streamed bundle should be finalized.
+
+    Raises
+    ------
+    TorchLensIOError
+        If portable scrubbing or bundle finalization fails.
+    """
+
+    writer = self._activation_writer
+    if writer is None:
+        return
+
+    from .._io.scrub import scrub_for_save
+
+    scrubbed_state, blob_specs = scrub_for_save(
+        self,
+        include_activations=True,
+        include_gradients=self.save_gradients,
+        include_captured_args=self.save_function_args,
+        include_rng_states=self.save_rng_states,
+    )
+    scrubbed_state, blob_specs = _reuse_streamed_activation_blob_ids(
+        self,
+        scrubbed_state=scrubbed_state,
+        blob_specs=blob_specs,
+        writer=writer,
+    )
+    final_path = writer.finalize(
+        scrubbed_state=scrubbed_state, blob_specs=blob_specs, unsupported=[]
+    )
+    _attach_streamed_activation_refs(
+        self, scrubbed_state=scrubbed_state, writer=writer, final_path=final_path
+    )
+    self._activation_writer = None
+
+
+def _evict_streamed_activations(self: "ModelLog") -> None:
+    """Step 20: Drop in-memory activations once streaming refs have been attached.
+
+    Parameters
+    ----------
+    self:
+        Model log whose streamed activations should be evicted.
+    """
+
+    for layer_entry in self.layer_list:
+        if getattr(layer_entry, "activation_ref", None) is not None:
+            layer_entry.activation = None
+
+
+def _reuse_streamed_activation_blob_ids(
+    model_log: "ModelLog",
+    *,
+    scrubbed_state: dict,
+    blob_specs: list[tuple[str, torch.Tensor, str, str]],
+    writer: BundleStreamWriter,
+) -> tuple[dict, list[tuple[str, torch.Tensor, str, str]]]:
+    """Patch scrubbed activation refs to reuse blob ids written during capture.
+
+    Parameters
+    ----------
+    model_log:
+        Live model log containing pending streamed blob ids.
+    scrubbed_state:
+        Scrubbed portable metadata state produced by ``scrub_for_save``.
+    blob_specs:
+        Scrub-generated blob specs.
+    writer:
+        Streaming writer holding already-written activation entries.
+
+    Returns
+    -------
+    tuple[dict, list[tuple[str, torch.Tensor, str, str]]]
+        Patched scrubbed state and the filtered blob spec list.
+    """
+
+    scrubbed_layers = scrubbed_state.get("layer_list")
+    if not isinstance(scrubbed_layers, list):
+        raise TorchLensIOError(
+            "Streaming finalize expected scrubbed_state['layer_list'] to be a list."
+        )
+
+    skipped_blob_ids: set[str] = set()
+    for live_layer, scrubbed_layer in zip(model_log.layer_list, scrubbed_layers):
+        activation_blob = getattr(scrubbed_layer, "activation", None)
+        if not isinstance(activation_blob, BlobRef):
+            continue
+        pending_blob_id = getattr(live_layer, "_pending_blob_id", None)
+        if pending_blob_id is None:
+            continue
+        skipped_blob_ids.add(activation_blob.blob_id)
+        scrubbed_layer.activation = BlobRef(blob_id=pending_blob_id, kind=activation_blob.kind)
+        writer.relabel_blob(pending_blob_id, live_layer._streaming_label)
+
+    filtered_blob_specs = [spec for spec in blob_specs if spec[0] not in skipped_blob_ids]
+    return scrubbed_state, filtered_blob_specs
+
+
+def _attach_streamed_activation_refs(
+    model_log: "ModelLog",
+    *,
+    scrubbed_state: dict,
+    writer: BundleStreamWriter,
+    final_path: str | Path,
+) -> None:
+    """Attach ``LazyActivationRef`` placeholders for persisted activation blobs.
+
+    Parameters
+    ----------
+    model_log:
+        Live model log receiving the refs.
+    scrubbed_state:
+        Scrubbed metadata state whose activation ``BlobRef`` values now match the
+        final persisted blob ids.
+    writer:
+        Streaming writer containing manifest entries for all saved blobs.
+    final_path:
+        Final bundle directory path after the temp-dir rename.
+    """
+
+    scrubbed_layers = scrubbed_state.get("layer_list")
+    if not isinstance(scrubbed_layers, list):
+        raise TorchLensIOError(
+            "Streaming finalize expected scrubbed_state['layer_list'] to be a list."
+        )
+
+    for live_layer, scrubbed_layer in zip(model_log.layer_list, scrubbed_layers):
+        activation_blob = getattr(scrubbed_layer, "activation", None)
+        if not isinstance(activation_blob, BlobRef):
+            continue
+        manifest_entry = writer.get_entry(activation_blob.blob_id)
+        live_layer.activation_ref = LazyActivationRef(
+            blob_id=manifest_entry.blob_id,
+            shape=tuple(manifest_entry.shape),
+            dtype=_dtype_from_manifest_string(manifest_entry.dtype),
+            device_at_save=manifest_entry.device_at_save,
+            source_bundle_path=Path(final_path),
+            kind="activation",
+            expected_sha256=manifest_entry.sha256,
+        )
+
+
+def _dtype_from_manifest_string(dtype_name: str) -> torch.dtype:
+    """Resolve a manifest dtype string back into a ``torch.dtype``.
+
+    Parameters
+    ----------
+    dtype_name:
+        Manifest dtype name without the ``torch.`` prefix.
+
+    Returns
+    -------
+    torch.dtype
+        Resolved dtype object.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the dtype name is unknown to the current runtime.
+    """
+
+    dtype_obj = getattr(torch, dtype_name, None)
+    if not isinstance(dtype_obj, torch.dtype):
+        raise TorchLensIOError(f"Unsupported dtype string in manifest: {dtype_name}.")
+    return dtype_obj

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -326,7 +326,16 @@ def log_forward_pass(
     if type(layers_to_save) is str:
         layers_to_save = layers_to_save.lower()
 
-    if layers_to_save in ["all", "none", None, []]:
+    uses_two_pass = layers_to_save not in ["all", "none", None, []]
+    if save_activations_to is not None and uses_two_pass:
+        raise TorchLensIOError(
+            'save_activations_to is only supported with layers_to_save="all" in this '
+            "release. For selective streaming use activation_sink=callable, or capture "
+            'with layers_to_save="all" and filter post-hoc with '
+            "torchlens.save(..., include_activations=True)."
+        )
+
+    if not uses_two_pass:
         # --- SINGLE-PASS path ---
         # "all" or "none": no name resolution needed, so one pass suffices.
         model_log = _run_model_and_save_specified_activations(

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -1,15 +1,15 @@
 """Public API entry points for TorchLens.
 
 This module contains every user-facing function:
-  - ``log_forward_pass``  — the main entry point (runs model, returns ModelLog)
-  - ``validate_forward_pass`` — replay-based correctness check
-  - ``show_model_graph`` — visualization convenience wrapper
-  - ``get_model_metadata`` — metadata-only convenience wrapper (deprecated path)
-  - ``validate_batch_of_models_and_inputs`` — bulk validation harness
+  - ``log_forward_pass``  - the main entry point (runs model, returns ModelLog)
+  - ``validate_forward_pass`` - replay-based correctness check
+  - ``show_model_graph`` - visualization convenience wrapper
+  - ``get_model_metadata`` - metadata-only convenience wrapper (deprecated path)
+  - ``validate_batch_of_models_and_inputs`` - bulk validation harness
 
 **Two-pass strategy** (``log_forward_pass`` with selective layers):
 When the user requests specific layers (not "all" or "none"), TorchLens must
-first run an exhaustive pass to discover the full graph structure — only then can
+first run an exhaustive pass to discover the full graph structure - only then can
 it resolve user-friendly layer names/indices to internal layer numbers.  A second
 fast pass replays the model, saving only the requested activations.  This is why
 ``log_forward_pass`` has two branches: the simple path (save all/none) and the
@@ -108,17 +108,17 @@ def _run_model_and_save_specified_activations(
         activation_postfunc: Optional transform applied to each activation before storage
             (e.g., channel-wise averaging to reduce memory).
         mark_input_output_distances: Compute BFS distances from input/output layers.
-            Expensive for large graphs — off by default.
+            Expensive for large graphs - off by default.
         detach_saved_tensors: If True, saved tensors are detached from the autograd graph.
         save_function_args: If True, store the non-tensor arguments to each function call.
             Required for validation replay (``validate_saved_activations``).
         save_gradients: If True, register backward hooks to capture gradients.
         random_seed: Fixed RNG seed for reproducibility (important for stochastic models).
         num_context_lines: Number of source-code context lines stored per function call.
-        optimizer: Optional optimizer — used to tag which parameters have optimizers attached.
+        optimizer: Optional optimizer - used to tag which parameters have optimizers attached.
         detect_loops: If True (default), run full isomorphic subgraph expansion to
             detect repeated patterns (loops). If False, only group operations that
-            share the same parameters — much faster for very large graphs.
+            share the same parameters - much faster for very large graphs.
         save_activations_to: Optional portable bundle directory for streaming activation save.
         keep_activations_in_memory: Whether streamed activations should remain in memory
             after finalization.
@@ -227,8 +227,8 @@ def log_forward_pass(
 
     **Layer selection** (``layers_to_save``):
 
-    - ``'all'`` (default) — save activations for every layer.
-    - ``'none'`` / ``None`` / ``[]`` — save no activations (metadata only).
+    - ``'all'`` (default) - save activations for every layer.
+    - ``'none'`` / ``None`` / ``[]`` - save no activations (metadata only).
     - A list containing any mix of:
       1. Layer name, e.g. ``'conv2d_1_1'`` (all passes).
       2. Pass-qualified label, e.g. ``'conv2d_1_1:2'`` (second pass only).
@@ -290,19 +290,28 @@ def log_forward_pass(
         num_context_lines: Lines of source context to capture per function call.
         optimizer: Optional optimizer to annotate which params are being optimized.
         detect_loops: If True (default), run full isomorphic subgraph expansion.
-        save_activations_to: Optional portable bundle directory for streaming activation save.
-        keep_activations_in_memory: Whether streamed activations should remain in memory
-            after finalization.
+        save_activations_to: Optional portable bundle directory for streaming activation
+            save. When set, TorchLens writes each saved activation to disk during the
+            forward pass and finalizes a directory bundle at the end. Streaming is
+            always strict, requires ``safetensors``, and is mutually exclusive with
+            ``activation_sink``.
+        keep_activations_in_memory: Only applies when ``save_activations_to`` is set.
+            If True (default), the returned log keeps the in-memory tensors and also
+            attaches ``activation_ref`` handles to the finalized bundle. If False,
+            activations are evicted after finalization and must be materialized back
+            from disk on demand.
         activation_sink: Optional callback invoked with ``(label, tensor)`` for each
-            saved activation.
+            saved activation instead of writing a portable bundle. This is useful for
+            custom streaming consumers and cannot be combined with
+            ``save_activations_to``.
         unwrap_when_done: If True, restore original torch callables after logging.
-            Default False — torch stays wrapped for subsequent calls.
+            Default False - torch stays wrapped for subsequent calls.
         verbose: If True, print timed progress messages at each major pipeline stage.
 
     Returns:
         A ``ModelLog`` containing layer activations (if requested) and full metadata.
     """
-    # DataParallel is not supported — unwrap and warn if present.
+    # DataParallel is not supported - unwrap and warn if present.
     warn_parallel()
     model = _unwrap_data_parallel(model)
 
@@ -347,7 +356,7 @@ def log_forward_pass(
         # --- TWO-PASS path ---
         # Pass 1 (exhaustive): Run with layers_to_save=None and keep_unsaved_layers=True
         # so the full graph is discovered and all layer labels are assigned.  No
-        # activations are saved yet — this pass is purely for metadata/structure.
+        # activations are saved yet - this pass is purely for metadata/structure.
         if verbose:
             print("[torchlens] Two-pass mode: Pass 1 (exhaustive, metadata only)")
         model_log = _run_model_and_save_specified_activations(
@@ -430,7 +439,7 @@ def get_model_metadata(
     """Return model metadata without saving any activations.
 
     Equivalent to ``log_forward_pass(model, input_args, input_kwargs, layers_to_save=None,
-    mark_input_output_distances=True)``.  Prefer using ``log_forward_pass`` directly —
+    mark_input_output_distances=True)``.  Prefer using ``log_forward_pass`` directly -
     this wrapper exists for backward compatibility and may be removed in a future release.
 
     Args:
@@ -625,7 +634,7 @@ def validate_forward_pass(
     model.load_state_dict(state_dict)
 
     # Step 2: Run the model *through* TorchLens, saving all activations.
-    # save_function_args=True is essential — the replay needs each function's
+    # save_function_args=True is essential - the replay needs each function's
     # non-tensor arguments to re-execute the computation from saved activations.
     model_log = _run_model_and_save_specified_activations(
         model=model,

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -19,6 +19,7 @@ two-pass path (save specific layers).
 import collections.abc
 import os
 import random
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -30,6 +31,8 @@ from .utils.introspection import get_vars_of_type_from_obj
 from .utils.rng import set_random_seed
 from .utils.display import warn_parallel, _vprint
 from .utils.arg_handling import safe_copy_args, safe_copy_kwargs, normalize_input_args
+from ._io import TorchLensIOError
+from ._io.streaming import BundleStreamWriter
 from .data_classes.model_log import (
     ModelLog,
 )
@@ -83,6 +86,9 @@ def _run_model_and_save_specified_activations(
     save_source_context: bool = False,
     save_rng_states: bool = False,
     detect_loops: bool = True,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
     verbose: bool = False,
 ) -> ModelLog:
     """Run a forward pass with logging enabled, returning a populated ModelLog.
@@ -113,6 +119,11 @@ def _run_model_and_save_specified_activations(
         detect_loops: If True (default), run full isomorphic subgraph expansion to
             detect repeated patterns (loops). If False, only group operations that
             share the same parameters — much faster for very large graphs.
+        save_activations_to: Optional portable bundle directory for streaming activation save.
+        keep_activations_in_memory: Whether streamed activations should remain in memory
+            after finalization.
+        activation_sink: Optional callback invoked with ``(label, tensor)`` for each
+            saved activation.
         verbose: If True, print timed progress messages at each major pipeline stage.
 
     Returns:
@@ -144,9 +155,22 @@ def _run_model_and_save_specified_activations(
         detect_loops,
         verbose,
     )
-    model_log._run_and_log_inputs_through_model(
-        model, input_args, input_kwargs, layers_to_save, random_seed
-    )
+    model_log._activation_sink = activation_sink
+    model_log._keep_activations_in_memory = keep_activations_in_memory
+    model_log._in_exhaustive_pass = True
+    if save_activations_to is not None:
+        model_log._activation_writer = BundleStreamWriter(save_activations_to)
+    try:
+        model_log._run_and_log_inputs_through_model(
+            model, input_args, input_kwargs, layers_to_save, random_seed
+        )
+    except TorchLensIOError:
+        raise
+    except Exception as exc:
+        if model_log._activation_writer is not None:
+            model_log._activation_writer.abort(str(exc))
+            raise TorchLensIOError("Streaming activation save failed during forward pass.") from exc
+        raise
     return model_log
 
 
@@ -184,6 +208,9 @@ def log_forward_pass(
     num_context_lines: int = 7,
     optimizer=None,
     detect_loops: bool = True,
+    save_activations_to: str | Path | None = None,
+    keep_activations_in_memory: bool = True,
+    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
     unwrap_when_done: bool = False,
     verbose: bool = False,
 ) -> ModelLog:
@@ -263,6 +290,11 @@ def log_forward_pass(
         num_context_lines: Lines of source context to capture per function call.
         optimizer: Optional optimizer to annotate which params are being optimized.
         detect_loops: If True (default), run full isomorphic subgraph expansion.
+        save_activations_to: Optional portable bundle directory for streaming activation save.
+        keep_activations_in_memory: Whether streamed activations should remain in memory
+            after finalization.
+        activation_sink: Optional callback invoked with ``(label, tensor)`` for each
+            saved activation.
         unwrap_when_done: If True, restore original torch callables after logging.
             Default False — torch stays wrapped for subsequent calls.
         verbose: If True, print timed progress messages at each major pipeline stage.
@@ -279,6 +311,8 @@ def log_forward_pass(
 
     if output_device not in ["same", "cpu", "cuda"]:
         raise ValueError("output_device must be either 'same', 'cpu', or 'cuda'.")
+    if save_activations_to is not None and activation_sink is not None:
+        raise ValueError("save_activations_to and activation_sink are mutually exclusive.")
 
     if type(layers_to_save) is str:
         layers_to_save = layers_to_save.lower()
@@ -304,6 +338,9 @@ def log_forward_pass(
             save_source_context=save_source_context,
             save_rng_states=save_rng_states,
             detect_loops=detect_loops,
+            save_activations_to=save_activations_to,
+            keep_activations_in_memory=keep_activations_in_memory,
+            activation_sink=activation_sink,
             verbose=verbose,
         )
     else:
@@ -331,6 +368,9 @@ def log_forward_pass(
             save_source_context=save_source_context,
             save_rng_states=save_rng_states,
             detect_loops=detect_loops,
+            save_activations_to=save_activations_to,
+            keep_activations_in_memory=keep_activations_in_memory,
+            activation_sink=activation_sink,
             verbose=verbose,
         )
         # Pass 2 (fast): Now that layer labels exist, resolve the user's requested

--- a/torchlens/validation/core.py
+++ b/torchlens/validation/core.py
@@ -72,6 +72,14 @@ def validate_saved_activations(
     Returns:
         True if all checks pass, False otherwise.
     """
+    if bool(getattr(self, "_loaded_from_bundle", False)):
+        from .._io import TorchLensIOError
+
+        raise TorchLensIOError(
+            "validate_forward_pass requires live func_applied callables; portable bundles "
+            "drop them. Run validation before saving or use plain pickle instead."
+        )
+
     # Phase 0: verify logged outputs match a fresh forward pass (no tolerance).
     for i, output_layer_label in enumerate(self.output_layers):
         output_layer = self[output_layer_label]

--- a/torchlens/validation/core.py
+++ b/torchlens/validation/core.py
@@ -42,6 +42,29 @@ from .exemptions import (
 MAX_PERTURB_ATTEMPTS = 100
 
 
+def _raise_if_portable_bundle_log(self: Any) -> None:
+    """Reject validation on portable-loaded model logs.
+
+    Parameters
+    ----------
+    self:
+        Model log being validated.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the log was loaded from a portable bundle.
+    """
+
+    if bool(getattr(self, "_loaded_from_bundle", False)):
+        from .._io import TorchLensIOError
+
+        raise TorchLensIOError(
+            "validate_forward_pass requires live func_applied callables; portable bundles "
+            "drop them. Run validation before saving or use plain pickle instead."
+        )
+
+
 def validate_saved_activations(
     self,
     ground_truth_output_tensors: List[torch.Tensor],
@@ -72,13 +95,7 @@ def validate_saved_activations(
     Returns:
         True if all checks pass, False otherwise.
     """
-    if bool(getattr(self, "_loaded_from_bundle", False)):
-        from .._io import TorchLensIOError
-
-        raise TorchLensIOError(
-            "validate_forward_pass requires live func_applied callables; portable bundles "
-            "drop them. Run validation before saving or use plain pickle instead."
-        )
+    _raise_if_portable_bundle_log(self)
 
     # Phase 0: verify logged outputs match a fresh forward pass (no tolerance).
     for i, output_layer_label in enumerate(self.output_layers):


### PR DESCRIPTION
## Summary

Comprehensive I/O system for TorchLens data structures. Adds portable save/load with pickle + safetensors bundles, on-the-fly streaming of activations during forward pass, and tabular exports (pandas/CSV/Parquet/JSON) at every log level.

## What ships

### Save / load
- `torchlens.save(model_log, path)` — directory bundle: scrubbed pickle + one `safetensors` blob per tensor + rich `manifest.json`
- `torchlens.load(path, lazy=False, map_location="cpu", materialize_nested=True)` — symmetric loader with lazy + eager modes
- `ModelLog.save(path)` / `ModelLog.load(path)` — sugar
- `torchlens.cleanup_tmp(path)` — remove partial temp dirs
- `torchlens.rehydrate_nested(model_log)` — power-user materialize for `lazy=True, materialize_nested=False` mode
- `LazyActivationRef.materialize()` / `LayerPassLog.materialize_activation()` / `.materialize_gradient()`
- Plain `pickle.dump/load(model_log)` still works (backward compat)

### Streaming
- `log_forward_pass(..., save_activations_to=path, keep_activations_in_memory=False, activation_sink=callable)` — writes activations to disk during the forward pass so models with multi-GB activations don't need to fit in RAM
- New postprocess steps 19 (`_finalize_streamed_bundle`, always runs) and 20 (`_evict_streamed_activations`, conditional)

### Tabular export (six DataFrame surfaces)
- `to_pandas` / `to_csv` / `to_parquet` / `to_json` on: `ModelLog`, `LayerAccessor`, `ModuleAccessor`, `ModuleLog`, `ModulePassLog`, `ParamAccessor`, `BufferAccessor`
- New `forward_args_summary` / `forward_kwargs_summary` on `ModulePassLog` (captures call-arg shape metadata before the existing GC step clears the args)

### Safety
- Path-traversal hardening on every blob-read site (`resolve_bundle_blob_path` helper; rejects absolute paths, `..` escapes, symlinks)
- Two-layer drift detection on lazy resave (manifest sha256 + per-blob sha256)
- 13-row version-policy enforcement on load (PEP 440 parsing; torch/python major-mismatch gates)
- `TorchLensIOError` wraps every bundle-layer failure
- `pickle.load` security warning in README + docstrings + architecture doc
- `PORTABLE_STATE_SPEC` completeness lint prevents silent scrub drift when new fields are added
- Streaming is always strict (unsupported tensor mid-pass aborts with `PARTIAL` sentinel; users who want lenient behavior capture normally and `torchlens.save(..., strict=False)` post-hoc)
- Portable-loaded `ModelLog` objects raise clearly on `validate_forward_pass` / `validate_saved_activations` (replay requires live `func_applied` callables that are dropped during scrub)

## Architecture
- New subpackage `torchlens/_io/`: `bundle.py`, `manifest.py`, `scrub.py`, `rehydrate.py`, `accessor_rebuild.py`, `streaming.py`, `tensor_policy.py`, `lazy.py`, `paths.py`
- `PORTABLE_STATE_SPEC: dict[str, FieldPolicy]` class attribute on all persisted data classes
- New required dep: `safetensors>=0.4`
- Optional dep: `pyarrow` via `pip install torchlens[io]` for parquet export

## Out of scope this sprint (deferred)
- Selective streaming (`save_activations_to` combined with `layers_to_save=[list]`) — rejected cleanly at the API boundary with an actionable error; future sprint can plumb through the two-pass path
- `pack_bundle` tar archival utility
- Async / chunked streaming writer
- Replay / validation on portable-loaded `ModelLog` objects

## Test plan

- [x] Full non-slow suite: 1064 passed, 21 skipped (pyarrow/CUDA-gated), 0 failed
- [x] New IO test suite (11 files, 96 tests): pickle round-trip, scrub-policy completeness, pandas schemas, export wrappers, bundle save/load + integrity, streaming, lazy refs + drift detection, integration, corruption battery, plain pickle, security (path-traversal + blob-swap attacks)
- [x] `ruff check .` and `mypy torchlens/` both clean
- [x] Smoke suite: 28 passed
- [x] End-to-end demo: `log_forward_pass -> torchlens.save -> torchlens.load` round-trips with bit-exact activations on a toy model
- [x] Path-traversal exploit scripted, confirmed rejected
- [x] Two-pass streaming misuse scripted, confirmed rejected with actionable error

## Sprint record (in \`.project-context/plans/io-sprint/\`)
- \`plan.md\` (final v6, GREEN after 8 adversarial rounds)
- \`plan_v1.md\` ... \`plan_v5.md\` (revision history)
- \`review_round_1.md\` ... \`review_round_8.md\` (convergence trace: 23 → 12 → 9 → 4 → 3 → 1 → 1 → 0 findings)
- \`final_review_codex.md\`, \`final_review_claude.md\` (Phase 5 dual code review)

## Design forks resolved (see plan.md)
A. Directory bundle format (pickle + safetensors + manifest); no tar this sprint
B. \`lazy=False\` is the default load mode
C. Six pandas surfaces, recursive summary formatter
D. Streaming writer hook in \`save_tensor_data\`; step-19 finalize always, step-20 evict conditional
E. \`strict=True\` is the default save mode
F. 13-row version policy, PEP 440 parsing
G. All bundle errors wrap \`TorchLensIOError\`
H. Two-layer drift detection (manifest + per-blob sha256)
I. Directory-of-blobs format deferred (acknowledged, not claimed solved)
J. Symlinks rejected everywhere
K. No shared safetensors readers; open/read/close per materialize
L. Validation unsupported on portable-loaded ModelLogs
M. Save rejects lingering nested BlobRefs