### PR TITLE
feat(ux): 1.3.0 UX sprint — ModelLog.summary + option groups + renames + cross-file refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 
 ## v1.3.0 (unreleased)
 
+### Documentation
+
+- **ux**: Default-value audit doc clarifications only; no entry-point defaults changed in Wave 4c.
+
+Clarify that `keep_unsaved_layers=True` still allows a full discovery pass before selective-layer
+replay, that `save_source_context=False` still captures the identity fields needed for branch
+attribution, and that `detect_loops=True` should be flipped off manually for very large (>1M-op)
+graphs when postprocessing speed matters.
+
 ### Features
 
 - **summary**: Add `ModelLog.summary()`, compact `ModelLog.__repr__`, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
 
+## v1.3.0 (unreleased)
+
+### Features
+
+- **summary**: Add `ModelLog.summary()`, compact `ModelLog.__repr__`, and the
+  top-level `torchlens.summary()` convenience wrapper.
+
+
 ## v1.2.0 (2026-04-23)
 
 ### Bug Fixes

--- a/tests/test_api_renames.py
+++ b/tests/test_api_renames.py
@@ -1,0 +1,633 @@
+"""Tests for additive API renames and grouped-option migrations."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens import user_funcs
+from torchlens._deprecations import _WARNED_DEPRECATIONS
+from torchlens.options import StreamingOptions, VisualizationOptions
+from torchlens.validation import core as validation_core
+
+
+_VISUALIZATION_CASES = [
+    ("mode", "vis_mode", "rolled", "vis_mode"),
+    ("max_module_depth", "vis_nesting_depth", 5, "vis_nesting_depth"),
+    ("output_path", "vis_outpath", "custom.gv", "vis_outpath"),
+    ("save_only", "vis_save_only", True, "vis_save_only"),
+    ("file_format", "vis_fileformat", "svg", "vis_fileformat"),
+    ("show_buffers", "vis_buffer_layers", True, "show_buffer_layers"),
+    ("direction", "vis_direction", "leftright", "direction"),
+    ("graph_overrides", "vis_graph_overrides", {"ranksep": "2.0"}, "vis_graph_overrides"),
+    ("node_overrides", "vis_node_overrides", {"shape": "box"}, "vis_node_overrides"),
+    (
+        "nested_node_overrides",
+        "vis_nested_node_overrides",
+        {"style": "filled"},
+        "vis_nested_node_overrides",
+    ),
+    ("edge_overrides", "vis_edge_overrides", {"color": "red"}, "vis_edge_overrides"),
+    (
+        "gradient_edge_overrides",
+        "vis_gradient_edge_overrides",
+        {"style": "dashed"},
+        "vis_gradient_edge_overrides",
+    ),
+    ("module_overrides", "vis_module_overrides", {"color": "blue"}, "vis_module_overrides"),
+    ("layout_engine", "vis_node_placement", "dot", "vis_node_placement"),
+    ("renderer", "vis_renderer", "dagua", "vis_renderer"),
+    ("theme", "vis_theme", "gallery", "vis_theme"),
+]
+_STREAMING_CASES = [
+    ("bundle_path", "save_activations_to", Path("bundle"), "save_activations_to"),
+    ("retain_in_memory", "keep_activations_in_memory", False, "keep_activations_in_memory"),
+    ("activation_callback", "activation_sink", torch.sigmoid, "activation_sink"),
+]
+
+
+class _TinyModel(nn.Module):
+    """Small model used for API-plumbing tests."""
+
+    def __init__(self) -> None:
+        """Initialize the toy model."""
+
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the toy forward pass."""
+
+        return torch.relu(self.linear(x))
+
+
+class _DummyLog:
+    """Test double for ``ModelLog`` used by API-plumbing tests."""
+
+    def __init__(self) -> None:
+        """Initialize captured state for a fake log object."""
+
+        self.verbose = False
+        self.layer_logs: dict[str, Any] = {}
+        self.num_tensors_saved = 0
+        self.total_activation_memory_str = "0 B"
+        self.render_calls: list[dict[str, Any]] = []
+        self.cleaned_up = False
+
+    def render_graph(
+        self,
+        vis_mode: str = "unrolled",
+        vis_nesting_depth: int = 1000,
+        vis_outpath: str = "modelgraph",
+        vis_graph_overrides: dict[str, Any] | None = None,
+        vis_node_overrides: dict[str, Any] | None = None,
+        vis_nested_node_overrides: dict[str, Any] | None = None,
+        vis_edge_overrides: dict[str, Any] | None = None,
+        vis_gradient_edge_overrides: dict[str, Any] | None = None,
+        vis_module_overrides: dict[str, Any] | None = None,
+        vis_save_only: bool = False,
+        vis_fileformat: str = "pdf",
+        show_buffer_layers: bool = False,
+        direction: str = "bottomup",
+        vis_node_placement: str = "auto",
+        vis_renderer: str = "graphviz",
+        vis_theme: str = "torchlens",
+    ) -> str:
+        """Record render kwargs passed by the API under test."""
+
+        self.render_calls.append(
+            {
+                "vis_mode": vis_mode,
+                "vis_nesting_depth": vis_nesting_depth,
+                "vis_outpath": vis_outpath,
+                "vis_graph_overrides": vis_graph_overrides,
+                "vis_node_overrides": vis_node_overrides,
+                "vis_nested_node_overrides": vis_nested_node_overrides,
+                "vis_edge_overrides": vis_edge_overrides,
+                "vis_gradient_edge_overrides": vis_gradient_edge_overrides,
+                "vis_module_overrides": vis_module_overrides,
+                "vis_save_only": vis_save_only,
+                "vis_fileformat": vis_fileformat,
+                "show_buffer_layers": show_buffer_layers,
+                "direction": direction,
+                "vis_node_placement": vis_node_placement,
+                "vis_renderer": vis_renderer,
+                "vis_theme": vis_theme,
+            }
+        )
+        return "graph"
+
+    def cleanup(self) -> None:
+        """Record cleanup calls from wrapper helpers."""
+
+        self.cleaned_up = True
+
+
+@pytest.fixture(autouse=True)
+def clear_deprecation_state() -> None:
+    """Reset deprecation dedup state before each test."""
+
+    _WARNED_DEPRECATIONS.clear()
+
+
+@pytest.fixture
+def stubbed_runner(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, Any], _DummyLog]:
+    """Replace the heavy logging helper with a capturing test double."""
+
+    captured: dict[str, Any] = {}
+    dummy_log = _DummyLog()
+
+    def fake_run_model_and_save_specified_activations(*args: Any, **kwargs: Any) -> _DummyLog:
+        """Capture forwarded kwargs and return a dummy log object."""
+
+        del args
+        captured.update(kwargs)
+        return dummy_log
+
+    monkeypatch.setattr(
+        user_funcs,
+        "_run_model_and_save_specified_activations",
+        fake_run_model_and_save_specified_activations,
+    )
+    return captured, dummy_log
+
+
+def _tiny_input() -> torch.Tensor:
+    """Return a deterministic small input tensor."""
+
+    return torch.randn(1, 4)
+
+
+def _deprecation_messages(records: list[warnings.WarningMessage]) -> list[str]:
+    """Extract deprecation-warning messages from captured warnings."""
+
+    return [
+        str(record.message) for record in records if issubclass(record.category, DeprecationWarning)
+    ]
+
+
+def test_get_model_metadata_warns_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deprecated top-level metadata helper should warn once per process."""
+
+    sentinel = object()
+
+    def fake_log_model_metadata(*args: Any, **kwargs: Any) -> object:
+        """Return a stable sentinel without running real logging."""
+
+        del args, kwargs
+        return sentinel
+
+    monkeypatch.setattr(user_funcs, "log_model_metadata", fake_log_model_metadata)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        first = tl.get_model_metadata(_TinyModel(), _tiny_input())
+        second = tl.get_model_metadata(_TinyModel(), _tiny_input())
+
+    assert first is sentinel
+    assert second is sentinel
+    assert _deprecation_messages(records) == [
+        "`get_model_metadata` is deprecated; use `log_model_metadata` instead. "
+        "The old name continues to work but will be removed in a future release."
+    ]
+
+
+def test_log_model_metadata_new_name_has_no_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The canonical metadata helper should not emit deprecation warnings."""
+
+    sentinel = object()
+
+    def fake_log_forward_pass(*args: Any, **kwargs: Any) -> object:
+        """Return a stable sentinel without running real logging."""
+
+        del args, kwargs
+        return sentinel
+
+    monkeypatch.setattr(user_funcs, "log_forward_pass", fake_log_forward_pass)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        result = tl.log_model_metadata(_TinyModel(), _tiny_input())
+
+    assert result is sentinel
+    assert _deprecation_messages(records) == []
+
+
+def test_validate_saved_activations_alias_warns_and_forwards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deprecated top-level validation alias should warn and forward kwargs."""
+
+    captured: dict[str, Any] = {}
+
+    def fake_validate_forward_pass(*args: Any, **kwargs: Any) -> bool:
+        """Capture forwarded kwargs and return success."""
+
+        del args
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(user_funcs, "validate_forward_pass", fake_validate_forward_pass)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        result = tl.validate_saved_activations(
+            _TinyModel(),
+            _tiny_input(),
+            validate_metadata=False,
+        )
+
+    assert result is True
+    assert captured["validate_metadata"] is False
+    assert len(_deprecation_messages(records)) == 1
+
+
+def test_model_log_validate_saved_activations_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deprecated ``ModelLog`` method alias should warn once and delegate."""
+
+    model_log = tl.ModelLog("tiny")
+
+    def fake_validate_saved_activations(*args: Any, **kwargs: Any) -> bool:
+        """Return success without running the real validation path."""
+
+        del args, kwargs
+        return True
+
+    monkeypatch.setattr(
+        validation_core,
+        "validate_saved_activations",
+        fake_validate_saved_activations,
+    )
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        first = model_log.validate_saved_activations([torch.randn(1)])
+        second = model_log.validate_saved_activations([torch.randn(1)])
+
+    assert first is True
+    assert second is True
+    assert len(_deprecation_messages(records)) == 1
+
+
+@pytest.mark.parametrize(
+    ("old_name", "new_name", "value", "captured_key"),
+    [
+        ("num_context_lines", "source_context_lines", 5, "num_context_lines"),
+        (
+            "mark_input_output_distances",
+            "compute_input_output_distances",
+            True,
+            "mark_input_output_distances",
+        ),
+        ("detect_loops", "detect_recurrent_patterns", False, "detect_loops"),
+    ],
+)
+def test_log_forward_pass_old_renamed_kwargs_warn(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+    old_name: str,
+    new_name: str,
+    value: Any,
+    captured_key: str,
+) -> None:
+    """Deprecated flat rename aliases should still work on ``log_forward_pass``."""
+
+    captured, _dummy_log = stubbed_runner
+    kwargs = {old_name: value}
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save=None, **kwargs)
+
+    assert captured[captured_key] == value
+    assert len(_deprecation_messages(records)) == 1
+    assert new_name in _deprecation_messages(records)[0]
+
+
+@pytest.mark.parametrize(
+    ("new_name", "value", "captured_key"),
+    [
+        ("source_context_lines", 6, "num_context_lines"),
+        ("compute_input_output_distances", True, "mark_input_output_distances"),
+        ("detect_recurrent_patterns", False, "detect_loops"),
+    ],
+)
+def test_log_forward_pass_new_renamed_kwargs_do_not_warn(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+    new_name: str,
+    value: Any,
+    captured_key: str,
+) -> None:
+    """Canonical renamed kwargs should work on ``log_forward_pass`` without warnings."""
+
+    captured, _dummy_log = stubbed_runner
+    kwargs = {new_name: value}
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save=None, **kwargs)
+
+    assert captured[captured_key] == value
+    assert _deprecation_messages(records) == []
+
+
+@pytest.mark.parametrize(
+    ("old_name", "new_name", "old_value", "new_value"),
+    [
+        ("num_context_lines", "source_context_lines", 5, 6),
+        ("mark_input_output_distances", "compute_input_output_distances", True, False),
+        ("detect_loops", "detect_recurrent_patterns", True, False),
+    ],
+)
+def test_log_forward_pass_mixing_old_and_new_renamed_kwargs_raises(
+    old_name: str,
+    new_name: str,
+    old_value: Any,
+    new_value: Any,
+) -> None:
+    """Mixing deprecated and canonical rename spellings should fail."""
+
+    with pytest.raises(
+        TypeError,
+        match=f"kwarg {old_name} deprecated, use {new_name}; do not pass both",
+    ):
+        tl.log_forward_pass(
+            _TinyModel(),
+            _tiny_input(),
+            layers_to_save=None,
+            **{old_name: old_value, new_name: new_value},
+        )
+
+
+def test_old_kwarg_warning_deduplicates_per_process(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+) -> None:
+    """Repeated use of the same deprecated kwarg should only warn once."""
+
+    del stubbed_runner
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save=None, num_context_lines=3)
+        tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save=None, num_context_lines=4)
+
+    assert len(_deprecation_messages(records)) == 1
+
+
+def test_show_model_graph_new_detect_recurrent_patterns_has_no_warning(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+) -> None:
+    """The canonical recurrent-pattern kwarg should work on ``show_model_graph``."""
+
+    captured, _dummy_log = stubbed_runner
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.show_model_graph(_TinyModel(), _tiny_input(), detect_recurrent_patterns=False)
+
+    assert captured["detect_loops"] is False
+    assert _deprecation_messages(records) == []
+
+
+def test_show_model_graph_old_detect_loops_warns(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+) -> None:
+    """The deprecated recurrent-pattern kwarg should still work on ``show_model_graph``."""
+
+    captured, _dummy_log = stubbed_runner
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.show_model_graph(_TinyModel(), _tiny_input(), detect_loops=False)
+
+    assert captured["detect_loops"] is False
+    assert len(_deprecation_messages(records)) == 1
+
+
+def test_show_model_graph_mixing_detect_loop_names_raises() -> None:
+    """Mixing old and new recurrent-pattern kwarg names should fail."""
+
+    with pytest.raises(
+        TypeError,
+        match="kwarg detect_loops deprecated, use detect_recurrent_patterns; do not pass both",
+    ):
+        tl.show_model_graph(
+            _TinyModel(),
+            _tiny_input(),
+            detect_loops=True,
+            detect_recurrent_patterns=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "flat_name", "value", "render_key"),
+    _VISUALIZATION_CASES,
+)
+def test_visualization_options_group_supports_every_field(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+    field_name: str,
+    flat_name: str,
+    value: Any,
+    render_key: str,
+) -> None:
+    """Every visualization group field should route through the grouped object."""
+
+    del flat_name
+    _captured, dummy_log = stubbed_runner
+    option_kwargs: dict[str, Any] = {"mode": "rolled"}
+    if field_name == "mode":
+        option_kwargs = {"mode": value}
+    else:
+        option_kwargs[field_name] = value
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(
+            _TinyModel(),
+            _tiny_input(),
+            layers_to_save=None,
+            visualization=VisualizationOptions(**option_kwargs),
+        )
+
+    assert _deprecation_messages(records) == []
+    assert dummy_log.render_calls[-1][render_key] == value
+
+
+@pytest.mark.parametrize(
+    ("field_name", "flat_name", "value", "render_key"),
+    _VISUALIZATION_CASES,
+)
+def test_visualization_flat_aliases_warn_and_route(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+    field_name: str,
+    flat_name: str,
+    value: Any,
+    render_key: str,
+) -> None:
+    """Every deprecated flat visualization kwarg should still work."""
+
+    del field_name
+    _captured, dummy_log = stubbed_runner
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.show_model_graph(_TinyModel(), _tiny_input(), **{flat_name: value})
+
+    assert dummy_log.render_calls[-1][render_key] == value
+    assert len(_deprecation_messages(records)) == 1
+
+
+def test_visualization_group_and_flat_same_field_raise() -> None:
+    """Same-field grouped and flat visualization inputs should conflict."""
+
+    with pytest.raises(TypeError, match="Do not pass both `vis_mode` and `visualization.mode`."):
+        tl.show_model_graph(
+            _TinyModel(),
+            _tiny_input(),
+            visualization=VisualizationOptions(mode="rolled"),
+            vis_mode="unrolled",
+        )
+
+
+def test_visualization_group_and_flat_same_field_raise_for_explicit_default() -> None:
+    """Explicit default-valued grouped visualization fields still count as supplied."""
+
+    with pytest.raises(
+        TypeError,
+        match="Do not pass both `vis_nesting_depth` and `visualization.max_module_depth`.",
+    ):
+        tl.show_model_graph(
+            _TinyModel(),
+            _tiny_input(),
+            visualization=VisualizationOptions(mode="rolled", max_module_depth=1000),
+            vis_nesting_depth=5,
+        )
+
+
+def test_visualization_group_and_flat_different_fields_merge_without_mutation(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+) -> None:
+    """Different visualization fields should merge and leave the caller object unchanged."""
+
+    _captured, dummy_log = stubbed_runner
+    visualization = VisualizationOptions(mode="rolled")
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.show_model_graph(
+            _TinyModel(),
+            _tiny_input(),
+            visualization=visualization,
+            vis_nesting_depth=5,
+        )
+
+    assert visualization.max_module_depth == 1000
+    assert dummy_log.render_calls[-1]["vis_mode"] == "rolled"
+    assert dummy_log.render_calls[-1]["vis_nesting_depth"] == 5
+    assert len(_deprecation_messages(records)) == 1
+
+
+def test_visualization_defaults_preserve_per_function_behavior(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+) -> None:
+    """Grouped visualization defaults must keep current per-function behavior."""
+
+    _captured, dummy_log = stubbed_runner
+
+    tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save=None)
+    assert dummy_log.render_calls == []
+
+    tl.show_model_graph(_TinyModel(), _tiny_input())
+    assert dummy_log.render_calls[-1]["vis_mode"] == "unrolled"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "flat_name", "value", "captured_key"),
+    _STREAMING_CASES,
+)
+def test_streaming_options_group_supports_every_field(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+    field_name: str,
+    flat_name: str,
+    value: Any,
+    captured_key: str,
+) -> None:
+    """Every streaming group field should route through the grouped object."""
+
+    del flat_name
+    captured, _dummy_log = stubbed_runner
+    option_kwargs = {field_name: value}
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(
+            _TinyModel(),
+            _tiny_input(),
+            layers_to_save="all",
+            streaming=StreamingOptions(**option_kwargs),
+        )
+
+    assert captured[captured_key] == value
+    assert _deprecation_messages(records) == []
+
+
+@pytest.mark.parametrize(
+    ("field_name", "flat_name", "value", "captured_key"),
+    _STREAMING_CASES,
+)
+def test_streaming_flat_aliases_warn_and_route(
+    stubbed_runner: tuple[dict[str, Any], _DummyLog],
+    field_name: str,
+    flat_name: str,
+    value: Any,
+    captured_key: str,
+) -> None:
+    """Every deprecated flat streaming kwarg should still work."""
+
+    del field_name
+    captured, _dummy_log = stubbed_runner
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save="all", **{flat_name: value})
+
+    assert captured[captured_key] == value
+    assert len(_deprecation_messages(records)) == 1
+
+
+def test_streaming_group_and_flat_same_field_raise() -> None:
+    """Same-field grouped and flat streaming inputs should conflict."""
+
+    with pytest.raises(
+        TypeError,
+        match="Do not pass both `save_activations_to` and `streaming.bundle_path`.",
+    ):
+        tl.log_forward_pass(
+            _TinyModel(),
+            _tiny_input(),
+            layers_to_save="all",
+            streaming=StreamingOptions(bundle_path=Path("bundle")),
+            save_activations_to=Path("other"),
+        )
+
+
+def test_streaming_group_and_flat_same_field_raise_for_explicit_default() -> None:
+    """Explicit default-valued grouped streaming fields still count as supplied."""
+
+    with pytest.raises(
+        TypeError,
+        match="Do not pass both `save_activations_to` and `streaming.bundle_path`.",
+    ):
+        tl.log_forward_pass(
+            _TinyModel(),
+            _tiny_input(),
+            layers_to_save="all",
+            streaming=StreamingOptions(bundle_path=None),
+            save_activations_to=Path("bundle"),
+        )

--- a/tests/test_cross_file_refactor.py
+++ b/tests/test_cross_file_refactor.py
@@ -1,0 +1,58 @@
+"""Guards against reintroducing ModelLog class-body method rebinding."""
+
+import ast
+import inspect
+
+from torchlens.data_classes import model_log as model_log_module
+
+
+EXPECTED_MODELLOG_METHODS = {
+    "render_graph",
+    "render_dagua_graph",
+    "to_dagua_graph",
+    "visualization_field_audit",
+    "print_all_fields",
+    "to_pandas",
+    "to_csv",
+    "to_parquet",
+    "to_json",
+    "save_new_activations",
+    "validate_saved_activations",
+    "validate_forward_pass",
+    "check_metadata_invariants",
+    "cleanup",
+    "release_param_refs",
+    "_postprocess",
+    "_run_and_log_inputs_through_model",
+    "_remove_log_entry",
+    "_batch_remove_log_entries",
+}
+
+
+def test_modellog_has_no_class_body_attribute_rebindings() -> None:
+    """ModelLog must define its method surface with explicit ``def`` statements."""
+    source = inspect.getsource(model_log_module)
+    tree = ast.parse(source)
+    class_defs = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == "ModelLog"
+    ]
+    assert class_defs, "ModelLog class not found"
+
+    model_log_class = class_defs[0]
+    defined_methods = {
+        node.name
+        for node in model_log_class.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    missing_methods = EXPECTED_MODELLOG_METHODS - defined_methods
+    assert not missing_methods, f"ModelLog is missing explicit defs: {sorted(missing_methods)}"
+
+    for body_node in model_log_class.body:
+        if isinstance(body_node, ast.Assign) and isinstance(body_node.value, ast.Name):
+            targets = ", ".join(ast.unparse(target) for target in body_node.targets)
+            raise AssertionError(
+                f"ModelLog class body contains attribute rebinding "
+                f"'{targets} = {body_node.value.id}'"
+            )

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,321 @@
+"""Regression coverage for current TorchLens entry-point defaults."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+import torchlens.user_funcs as user_funcs
+from torchlens.options import VisualizationOptions
+
+
+class _DummyLog:
+    """Minimal stand-in for ``ModelLog`` used by default-behavior tests."""
+
+    def __init__(self) -> None:
+        """Initialize a capture object with the attributes the wrappers expect."""
+        self.cleanup_calls = 0
+        self.layer_logs: dict[str, Any] = {}
+        self.num_tensors_saved = 0
+        self.render_calls: list[dict[str, Any]] = []
+        self.summary_calls: list[dict[str, Any]] = []
+        self.summary_result = "summary output"
+        self.total_activation_memory_str = "0 B"
+        self.validate_calls: list[dict[str, Any]] = []
+        self.verbose = False
+
+    def cleanup(self) -> None:
+        """Record cleanup requests from wrapper helpers."""
+        self.cleanup_calls += 1
+
+    def render_graph(self, **kwargs: Any) -> None:
+        """Record visualization kwargs forwarded by the wrapper."""
+        self.render_calls.append(kwargs)
+
+    def summary(self, **kwargs: Any) -> str:
+        """Record summary kwargs and return a fixed summary string."""
+        self.summary_calls.append(kwargs)
+        return self.summary_result
+
+    def validate_forward_pass(
+        self,
+        ground_truth_output_tensors: list[torch.Tensor],
+        verbose: bool,
+        validate_metadata: bool = True,
+    ) -> bool:
+        """Record replay-validation inputs and return success.
+
+        Parameters
+        ----------
+        ground_truth_output_tensors:
+            Deduplicated model outputs collected before logging.
+        verbose:
+            Verbosity flag forwarded by ``validate_forward_pass``.
+        validate_metadata:
+            Metadata-invariant flag forwarded by ``validate_forward_pass``.
+
+        Returns
+        -------
+        bool
+            Always ``True`` for the stubbed validation path.
+        """
+
+        self.validate_calls.append(
+            {
+                "ground_truth_output_tensors": ground_truth_output_tensors,
+                "verbose": verbose,
+                "validate_metadata": validate_metadata,
+            }
+        )
+        return True
+
+
+class _TinyModel(nn.Module):
+    """Small module used to exercise the public entry points."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return a simple deterministic output tensor.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Input shifted by one.
+        """
+
+        return x + 1
+
+
+def _tiny_input() -> torch.Tensor:
+    """Return a stable input tensor for wrapper tests.
+
+    Returns
+    -------
+    torch.Tensor
+        Input tensor with a single batch element.
+    """
+
+    return torch.randn(1, 2)
+
+
+@pytest.fixture
+def stubbed_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[dict[str, Any]], list[_DummyLog]]:
+    """Patch the internal logging runner and capture forwarded kwargs.
+
+    Parameters
+    ----------
+    monkeypatch:
+        Pytest monkeypatch fixture.
+
+    Returns
+    -------
+    tuple[list[dict[str, Any]], list[_DummyLog]]
+        Captured runner kwargs and the dummy logs returned for each call.
+    """
+
+    captured_calls: list[dict[str, Any]] = []
+    dummy_logs: list[_DummyLog] = []
+
+    def _fake_runner(**kwargs: Any) -> _DummyLog:
+        """Capture runner kwargs and return a fresh dummy log.
+
+        Parameters
+        ----------
+        **kwargs:
+            Keyword arguments forwarded by the public wrappers.
+
+        Returns
+        -------
+        _DummyLog
+            Stand-in log instance for the wrapper under test.
+        """
+
+        captured_calls.append(kwargs)
+        dummy_log = _DummyLog()
+        dummy_logs.append(dummy_log)
+        return dummy_log
+
+    monkeypatch.setattr(user_funcs, "_run_model_and_save_specified_activations", _fake_runner)
+    return captured_calls, dummy_logs
+
+
+def test_log_forward_pass_defaults_are_stable(
+    stubbed_runner: tuple[list[dict[str, Any]], list[_DummyLog]],
+) -> None:
+    """``log_forward_pass`` should preserve the audited default behavior."""
+
+    captured_calls, dummy_logs = stubbed_runner
+
+    result = tl.log_forward_pass(_TinyModel(), _tiny_input(), layers_to_save=None)
+
+    assert result is dummy_logs[-1]
+    assert captured_calls[-1]["layers_to_save"] is None
+    assert captured_calls[-1]["keep_unsaved_layers"] is True
+    assert captured_calls[-1]["output_device"] == "same"
+    assert captured_calls[-1]["activation_postfunc"] is None
+    assert captured_calls[-1]["mark_input_output_distances"] is False
+    assert captured_calls[-1]["detach_saved_tensors"] is False
+    assert captured_calls[-1]["save_function_args"] is False
+    assert captured_calls[-1]["save_gradients"] is False
+    assert captured_calls[-1]["num_context_lines"] == 7
+    assert captured_calls[-1]["save_source_context"] is False
+    assert captured_calls[-1]["save_rng_states"] is False
+    assert captured_calls[-1]["detect_loops"] is True
+    assert captured_calls[-1]["save_activations_to"] is None
+    assert captured_calls[-1]["keep_activations_in_memory"] is True
+    assert captured_calls[-1]["activation_sink"] is None
+    assert captured_calls[-1]["verbose"] is False
+    assert dummy_logs[-1].render_calls == []
+
+
+def test_log_forward_pass_accepts_explicit_opt_in_overrides(
+    stubbed_runner: tuple[list[dict[str, Any]], list[_DummyLog]],
+) -> None:
+    """Callers should still be able to opt into the non-default behaviors."""
+
+    captured_calls, dummy_logs = stubbed_runner
+
+    result = tl.log_forward_pass(
+        _TinyModel(),
+        _tiny_input(),
+        layers_to_save=None,
+        keep_unsaved_layers=False,
+        compute_input_output_distances=True,
+        save_source_context=True,
+        detect_recurrent_patterns=False,
+        visualization=VisualizationOptions(mode="rolled"),
+    )
+
+    assert result is dummy_logs[-1]
+    assert captured_calls[-1]["keep_unsaved_layers"] is False
+    assert captured_calls[-1]["mark_input_output_distances"] is True
+    assert captured_calls[-1]["save_source_context"] is True
+    assert captured_calls[-1]["detect_loops"] is False
+    assert dummy_logs[-1].render_calls[-1]["vis_mode"] == "rolled"
+
+
+def test_show_model_graph_defaults_are_stable(
+    stubbed_runner: tuple[list[dict[str, Any]], list[_DummyLog]],
+) -> None:
+    """``show_model_graph`` should preserve its wrapper-specific defaults."""
+
+    captured_calls, dummy_logs = stubbed_runner
+
+    tl.show_model_graph(_TinyModel(), _tiny_input())
+
+    assert captured_calls[-1]["layers_to_save"] is None
+    assert captured_calls[-1]["mark_input_output_distances"] is False
+    assert captured_calls[-1]["detach_saved_tensors"] is False
+    assert captured_calls[-1]["save_gradients"] is False
+    assert captured_calls[-1]["detect_loops"] is True
+    assert captured_calls[-1]["verbose"] is False
+    assert dummy_logs[-1].render_calls[-1]["vis_mode"] == "unrolled"
+    assert dummy_logs[-1].cleanup_calls == 1
+
+
+def test_show_model_graph_accepts_explicit_opt_in_overrides(
+    stubbed_runner: tuple[list[dict[str, Any]], list[_DummyLog]],
+) -> None:
+    """``show_model_graph`` should still honor explicit non-default choices."""
+
+    captured_calls, dummy_logs = stubbed_runner
+
+    tl.show_model_graph(
+        _TinyModel(),
+        _tiny_input(),
+        detect_recurrent_patterns=False,
+        visualization=VisualizationOptions(mode="rolled"),
+    )
+
+    assert captured_calls[-1]["detect_loops"] is False
+    assert dummy_logs[-1].render_calls[-1]["vis_mode"] == "rolled"
+    assert dummy_logs[-1].cleanup_calls == 1
+
+
+def test_log_model_metadata_forces_metadata_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``log_model_metadata`` should keep its metadata-only wrapper behavior."""
+
+    captured_kwargs: dict[str, Any] = {}
+    dummy_log = _DummyLog()
+
+    def _fake_log_forward_pass(*args: Any, **kwargs: Any) -> _DummyLog:
+        """Capture wrapper kwargs and return a dummy log.
+
+        Parameters
+        ----------
+        *args:
+            Positional arguments passed through the wrapper.
+        **kwargs:
+            Keyword arguments passed through the wrapper.
+
+        Returns
+        -------
+        _DummyLog
+            Stand-in log instance for the wrapper under test.
+        """
+
+        del args
+        captured_kwargs.update(kwargs)
+        return dummy_log
+
+    monkeypatch.setattr(user_funcs, "log_forward_pass", _fake_log_forward_pass)
+
+    result = tl.log_model_metadata(_TinyModel(), _tiny_input())
+
+    assert result is dummy_log
+    assert captured_kwargs["layers_to_save"] is None
+    assert captured_kwargs["compute_input_output_distances"] is True
+
+
+def test_summary_uses_metadata_only_defaults(
+    stubbed_runner: tuple[list[dict[str, Any]], list[_DummyLog]],
+) -> None:
+    """``summary`` should still use metadata-only logging defaults."""
+
+    captured_calls, dummy_logs = stubbed_runner
+
+    result = tl.summary(_TinyModel(), _tiny_input(), depth=2)
+
+    assert result == "summary output"
+    assert captured_calls[-1]["layers_to_save"] is None
+    assert captured_calls[-1]["keep_unsaved_layers"] is True
+    assert captured_calls[-1]["detect_loops"] is True
+    assert dummy_logs[-1].summary_calls[-1] == {"depth": 2}
+    assert dummy_logs[-1].cleanup_calls == 1
+
+
+def test_validate_forward_pass_uses_validation_overrides(
+    stubbed_runner: tuple[list[dict[str, Any]], list[_DummyLog]],
+) -> None:
+    """``validate_forward_pass`` should keep its replay-specific overrides."""
+
+    captured_calls, dummy_logs = stubbed_runner
+
+    result = tl.validate_forward_pass(
+        _TinyModel(),
+        _tiny_input(),
+        random_seed=123,
+        validate_metadata=False,
+    )
+
+    assert result is True
+    assert captured_calls[-1]["layers_to_save"] == "all"
+    assert captured_calls[-1]["keep_unsaved_layers"] is True
+    assert captured_calls[-1]["activation_postfunc"] is None
+    assert captured_calls[-1]["mark_input_output_distances"] is False
+    assert captured_calls[-1]["detach_saved_tensors"] is False
+    assert captured_calls[-1]["save_gradients"] is False
+    assert captured_calls[-1]["save_function_args"] is True
+    assert captured_calls[-1]["save_rng_states"] is True
+    assert dummy_logs[-1].validate_calls[-1]["validate_metadata"] is False
+    assert dummy_logs[-1].cleanup_calls == 1

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,122 @@
+"""Tests for the ModelLog summary feature."""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+
+
+class TinySummaryModel(nn.Module):
+    """Small model with stable top-level module names for summary tests."""
+
+    def __init__(self) -> None:
+        """Initialize the test model."""
+        super().__init__()
+        self.conv = nn.Conv2d(3, 4, kernel_size=3, padding=1, bias=False)
+        self.relu = nn.ReLU()
+        self.flatten = nn.Flatten()
+        self.fc = nn.Linear(4 * 8 * 8, 5, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass."""
+        x = self.conv(x)
+        x = self.relu(x)
+        x = self.flatten(x)
+        return self.fc(x)
+
+
+@pytest.fixture()
+def tiny_summary_log() -> Generator[tl.ModelLog, None, None]:
+    """Return a metadata-only log for the tiny summary model."""
+    model = TinySummaryModel()
+    x = torch.randn(1, 3, 8, 8)
+    log = tl.log_forward_pass(model, x, layers_to_save=None)
+    try:
+        yield log
+    finally:
+        log.cleanup()
+
+
+def test_small_model_default_output_golden(tiny_summary_log: tl.ModelLog) -> None:
+    """Default overview output should match the expected compact golden text."""
+    summary_text = tiny_summary_log.summary()
+    assert summary_text == (
+        "Model: TinySummaryModel\n"
+        "+-------------------+--------------+--------+-------+\n"
+        "| Layer             | Output Shape | Params | Train |\n"
+        "+-------------------+--------------+--------+-------+\n"
+        "| input             | [1,3,8,8]    | 0      | -     |\n"
+        "| conv (Conv2d)     | [1,4,8,8]    | 108    | yes   |\n"
+        "| relu (ReLU)       | [1,4,8,8]    | 0      | -     |\n"
+        "| flatten (Flatten) | [1,256]      | 0      | -     |\n"
+        "| fc (Linear)       | [1,5]        | 1.3 K  | yes   |\n"
+        "| output            | [1,5]        | -      | -     |\n"
+        "+-------------------+--------------+--------+-------+\n"
+        "Params: 1,388 unique; trainable: 1,388\n"
+        "Ops: 4 total\n"
+        "Saved activations: 0 B\n"
+        "Forward FLOPs: 19.2 K  MACs: 9.6 K"
+    )
+
+
+@pytest.mark.parametrize(
+    "level, expected_fragment",
+    [
+        ("overview", "Model: TinySummaryModel"),
+        ("graph", "Graph Summary: TinySummaryModel"),
+        ("memory", "Memory Summary: TinySummaryModel"),
+        ("control_flow", "Control-Flow Summary: TinySummaryModel"),
+        ("compute", "Compute Summary: TinySummaryModel"),
+        ("cost", "Compute Summary: TinySummaryModel"),
+    ],
+)
+def test_all_level_options(
+    tiny_summary_log: tl.ModelLog,
+    level: str,
+    expected_fragment: str,
+) -> None:
+    """Every supported level should render without error."""
+    summary_text = tiny_summary_log.summary(level=level)  # type: ignore[arg-type]
+    assert expected_fragment in summary_text
+
+
+def test_custom_fields_selection(tiny_summary_log: tl.ModelLog) -> None:
+    """Custom field selection should drive the primary table columns."""
+    summary_text = tiny_summary_log.summary(fields=["name", "params"])
+    assert "| Layer             | Params |" in summary_text
+    assert "Output Shape" not in summary_text
+
+
+def test_show_ops_true_dumps_op_level_rows(tiny_summary_log: tl.ModelLog) -> None:
+    """show_ops=True should append operation-level rows."""
+    summary_text = tiny_summary_log.summary(show_ops=True, mode="rolled")
+    assert "Operations:" in summary_text
+    assert "conv2d_1_1" in summary_text
+    assert "linear_1_4" in summary_text
+
+
+def test_repr_remains_short_for_resnet18() -> None:
+    """The compact repr should stay comfortably below the sprint cap."""
+    torchvision_models = pytest.importorskip("torchvision.models")
+    model = torchvision_models.resnet18()
+    x = torch.randn(1, 3, 64, 64)
+    log = tl.log_forward_pass(model, x, layers_to_save=None)
+    try:
+        rendered = repr(log)
+    finally:
+        log.cleanup()
+    assert len(rendered) < 1200
+
+
+def test_torchlens_summary_wrapper() -> None:
+    """The top-level wrapper should return the rendered summary string."""
+    model = TinySummaryModel()
+    x = torch.randn(1, 3, 8, 8)
+    summary_text = tl.summary(model, x)
+    assert isinstance(summary_text, str)
+    assert "Model: TinySummaryModel" in summary_text

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -15,6 +15,7 @@ __version__ = "1.2.0"
 
 from .user_funcs import (
     log_forward_pass,
+    summary,
     show_model_graph,
     get_model_metadata,
     validate_forward_pass,

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -17,11 +17,13 @@ from .user_funcs import (
     log_forward_pass,
     summary,
     show_model_graph,
+    log_model_metadata,
     get_model_metadata,
     validate_forward_pass,
     validate_saved_activations,
     validate_batch_of_models_and_inputs,
 )
+from .options import StreamingOptions, VisualizationOptions
 from .validation.invariants import check_metadata_invariants, MetadataInvariantError
 from ._io.bundle import save, load, cleanup_tmp
 from ._io import rehydrate_nested

--- a/torchlens/_deprecations.py
+++ b/torchlens/_deprecations.py
@@ -1,0 +1,97 @@
+"""Shared helpers for additive public-API deprecations."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Final, TypeVar, cast
+
+T = TypeVar("T")
+
+
+class MissingType:
+    """Sentinel type used to detect explicitly supplied public kwargs.
+
+    Notes
+    -----
+    Public APIs in this sprint must distinguish ``caller omitted this kwarg``
+    from ``caller explicitly passed the public default``. A dedicated sentinel
+    keeps those cases separate without relying on value comparisons.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        """Return a stable debugging representation."""
+
+        return "MISSING"
+
+
+MISSING: Final[MissingType] = MissingType()
+_WARNED_DEPRECATIONS: set[str] = set()
+
+
+def warn_deprecated_alias(old: str, new: str) -> None:
+    """Emit a once-per-process deprecation warning for an old public name.
+
+    Parameters
+    ----------
+    old:
+        Deprecated public name.
+    new:
+        Canonical replacement name.
+    """
+
+    key = f"{old}->{new}"
+    if key in _WARNED_DEPRECATIONS:
+        return
+    _WARNED_DEPRECATIONS.add(key)
+    warnings.warn(
+        f"`{old}` is deprecated; use `{new}` instead. "
+        "The old name continues to work but will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+def resolve_renamed_kwarg(
+    *,
+    old_name: str,
+    new_name: str,
+    old_value: T | MissingType,
+    new_value: T | MissingType,
+    default: T,
+) -> T:
+    """Resolve a deprecated kwarg alias to its canonical replacement.
+
+    Parameters
+    ----------
+    old_name:
+        Deprecated kwarg name.
+    new_name:
+        Canonical replacement kwarg name.
+    old_value:
+        Value supplied via the deprecated kwarg, or ``MISSING``.
+    new_value:
+        Value supplied via the canonical kwarg, or ``MISSING``.
+    default:
+        Public default used when neither spelling is supplied.
+
+    Returns
+    -------
+    T
+        Resolved kwarg value.
+
+    Raises
+    ------
+    TypeError
+        If both the deprecated and canonical spellings were supplied.
+    """
+
+    if old_value is not MISSING and new_value is not MISSING:
+        raise TypeError(f"kwarg {old_name} deprecated, use {new_name}; do not pass both")
+    if old_value is not MISSING:
+        warn_deprecated_alias(old_name, new_name)
+        return cast(T, old_value)
+    if new_value is not MISSING:
+        return cast(T, new_value)
+    return default

--- a/torchlens/_literals.py
+++ b/torchlens/_literals.py
@@ -1,0 +1,9 @@
+"""Shared Literal aliases for public TorchLens option strings."""
+
+from typing import Literal
+
+OutputDeviceLiteral = Literal["same", "cpu", "cuda"]
+VisModeLiteral = Literal["none", "rolled", "unrolled"]
+VisDirectionLiteral = Literal["bottomup", "topdown", "leftright"]
+VisNodePlacementLiteral = Literal["auto", "dot", "elk", "sfdp"]
+VisRendererLiteral = Literal["graphviz", "dagua"]

--- a/torchlens/_summary/__init__.py
+++ b/torchlens/_summary/__init__.py
@@ -1,0 +1,5 @@
+"""Text summary helpers for ``ModelLog`` objects."""
+
+from ._builder import format_model_repr, render_model_summary
+
+__all__ = ["format_model_repr", "render_model_summary"]

--- a/torchlens/_summary/_builder.py
+++ b/torchlens/_summary/_builder.py
@@ -1,0 +1,1183 @@
+"""Build compact text summaries for ``ModelLog`` objects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Literal, Optional, Sequence
+
+from ..utils.display import human_readable_size
+
+if TYPE_CHECKING:
+    from ..data_classes.layer_log import LayerLog
+    from ..data_classes.layer_pass_log import LayerPassLog
+    from ..data_classes.model_log import ConditionalEvent, ModelLog
+    from ..data_classes.module_log import ModuleLog
+
+
+SummaryLevel = Literal["overview", "graph", "memory", "control_flow", "compute", "cost"]
+SummaryMode = Literal["auto", "rolled", "unrolled"]
+
+_LEVEL_ALIASES: Dict[str, str] = {"cost": "compute"}
+
+_COLUMN_LABELS: Dict[str, str] = {
+    "name": "Layer",
+    "shape": "Output Shape",
+    "params": "Params",
+    "train": "Train",
+    "class": "Class",
+    "parents": "Connected To",
+    "dtype": "Dtype",
+    "tensor_mb": "Tensor MB",
+    "running_mb": "Cum Tensor MB",
+    "flops": "Fwd FLOPs",
+    "macs": "MACs",
+    "time_ms": "Time (ms)",
+    "site": "Site",
+    "source": "Source",
+    "taken": "Taken",
+    "bool_layer": "Bool Layer",
+    "branch_ops": "Branch Ops",
+    "notes": "Notes",
+}
+
+_LEVEL_DEFAULT_FIELDS: Dict[str, List[str]] = {
+    "overview": ["name", "shape", "params", "train"],
+    "graph": ["name", "shape", "params", "parents"],
+    "memory": ["name", "shape", "dtype", "tensor_mb", "running_mb"],
+    "control_flow": ["site", "source", "taken", "bool_layer", "branch_ops", "notes"],
+    "compute": ["name", "params", "flops", "macs", "time_ms", "dtype"],
+}
+
+
+def render_model_summary(
+    model_log: "ModelLog",
+    *,
+    level: SummaryLevel = "overview",
+    preset: SummaryLevel | None = None,
+    fields: Optional[List[str]] = None,
+    columns: Optional[List[str]] = None,
+    mode: SummaryMode = "auto",
+    show_ops: bool = False,
+    include_ops: Optional[bool] = None,
+    max_rows: Optional[int] = 200,
+    print_to: Optional[Callable[[str], None]] = None,
+) -> str:
+    """Render a textual summary for a ``ModelLog``.
+
+    Parameters
+    ----------
+    model_log:
+        Logged model metadata to summarize.
+    level:
+        Primary summary level. This is the public selector used by the sprint
+        prompt and maps to the design doc's preset concept.
+    preset:
+        Alias for ``level`` retained for compatibility with the design wording.
+    fields:
+        Explicit column selection for the primary table.
+    columns:
+        Alias for ``fields``.
+    mode:
+        Operation aggregation mode. ``"rolled"`` uses ``LayerLog`` rows,
+        ``"unrolled"`` uses ``LayerPassLog`` rows, and ``"auto"`` chooses
+        based on recurrence.
+    show_ops:
+        Whether to append an operation table after the primary summary.
+    include_ops:
+        Alias for ``show_ops`` retained for compatibility with the design wording.
+    max_rows:
+        Maximum number of rows to render per table. ``None`` disables truncation.
+    print_to:
+        Optional callable that receives the rendered summary.
+
+    Returns
+    -------
+    str
+        Rendered summary text.
+    """
+    resolved_level = _resolve_level(level=level, preset=preset)
+    resolved_show_ops = _resolve_show_ops(show_ops=show_ops, include_ops=include_ops)
+    resolved_fields = _resolve_fields(resolved_level, fields=fields, columns=columns)
+
+    if not model_log._pass_finished:
+        text = _render_in_progress_summary(
+            model_log=model_log,
+            fields=resolved_fields,
+            mode=mode,
+            show_ops=resolved_show_ops,
+            max_rows=max_rows,
+        )
+    else:
+        text = _render_finished_summary(
+            model_log=model_log,
+            level=resolved_level,
+            fields=resolved_fields,
+            mode=mode,
+            show_ops=resolved_show_ops,
+            max_rows=max_rows,
+        )
+    if print_to is not None:
+        print_to(text)
+    return text
+
+
+def format_model_repr(model_log: "ModelLog") -> str:
+    """Return a short ``repr`` string for a ``ModelLog``.
+
+    Parameters
+    ----------
+    model_log:
+        Logged model metadata to summarize.
+
+    Returns
+    -------
+    str
+        Short two-line representation.
+    """
+    if not model_log._pass_finished:
+        lines = [
+            f"<ModelLog {model_log.model_name}>",
+            f"pass_in_progress ops_logged={len(model_log._raw_layer_dict)} finalized=False",
+        ]
+        return "\n".join(lines)
+
+    lines = [
+        f"<ModelLog {model_log.model_name}>",
+        " ".join(
+            [
+                f"layers={len(model_log.layer_logs)}",
+                f"params={_human_count(model_log.total_params)}",
+                f"ops={model_log.num_operations}",
+                f"saved={human_readable_size(model_log.saved_activation_memory)}",
+                f"forward={model_log.time_forward_pass:.3f}s",
+            ]
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def _resolve_level(*, level: SummaryLevel, preset: SummaryLevel | None) -> str:
+    """Resolve the level/preset selector to a canonical level name.
+
+    Parameters
+    ----------
+    level:
+        User-supplied level selector.
+    preset:
+        Optional alias supplied via the design-doc name.
+
+    Returns
+    -------
+    str
+        Canonical level name.
+
+    Raises
+    ------
+    ValueError
+        If conflicting selectors are provided.
+    """
+    if preset is not None and preset != level:
+        raise ValueError("Pass either `level` or `preset`, not both with different values.")
+    selected_name: str = preset or level
+    selected_name = _LEVEL_ALIASES.get(selected_name, selected_name)
+    if selected_name not in _LEVEL_DEFAULT_FIELDS:
+        raise ValueError(f"Unsupported summary level: {selected_name!r}.")
+    return selected_name
+
+
+def _resolve_show_ops(*, show_ops: bool, include_ops: Optional[bool]) -> bool:
+    """Resolve the operation-dump toggle.
+
+    Parameters
+    ----------
+    show_ops:
+        Public operation toggle used by the sprint prompt.
+    include_ops:
+        Optional alias supplied via the design-doc name.
+
+    Returns
+    -------
+    bool
+        Final operation-dump toggle.
+
+    Raises
+    ------
+    ValueError
+        If conflicting values are provided.
+    """
+    # NOTE: The prompt names `show_ops` while the design doc names `include_ops`.
+    # This implementation treats them as strict aliases and rejects conflicting
+    # values rather than silently guessing precedence.
+    if include_ops is not None and include_ops != show_ops:
+        raise ValueError("Pass either `show_ops` or `include_ops`, not both with different values.")
+    return include_ops if include_ops is not None else show_ops
+
+
+def _resolve_fields(
+    level: str,
+    *,
+    fields: Optional[List[str]],
+    columns: Optional[List[str]],
+) -> List[str]:
+    """Resolve the primary-table field selection.
+
+    Parameters
+    ----------
+    level:
+        Canonical summary level.
+    fields:
+        Primary field selector.
+    columns:
+        Alias for ``fields``.
+
+    Returns
+    -------
+    list[str]
+        Resolved field list.
+
+    Raises
+    ------
+    ValueError
+        If conflicting values are provided.
+    """
+    if fields is not None and columns is not None and fields != columns:
+        raise ValueError("Pass either `fields` or `columns`, not both with different values.")
+    selected = columns if columns is not None else fields
+    if selected is None:
+        return list(_LEVEL_DEFAULT_FIELDS[level])
+    unknown = [field for field in selected if field not in _COLUMN_LABELS]
+    if unknown:
+        raise ValueError(f"Unsupported summary fields: {unknown}.")
+    return list(selected)
+
+
+def _render_in_progress_summary(
+    *,
+    model_log: "ModelLog",
+    fields: Sequence[str],
+    mode: SummaryMode,
+    show_ops: bool,
+    max_rows: Optional[int],
+) -> str:
+    """Render a truthful summary while the pass is still in progress.
+
+    Parameters
+    ----------
+    model_log:
+        Log still being populated.
+    fields:
+        Requested primary fields.
+    mode:
+        Requested aggregation mode.
+    show_ops:
+        Whether to include raw operation rows.
+    max_rows:
+        Maximum number of rows to render.
+
+    Returns
+    -------
+    str
+        Rendered in-progress summary.
+    """
+    lines = [
+        f"Model: {model_log.model_name}",
+        "Status: pass in progress; postprocessing has not finished yet.",
+        f"Ops logged so far: {len(model_log._raw_layer_dict)}",
+    ]
+    if show_ops and model_log._raw_layer_dict:
+        rows = []
+        for raw_label in model_log._raw_layer_labels_list:
+            entry = model_log._raw_layer_dict[raw_label]
+            row = {
+                "name": str(
+                    getattr(entry, "layer_label_raw", None)
+                    or getattr(entry, "tensor_label_raw", raw_label)
+                ),
+                "shape": _shape_str(getattr(entry, "tensor_shape", None)),
+                "dtype": _dtype_str(getattr(entry, "tensor_dtype", None)),
+            }
+            rows.append(row)
+        display_fields = [field for field in fields if field in {"name", "shape", "dtype"}] or [
+            "name",
+            "shape",
+            "dtype",
+        ]
+        lines.extend(
+            [
+                "",
+                "Raw Operations:",
+                _render_table(display_fields, rows, max_rows=max_rows),
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _render_finished_summary(
+    *,
+    model_log: "ModelLog",
+    level: str,
+    fields: Sequence[str],
+    mode: SummaryMode,
+    show_ops: bool,
+    max_rows: Optional[int],
+) -> str:
+    """Render a summary for a finalized ``ModelLog``.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    level:
+        Canonical summary level.
+    fields:
+        Primary field selection.
+    mode:
+        Operation aggregation mode.
+    show_ops:
+        Whether to append an operation table.
+    max_rows:
+        Maximum number of rows to render per table.
+
+    Returns
+    -------
+    str
+        Rendered summary text.
+    """
+    primary_rows, footer_lines = _build_level_rows(model_log=model_log, level=level, mode=mode)
+    lines = [
+        _level_title(model_log=model_log, level=level),
+        _render_table(fields, primary_rows, max_rows=max_rows),
+    ]
+    if footer_lines:
+        lines.extend(footer_lines)
+    if show_ops and level != "control_flow":
+        op_fields = _default_op_fields(level)
+        op_rows, op_footer_lines = _build_operation_rows(
+            model_log=model_log, mode=mode, level=level
+        )
+        lines.extend(
+            [
+                "",
+                "Operations:",
+                _render_table(op_fields, op_rows, max_rows=max_rows),
+            ]
+        )
+        if op_footer_lines:
+            lines.extend(op_footer_lines)
+    return "\n".join(lines)
+
+
+def _level_title(*, model_log: "ModelLog", level: str) -> str:
+    """Return the section title for a summary level.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    level:
+        Canonical level name.
+
+    Returns
+    -------
+    str
+        Section title.
+    """
+    title_map = {
+        "overview": f"Model: {model_log.model_name}",
+        "graph": f"Graph Summary: {model_log.model_name}",
+        "memory": f"Memory Summary: {model_log.model_name}",
+        "control_flow": f"Control-Flow Summary: {model_log.model_name}",
+        "compute": f"Compute Summary: {model_log.model_name}",
+    }
+    return title_map[level]
+
+
+def _build_level_rows(
+    *,
+    model_log: "ModelLog",
+    level: str,
+    mode: SummaryMode,
+) -> tuple[List[Dict[str, str]], List[str]]:
+    """Build rows and footer lines for one summary level.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    level:
+        Canonical level name.
+    mode:
+        Operation aggregation mode.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Primary table rows and footer lines.
+    """
+    if level == "overview":
+        return _build_overview_rows(model_log)
+    if level == "graph":
+        return _build_graph_rows(model_log)
+    if level == "memory":
+        return _build_memory_rows(model_log, mode=mode)
+    if level == "control_flow":
+        return _build_control_flow_rows(model_log)
+    return _build_compute_rows(model_log)
+
+
+def _build_overview_rows(model_log: "ModelLog") -> tuple[List[Dict[str, str]], List[str]]:
+    """Build the default overview rows.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Overview rows and footer lines.
+    """
+    rows: List[Dict[str, str]] = [
+        {
+            "name": "input",
+            "shape": _combined_shape_str(model_log, model_log.input_layers),
+            "params": "0",
+            "train": "-",
+        }
+    ]
+    for module in _iter_summary_modules(model_log):
+        rows.append(_module_overview_row(model_log, module))
+    rows.append(
+        {
+            "name": "output",
+            "shape": _combined_shape_str(model_log, model_log.output_layers),
+            "params": "-",
+            "train": "-",
+        }
+    )
+    footer_lines = [
+        f"Params: {_int_with_commas(model_log.total_params)} unique; trainable: "
+        f"{_int_with_commas(model_log.total_params_trainable)}",
+        f"Ops: {model_log.num_operations} total",
+        f"Saved activations: {human_readable_size(model_log.saved_activation_memory)}",
+        f"Forward FLOPs: {_human_flops(model_log.total_flops_forward)}  "
+        f"MACs: {_human_flops(model_log.total_macs_forward)}",
+    ]
+    return rows, footer_lines
+
+
+def _build_graph_rows(model_log: "ModelLog") -> tuple[List[Dict[str, str]], List[str]]:
+    """Build graph-summary rows.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Graph rows and footer lines.
+    """
+    rows = []
+    for module in _iter_summary_modules(model_log):
+        rows.append(
+            {
+                "name": f"{module.address} ({module.module_class_name})",
+                "shape": _module_shape(model_log, module),
+                "params": _human_count(module.num_params),
+                "parents": _module_parent_summary(module),
+            }
+        )
+    footer_lines = [
+        f"Modules shown: {len(rows)}",
+        f"Ops tracked: {model_log.num_operations}",
+    ]
+    return rows, footer_lines
+
+
+def _build_memory_rows(
+    model_log: "ModelLog",
+    *,
+    mode: SummaryMode,
+) -> tuple[List[Dict[str, str]], List[str]]:
+    """Build memory-summary rows.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    mode:
+        Operation aggregation mode.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Memory rows and footer lines.
+    """
+    running_total = 0
+    rows: List[Dict[str, str]] = []
+    for entry in _iter_operation_entries(model_log, mode=mode):
+        tensor_memory = int(getattr(entry, "tensor_memory", 0) or 0)
+        running_total += tensor_memory
+        rows.append(
+            {
+                "name": _entry_name(entry),
+                "shape": _shape_str(getattr(entry, "tensor_shape", None)),
+                "dtype": _dtype_str(getattr(entry, "tensor_dtype", None)),
+                "tensor_mb": _mb_str(tensor_memory),
+                "running_mb": _mb_str(running_total),
+            }
+        )
+    footer_lines = [
+        f"Tracked tensor volume: {human_readable_size(model_log.total_activation_memory)}",
+        f"Saved activations: {human_readable_size(model_log.saved_activation_memory)}",
+        "Live forward-memory peak: not tracked in ModelLog",
+    ]
+    return rows, footer_lines
+
+
+def _build_control_flow_rows(model_log: "ModelLog") -> tuple[List[Dict[str, str]], List[str]]:
+    """Build control-flow rows or an empty state.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Control-flow rows and footer lines.
+    """
+    rows: List[Dict[str, str]] = []
+    for event in model_log.conditional_events:
+        branch_kinds = _event_branch_kinds(model_log, event)
+        rows.append(
+            {
+                "site": f"cond#{event.id}",
+                "source": _event_source(event),
+                "taken": ",".join(branch_kinds) if branch_kinds else "unknown",
+                "bool_layer": _event_bool_layer(event),
+                "branch_ops": str(_event_branch_op_count(model_log, event)),
+                "notes": event.function_qualname,
+            }
+        )
+    if not rows:
+        footer_lines = [
+            "No conditional branches or recurrent loop groups were detected in this forward pass."
+        ]
+        return rows, footer_lines
+    footer_lines = [f"Conditionals: {len(rows)}"]
+    return rows, footer_lines
+
+
+def _build_compute_rows(model_log: "ModelLog") -> tuple[List[Dict[str, str]], List[str]]:
+    """Build compute-summary rows.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Compute rows and footer lines.
+    """
+    rows = []
+    for module in _iter_summary_modules(model_log):
+        rows.append(
+            {
+                "name": module.address,
+                "params": _human_count(module.num_params),
+                "flops": _human_flops(module.flops_forward),
+                "macs": _human_flops(module.macs_forward),
+                "time_ms": f"{_module_time_ms(model_log, module):.2f}",
+                "dtype": _module_dtype(model_log, module),
+            }
+        )
+    footer_lines = [
+        f"Params: {_int_with_commas(model_log.total_params)} unique",
+        f"Forward FLOPs: {_human_flops(model_log.total_flops_forward)}",
+        f"MACs: {_human_flops(model_log.total_macs_forward)}",
+        f"Forward time: {model_log.time_forward_pass * 1000:.2f} ms",
+    ]
+    return rows, footer_lines
+
+
+def _build_operation_rows(
+    *,
+    model_log: "ModelLog",
+    mode: SummaryMode,
+    level: str,
+) -> tuple[List[Dict[str, str]], List[str]]:
+    """Build operation rows for the optional op dump.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    mode:
+        Operation aggregation mode.
+    level:
+        Active summary level, used to pick the most relevant row shape.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], list[str]]
+        Operation rows and footer lines.
+    """
+    rows: List[Dict[str, str]] = []
+    running_total = 0
+    for entry in _iter_operation_entries(model_log, mode=mode):
+        tensor_memory = int(getattr(entry, "tensor_memory", 0) or 0)
+        running_total += tensor_memory
+        rows.append(
+            {
+                "name": _entry_name(entry),
+                "shape": _shape_str(getattr(entry, "tensor_shape", None)),
+                "params": _human_count(int(getattr(entry, "num_params_total", 0) or 0)),
+                "parents": _parent_summary(getattr(entry, "parent_layers", [])),
+                "dtype": _dtype_str(getattr(entry, "tensor_dtype", None)),
+                "tensor_mb": _mb_str(tensor_memory),
+                "running_mb": _mb_str(running_total),
+                "flops": _human_flops(int(getattr(entry, "flops_forward", 0) or 0)),
+                "macs": _human_flops(int(getattr(entry, "macs_forward", 0) or 0)),
+                "time_ms": f"{float(getattr(entry, 'func_time', 0.0) or 0.0) * 1000:.2f}",
+            }
+        )
+    footer_lines = [
+        f"Operation rows shown: {len(rows)} ({mode if mode != 'auto' else _effective_mode(model_log, mode)})"
+    ]
+    return rows, footer_lines
+
+
+def _default_op_fields(level: str) -> List[str]:
+    """Return the default operation columns for the active level.
+
+    Parameters
+    ----------
+    level:
+        Canonical level name.
+
+    Returns
+    -------
+    list[str]
+        Default operation fields.
+    """
+    if level == "memory":
+        return ["name", "shape", "dtype", "tensor_mb", "running_mb"]
+    if level == "compute":
+        return ["name", "params", "flops", "macs", "time_ms", "dtype"]
+    return ["name", "shape", "params", "parents"]
+
+
+def _iter_summary_modules(model_log: "ModelLog") -> List["ModuleLog"]:
+    """Return top-level module rows for summary tables.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+
+    Returns
+    -------
+    list[ModuleLog]
+        Top-level modules in accessor order.
+    """
+    modules = []
+    for module in model_log.modules:
+        if module.address == "self":
+            continue
+        if module.address_depth == 1:
+            modules.append(module)
+    return modules
+
+
+def _module_overview_row(model_log: "ModelLog", module: "ModuleLog") -> Dict[str, str]:
+    """Build one overview row for a module.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    module:
+        Module to summarize.
+
+    Returns
+    -------
+    dict[str, str]
+        Renderable overview row.
+    """
+    train = "-"
+    if module.num_params > 0:
+        train = "yes" if module.num_params_trainable > 0 else "no"
+    return {
+        "name": f"{module.address} ({module.module_class_name})",
+        "shape": _module_shape(model_log, module),
+        "params": _human_count(module.num_params),
+        "train": train,
+        "parents": _module_parent_summary(module),
+        "class": module.module_class_name,
+    }
+
+
+def _module_shape(model_log: "ModelLog", module: "ModuleLog") -> str:
+    """Return a representative output shape for a module.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    module:
+        Module to summarize.
+
+    Returns
+    -------
+    str
+        Representative output shape.
+    """
+    if not module.all_layers:
+        return "-"
+    try:
+        layer = model_log[module.all_layers[-1]]
+    except KeyError:
+        return "-"
+    return _shape_str(getattr(layer, "tensor_shape", None))
+
+
+def _module_parent_summary(module: "ModuleLog") -> str:
+    """Return a short parent summary for a module row.
+
+    Parameters
+    ----------
+    module:
+        Module to summarize.
+
+    Returns
+    -------
+    str
+        Parent summary text.
+    """
+    if module.address_parent in (None, "self"):
+        return "input"
+    return str(module.address_parent)
+
+
+def _module_dtype(model_log: "ModelLog", module: "ModuleLog") -> str:
+    """Return a representative dtype for a module.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    module:
+        Module to summarize.
+
+    Returns
+    -------
+    str
+        Representative dtype.
+    """
+    if not module.all_layers:
+        return "-"
+    try:
+        layer = model_log[module.all_layers[-1]]
+    except KeyError:
+        return "-"
+    return _dtype_str(getattr(layer, "tensor_dtype", None))
+
+
+def _module_time_ms(model_log: "ModelLog", module: "ModuleLog") -> float:
+    """Return the summed forward time for a module.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    module:
+        Module to summarize.
+
+    Returns
+    -------
+    float
+        Summed execution time in milliseconds.
+    """
+    total = 0.0
+    for layer_label in module.all_layers:
+        try:
+            layer = model_log[layer_label]
+        except KeyError:
+            continue
+        total += float(getattr(layer, "func_time", 0.0) or 0.0)
+    return total * 1000.0
+
+
+def _iter_operation_entries(
+    model_log: "ModelLog",
+    *,
+    mode: SummaryMode,
+) -> Iterable["LayerLog | LayerPassLog"]:
+    """Iterate operation-like entries according to the requested mode.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    mode:
+        Requested aggregation mode.
+
+    Returns
+    -------
+    Iterable[LayerLog | LayerPassLog]
+        Operation entries in display order.
+    """
+    effective_mode = _effective_mode(model_log, mode)
+    if effective_mode == "rolled":
+        return model_log.layer_logs.values()
+    return model_log.layer_list
+
+
+def _effective_mode(model_log: "ModelLog", mode: SummaryMode) -> Literal["rolled", "unrolled"]:
+    """Resolve the effective operation mode.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    mode:
+        Requested mode.
+
+    Returns
+    -------
+    Literal["rolled", "unrolled"]
+        Effective operation mode.
+    """
+    if mode == "auto":
+        return "unrolled" if model_log.is_recurrent else "rolled"
+    return mode
+
+
+def _entry_name(entry: Any) -> str:
+    """Return a display name for a layer or layer-pass entry.
+
+    Parameters
+    ----------
+    entry:
+        Layer-like object.
+
+    Returns
+    -------
+    str
+        Display name.
+    """
+    base_name = getattr(entry, "layer_label_no_pass", None) or getattr(entry, "layer_label", None)
+    if base_name is None:
+        base_name = getattr(entry, "layer_label_w_pass", None) or getattr(entry, "layer_label", "?")
+    if (
+        getattr(entry, "num_passes", 1)
+        and getattr(entry, "num_passes", 1) > 1
+        and hasattr(entry, "passes")
+    ):
+        return f"{base_name} x{getattr(entry, 'num_passes', 1)}"
+    if getattr(entry, "pass_num", 1) > 1:
+        return str(getattr(entry, "layer_label", base_name))
+    return str(base_name)
+
+
+def _combined_shape_str(model_log: "ModelLog", labels: Sequence[str]) -> str:
+    """Return a compact combined shape string for one or more labels.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    labels:
+        Layer labels whose shapes should be summarized.
+
+    Returns
+    -------
+    str
+        Shape summary string.
+    """
+    if not labels:
+        return "-"
+    shapes = []
+    for label in labels:
+        try:
+            shapes.append(_shape_str(getattr(model_log[label], "tensor_shape", None)))
+        except KeyError:
+            continue
+    if not shapes:
+        return "-"
+    if len(shapes) == 1:
+        return shapes[0]
+    return f"{len(shapes)} tensors"
+
+
+def _event_branch_kinds(model_log: "ModelLog", event: "ConditionalEvent") -> List[str]:
+    """Return the taken branch kinds for one conditional event.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    event:
+        Conditional event to inspect.
+
+    Returns
+    -------
+    list[str]
+        Branch kinds observed for the event.
+    """
+    branch_kinds = {
+        branch_kind
+        for (cond_id, branch_kind) in model_log.conditional_arm_edges
+        if cond_id == event.id
+    }
+    return sorted(branch_kinds)
+
+
+def _event_source(event: "ConditionalEvent") -> str:
+    """Return a short source locator for a conditional event.
+
+    Parameters
+    ----------
+    event:
+        Conditional event to summarize.
+
+    Returns
+    -------
+    str
+        Source locator.
+    """
+    return f"{Path(event.source_file).name}:{event.if_stmt_span[0]}"
+
+
+def _event_bool_layer(event: "ConditionalEvent") -> str:
+    """Return a compact bool-layer summary for a conditional event.
+
+    Parameters
+    ----------
+    event:
+        Conditional event to summarize.
+
+    Returns
+    -------
+    str
+        Bool-layer summary.
+    """
+    if not event.bool_layers:
+        return "-"
+    if len(event.bool_layers) == 1:
+        return event.bool_layers[0]
+    return f"{event.bool_layers[0]} +{len(event.bool_layers) - 1}"
+
+
+def _event_branch_op_count(model_log: "ModelLog", event: "ConditionalEvent") -> int:
+    """Return the number of operation edges attributed to a conditional event.
+
+    Parameters
+    ----------
+    model_log:
+        Finalized log object.
+    event:
+        Conditional event to inspect.
+
+    Returns
+    -------
+    int
+        Number of attributed branch edges.
+    """
+    return sum(
+        len(edges)
+        for (cond_id, _branch_kind), edges in model_log.conditional_arm_edges.items()
+        if cond_id == event.id
+    )
+
+
+def _parent_summary(parent_layers: Sequence[str]) -> str:
+    """Return a compact parent-layer summary.
+
+    Parameters
+    ----------
+    parent_layers:
+        Parent layer labels.
+
+    Returns
+    -------
+    str
+        Compact parent summary.
+    """
+    if not parent_layers:
+        return "-"
+    if len(parent_layers) == 1:
+        return str(parent_layers[0])
+    return f"{parent_layers[0]} +{len(parent_layers) - 1}"
+
+
+def _shape_str(shape: Any) -> str:
+    """Format a tensor shape using ASCII-only list syntax.
+
+    Parameters
+    ----------
+    shape:
+        Shape-like object.
+
+    Returns
+    -------
+    str
+        ASCII shape string.
+    """
+    if shape is None:
+        return "-"
+    return str(list(shape)).replace(" ", "")
+
+
+def _dtype_str(dtype: Any) -> str:
+    """Format a dtype name.
+
+    Parameters
+    ----------
+    dtype:
+        Dtype-like object.
+
+    Returns
+    -------
+    str
+        Short dtype string.
+    """
+    if dtype is None:
+        return "-"
+    text = str(dtype)
+    return text.replace("torch.", "")
+
+
+def _mb_str(num_bytes: int) -> str:
+    """Format a byte count in megabytes.
+
+    Parameters
+    ----------
+    num_bytes:
+        Number of bytes.
+
+    Returns
+    -------
+    str
+        Megabyte string.
+    """
+    return f"{num_bytes / (1024.0 * 1024.0):.2f}"
+
+
+def _human_count(value: int) -> str:
+    """Format an integer count compactly.
+
+    Parameters
+    ----------
+    value:
+        Integer count.
+
+    Returns
+    -------
+    str
+        Compact count string.
+    """
+    if value >= 1_000_000_000:
+        return f"{value / 1_000_000_000:.1f} B"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f} M"
+    if value >= 1_000:
+        return f"{value / 1_000:.1f} K"
+    return str(value)
+
+
+def _human_flops(value: int) -> str:
+    """Format FLOPs or MACs compactly.
+
+    Parameters
+    ----------
+    value:
+        FLOP-like integer.
+
+    Returns
+    -------
+    str
+        Compact FLOP string.
+    """
+    return _human_count(value)
+
+
+def _int_with_commas(value: int) -> str:
+    """Format an integer with comma separators.
+
+    Parameters
+    ----------
+    value:
+        Integer value.
+
+    Returns
+    -------
+    str
+        Comma-separated string.
+    """
+    return f"{value:,}"
+
+
+def _render_table(
+    fields: Sequence[str],
+    rows: Sequence[Dict[str, str]],
+    *,
+    max_rows: Optional[int],
+) -> str:
+    """Render an ASCII table.
+
+    Parameters
+    ----------
+    fields:
+        Ordered field names to render.
+    rows:
+        Row dictionaries.
+    max_rows:
+        Maximum number of rows to render.
+
+    Returns
+    -------
+    str
+        ASCII table string.
+    """
+    if not rows:
+        return "(no rows)"
+
+    display_rows = list(rows)
+    truncated_count = 0
+    if max_rows is not None and len(display_rows) > max_rows:
+        truncated_count = len(display_rows) - max_rows
+        display_rows = display_rows[:max_rows]
+
+    widths = []
+    for field in fields:
+        header = _COLUMN_LABELS[field]
+        cell_width = max(len(str(row.get(field, "-"))) for row in display_rows)
+        widths.append(max(len(header), cell_width))
+
+    border = "+" + "+".join("-" * (width + 2) for width in widths) + "+"
+    header_row = (
+        "| "
+        + " | ".join(_COLUMN_LABELS[field].ljust(width) for field, width in zip(fields, widths))
+        + " |"
+    )
+    body_rows = [
+        "| "
+        + " | ".join(str(row.get(field, "-")).ljust(width) for field, width in zip(fields, widths))
+        + " |"
+        for row in display_rows
+    ]
+    lines = [border, header_row, border, *body_rows, border]
+    if truncated_count:
+        lines.append(
+            f"... showing first {len(display_rows)} of {len(rows)} rows; "
+            "try a narrower level or show_ops=False"
+        )
+    return "\n".join(lines)

--- a/torchlens/capture/trace.py
+++ b/torchlens/capture/trace.py
@@ -48,7 +48,7 @@ from ..utils.introspection import get_vars_of_type_from_obj, nested_assign
 from ..utils.rng import set_random_seed, log_current_rng_states, set_rng_from_saved_states
 from ..utils.arg_handling import safe_copy_args, safe_copy_kwargs, normalize_input_args
 from .source_tensors import log_source_tensor
-from ..data_classes.interface import _give_user_feedback_about_lookup_key
+from ..data_classes._lookup_keys import _give_user_feedback_about_lookup_key
 from ..utils.display import _vprint, _vtimed
 
 

--- a/torchlens/data_classes/_lookup_keys.py
+++ b/torchlens/data_classes/_lookup_keys.py
@@ -1,0 +1,124 @@
+"""Shared lookup-key validation helpers for ``ModelLog`` access paths."""
+
+import random
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from .model_log import ModelLog
+
+
+def _give_user_feedback_about_lookup_key(
+    self: "ModelLog",
+    key: Union[int, str],
+    mode: str,
+) -> None:
+    """Raise a contextual error for an invalid user lookup key.
+
+    Parameters
+    ----------
+    self:
+        Model log being queried.
+    key:
+        Lookup key supplied by the user.
+    mode:
+        Either ``"get_one_item"`` for single-item access or
+        ``"query_multiple"`` for multi-layer queries.
+    """
+    if (type(key) == int) and (key >= len(self.layer_list) or key < -len(self.layer_list)):
+        raise ValueError(
+            f"You specified the layer with index {key}, but there are only {len(self.layer_list)} "
+            f"layers; please specify an index in the range "
+            f"-{len(self.layer_list)} - {len(self.layer_list) - 1}."
+        )
+
+    if type(key) != str:
+        raise ValueError(_get_lookup_help_str(self, key, mode))
+
+    if hasattr(self, "_module_logs") and key.rsplit(":", 1)[0] in self._module_logs:
+        module, pass_num = key.rsplit(":", 1)
+        module_log = self._module_logs[module]
+        module_num_passes = getattr(module_log, "num_passes")
+        raise ValueError(
+            f"You specified module {module} pass {pass_num}, but {module} only has "
+            f"{module_num_passes} passes; specify a lower number."
+        )
+
+    if key in self.layer_labels_no_pass:
+        layer_num_passes = self.layer_num_passes.get(key, 1)
+        if layer_num_passes > 1:
+            raise ValueError(
+                f"You specified output of layer {key}, but it has {layer_num_passes} passes; "
+                f"please specify e.g. {key}:2 for the second pass of {key}."
+            )
+
+    if key.rsplit(":", 1)[0] in self.layer_labels_no_pass:
+        layer_label, pass_num = key.rsplit(":", 1)
+        layer_num_passes_for_label = self.layer_num_passes.get(layer_label)
+        layer_num_passes_msg: int | str = (
+            layer_num_passes_for_label if layer_num_passes_for_label is not None else "unknown"
+        )
+        raise ValueError(
+            f"You specified layer {layer_label} pass {pass_num}, but {layer_label} only has "
+            f"{layer_num_passes_msg} passes. Specify a lower number."
+        )
+
+    raise ValueError(_get_lookup_help_str(self, key, mode))
+
+
+def _get_lookup_help_str(self: "ModelLog", layer_label: Union[int, str], mode: str) -> str:
+    """Build the standard help text for failed ModelLog lookups.
+
+    Parameters
+    ----------
+    self:
+        Model log being queried.
+    layer_label:
+        Original key supplied by the user.
+    mode:
+        Either ``"get_one_item"`` or ``"query_multiple"``.
+
+    Returns
+    -------
+    str
+        Help text describing valid lookup forms.
+    """
+    if not self.layer_labels_w_pass:
+        sample_layer1 = "conv2d_1_1:1"
+        sample_layer2 = "conv2d_1_1"
+    else:
+        sample_layer1 = random.choice(self.layer_labels_w_pass)
+        sample_layer2 = random.choice(self.layer_labels_no_pass)
+    module_addrs = [ml.address for ml in self.modules if ml.address != "self"]
+    if len(module_addrs) > 0:
+        sample_module1 = random.choice(module_addrs)
+        all_pass_labels = [
+            pl for ml in self.modules for pl in ml.pass_labels if ml.address != "self"
+        ]
+        sample_module2 = random.choice(all_pass_labels) if all_pass_labels else "features.4:2"
+    else:
+        sample_module1 = "features.3"
+        sample_module2 = "features.4:2"
+    module_str = f"(e.g., {sample_module1}, {sample_module2})"
+    if mode == "get_one_item":
+        msg = (
+            "e.g., 'pool' will grab the maxpool2d or avgpool2d layer, 'maxpool' will grab the "
+            "'maxpool2d' layer, etc., but there must be only one such matching layer"
+        )
+    elif mode == "query_multiple":
+        msg = (
+            "e.g., 'pool' will grab all maxpool2d or avgpool2d layers, 'maxpool' will grab all "
+            "'maxpool2d' layers, etc."
+        )
+    else:
+        raise ValueError("mode must be either get_one_item or query_multiple")
+    help_str = (
+        f"Layer {layer_label} not recognized; please specify either "
+        f"\n\n\t1) an integer giving the ordinal position of the layer "
+        f"(e.g. 2 for 3rd layer, -4 for fourth-to-last), "
+        f"\n\t2) the layer label (e.g., {sample_layer1}, {sample_layer2}), "
+        f"\n\t3) the module address {module_str}"
+        f"\n\t4) A substring of any desired layer label ({msg})."
+        f"\n\n(Label meaning: conv2d_3_4:2 means the second pass of the third convolutional layer, "
+        f"and fourth layer overall in the model.)"
+    )
+    return help_str

--- a/torchlens/data_classes/cleanup.py
+++ b/torchlens/data_classes/cleanup.py
@@ -1,6 +1,6 @@
-"""ModelLog cleanup: removing individual log entries and post-session teardown.
+"""ModelLog cleanup helpers and post-session teardown.
 
-This module provides three levels of cleanup:
+This module provides the helper stack behind ModelLog cleanup operations:
 
 1. **cleanup()** — full teardown: deletes all LayerPassLog attributes, then
    deletes all ModelLog attributes (both FIELD_ORDER and internal containers).
@@ -8,15 +8,14 @@ This module provides three levels of cleanup:
    LayerLog <-> LayerPassLog.parent_layer_log, ModuleLog <-> _source_model_log).
    Also frees GPU memory via ``torch.cuda.empty_cache()``.
 
-2. **_remove_log_entry()** — removes a single LayerPassLog and all references
-   to it from ModelLog's list/dict fields (used by orphan removal).
+2. **_remove_log_entry_references()** — removes a single layer label from all
+   ModelLog list/dict fields that hold graph references.
 
-3. **_batch_remove_log_entries()** — removes multiple entries at once using
-   set-based filtering (O(N+M) instead of O(N*M) for N entries in M lists).
+3. **_scrub_conditional_fields_after_removal()** — repairs conditional metadata
+   after one or more labels are removed.
 
-Both _remove_log_entry and _batch_remove_log_entries must clean the same
-set of fields — if you add a new list/dict field to ModelLog that holds
-layer labels, add it to both.
+4. **_LIST_FIELDS_TO_CLEAN** — canonical list fields that must stay aligned
+   with the removal helpers.
 """
 
 from typing import Dict, Iterable, List, Set, Tuple
@@ -26,17 +25,6 @@ import torch
 from ..constants import MODEL_LOG_FIELD_ORDER
 from ..utils.collections import remove_entry_from_list
 from .layer_pass_log import LayerPassLog
-
-
-def release_param_refs(self) -> None:
-    """Release nn.Parameter references from all ParamLogs.
-
-    After calling this, gradients already cached are still accessible,
-    but new gradients won't be detected. The model's parameters can be
-    garbage collected independently of the ModelLog.
-    """
-    for pl in self.param_logs:
-        pl.release_param_ref()
 
 
 def cleanup(self) -> None:
@@ -348,25 +336,6 @@ def _scrub_conditional_fields_after_removal(
         ]
 
 
-def _remove_log_entry(self, log_entry: LayerPassLog, remove_references: bool = True) -> None:
-    """Remove a single LayerPassLog and scrub all references to it.
-
-    Used by orphan removal and other graph-pruning operations.
-
-    Args:
-        log_entry: The LayerPassLog to destroy.
-        remove_references: If True, also remove the entry's label from
-            every list/dict field on the ModelLog.
-    """
-    # The label used to find references depends on whether postprocessing
-    # has run: after postprocessing, layers are keyed by their final
-    # human-readable label; during the pass, by the raw internal barcode.
-    tensor_label = _label_for_reference_removal(log_entry, self._pass_finished)
-    if remove_references:
-        _remove_log_entry_references(self, tensor_label)
-    _clear_entry_attributes(log_entry)
-
-
 # List fields on ModelLog that hold tensor labels and need filtering during
 # entry removal.  Must stay in sync between _batch_remove_log_entries and
 # _remove_log_entry_references — if you add a new label-holding list field
@@ -382,69 +351,6 @@ _LIST_FIELDS_TO_CLEAN = [
     "layers_with_saved_gradients",
     "_layers_where_internal_branches_merge_with_input",
 ]
-
-
-def _batch_remove_log_entries(self, entries_to_remove, remove_references: bool = True) -> None:
-    """Remove multiple LayerPassLog entries at once using set-based filtering.
-
-    More efficient than calling ``_remove_log_entry`` in a loop: builds a
-    set of labels to remove, then does a single pass over each list/dict
-    field (O(N+M) instead of O(N*M) where N=entries, M=list length).
-
-    Args:
-        entries_to_remove: Iterable of LayerPassLog objects to remove.
-        remove_references: Whether to also remove references from ModelLog list/dict fields.
-    """
-    entries_to_remove = list(entries_to_remove)
-    surviving_entries = [entry for entry in self if entry not in entries_to_remove]
-
-    # Build a set of labels for O(1) membership testing, then clear each entry.
-    labels_to_remove = set()
-    for entry in entries_to_remove:
-        labels_to_remove.add(_label_for_reference_removal(entry, self._pass_finished))
-        _clear_entry_attributes(entry)
-
-    if not remove_references:
-        return
-
-    _scrub_conditional_fields_after_removal(self, labels_to_remove, surviving_entries)
-
-    # Single-pass filter on each list field (replaces N x remove_entry_from_list calls).
-    for field in _LIST_FIELDS_TO_CLEAN:
-        collection = getattr(self, field)
-        collection[:] = [label for label in collection if label not in labels_to_remove]
-
-    self.conditional_branch_edges = [
-        edge
-        for edge in self.conditional_branch_edges
-        if edge[0] not in labels_to_remove and edge[1] not in labels_to_remove
-    ]
-    self.conditional_then_edges = [
-        edge
-        for edge in self.conditional_then_edges
-        if edge[0] not in labels_to_remove and edge[1] not in labels_to_remove
-    ]
-
-    # Single-pass filter on dict fields:
-    # layers_with_params: param_barcode -> [layer_labels]
-    for param_group, tensor_labels in list(self.layers_with_params.items()):
-        self.layers_with_params[param_group] = [
-            label for label in tensor_labels if label not in labels_to_remove
-        ]
-    self.layers_with_params = {
-        param_group: tensor_labels
-        for param_group, tensor_labels in self.layers_with_params.items()
-        if len(tensor_labels) > 0
-    }
-
-    # equivalent_operations: equiv_type -> set(layer_labels)
-    for equiv_group, tensor_labels in list(self.equivalent_operations.items()):
-        tensor_labels -= labels_to_remove
-    self.equivalent_operations = {
-        equiv_group: tensor_labels
-        for equiv_group, tensor_labels in self.equivalent_operations.items()
-        if len(tensor_labels) > 0
-    }
 
 
 def _remove_log_entry_references(self, layer_to_remove: str) -> None:

--- a/torchlens/data_classes/interface.py
+++ b/torchlens/data_classes/interface.py
@@ -1,8 +1,4 @@
-"""ModelLog query and display methods: __getitem__, __str__, to_pandas, print_all_fields.
-
-These functions are defined here to keep ModelLog's class body small. They
-are bound to ModelLog as class attributes via assignment at the bottom of
-model_log.py (the "method importation" pattern).
+"""ModelLog query and display helpers used by ``ModelLog`` methods.
 
 **__getitem__ lookup logic** (``_getitem_after_pass``):
 
@@ -22,16 +18,14 @@ For integer keys: direct index into ``layer_list`` (supports negative indexing).
 For slice keys: returns a list slice of ``layer_list``.
 """
 
-import random
-from os import PathLike
-from typing import TYPE_CHECKING, Any, List, Literal, Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple
 
 import numpy as np
-import pandas as pd
 
 if TYPE_CHECKING:
     from .model_log import ModelLog
 
+from ._lookup_keys import _give_user_feedback_about_lookup_key
 from .layer_pass_log import LayerPassLog
 
 
@@ -122,52 +116,6 @@ def _getitem_after_pass(self, ix):
     # Step 7: nothing matched — give a helpful error
     _give_user_feedback_about_lookup_key(self, ix, "get_one_item")
     raise KeyError(ix)
-
-
-def _give_user_feedback_about_lookup_key(self, key: Union[int, str], mode: str):
-    """For __getitem__ and get_op_nums_from_user_labels, gives the user feedback about the user key
-    they entered if it doesn't yield any matches.
-
-    Args:
-        key: Lookup key used by the user.
-        mode: Either "get_one_item" (raise error if key not found) or
-            "query_multiple" (return empty list if no matches).
-    """
-    if (type(key) == int) and (key >= len(self.layer_list) or key < -len(self.layer_list)):
-        raise ValueError(
-            f"You specified the layer with index {key}, but there are only {len(self.layer_list)} "
-            f"layers; please specify an index in the range "
-            f"-{len(self.layer_list)} - {len(self.layer_list) - 1}."
-        )
-
-    if type(key) != str:
-        raise ValueError(_get_lookup_help_str(self, key, mode))
-
-    if hasattr(self, "_module_logs") and key.rsplit(":", 1)[0] in self._module_logs:
-        module, pass_num = key.rsplit(":", 1)
-        module_num_passes = self._module_logs[module].num_passes
-        raise ValueError(
-            f"You specified module {module} pass {pass_num}, but {module} only has "
-            f"{module_num_passes} passes; specify a lower number."
-        )
-
-    if key in self.layer_labels_no_pass:
-        layer_num_passes = self.layer_num_passes.get(key, 1)
-        if layer_num_passes > 1:
-            raise ValueError(
-                f"You specified output of layer {key}, but it has {layer_num_passes} passes; "
-                f"please specify e.g. {key}:2 for the second pass of {key}."
-            )
-
-    if key.rsplit(":", 1)[0] in self.layer_labels_no_pass:
-        layer_label, pass_num = key.rsplit(":", 1)
-        layer_num_passes = self.layer_num_passes.get(layer_label, "unknown")
-        raise ValueError(
-            f"You specified layer {layer_label} pass {pass_num}, but {layer_label} only has "
-            f"{layer_num_passes} passes. Specify a lower number."
-        )
-
-    raise ValueError(_get_lookup_help_str(self, key, mode))
 
 
 def _str_after_pass(self) -> str:
@@ -290,50 +238,6 @@ def _format_list_with_line_breaks(lst, indent_chars: str, line_break_every=5) ->
     return s
 
 
-def _get_lookup_help_str(self, layer_label: Union[int, str], mode: str) -> str:
-    """Generates a help string to be used in error messages when indexing fails."""
-    if not self.layer_labels_w_pass:
-        sample_layer1 = "conv2d_1_1:1"
-        sample_layer2 = "conv2d_1_1"
-    else:
-        sample_layer1 = random.choice(self.layer_labels_w_pass)
-        sample_layer2 = random.choice(self.layer_labels_no_pass)
-    module_addrs = [ml.address for ml in self.modules if ml.address != "self"]
-    if len(module_addrs) > 0:
-        sample_module1 = random.choice(module_addrs)
-        all_pass_labels = [
-            pl for ml in self.modules for pl in ml.pass_labels if ml.address != "self"
-        ]
-        sample_module2 = random.choice(all_pass_labels) if all_pass_labels else "features.4:2"
-    else:
-        sample_module1 = "features.3"
-        sample_module2 = "features.4:2"
-    module_str = f"(e.g., {sample_module1}, {sample_module2})"
-    if mode == "get_one_item":
-        msg = (
-            "e.g., 'pool' will grab the maxpool2d or avgpool2d layer, 'maxpool' will grab the 'maxpool2d' "
-            "layer, etc., but there must be only one such matching layer"
-        )
-    elif mode == "query_multiple":
-        msg = (
-            "e.g., 'pool' will grab all maxpool2d or avgpool2d layers, 'maxpool' will grab all 'maxpool2d' "
-            "layers, etc."
-        )
-    else:
-        raise ValueError("mode must be either get_one_item or query_multiple")
-    help_str = (
-        f"Layer {layer_label} not recognized; please specify either "
-        f"\n\n\t1) an integer giving the ordinal position of the layer "
-        f"(e.g. 2 for 3rd layer, -4 for fourth-to-last), "
-        f"\n\t2) the layer label (e.g., {sample_layer1}, {sample_layer2}), "
-        f"\n\t3) the module address {module_str}"
-        f"\n\t4) A substring of any desired layer label ({msg})."
-        f"\n\n(Label meaning: conv2d_3_4:2 means the second pass of the third convolutional layer, "
-        f"and fourth layer overall in the model.)"
-    )
-    return help_str
-
-
 def _module_hierarchy_str(self) -> str:
     """Build a tree-formatted string of the module call hierarchy.
 
@@ -388,22 +292,6 @@ def _module_hierarchy_str_recursive(self, module_pass, level) -> str:
     return s
 
 
-def print_all_fields(self) -> None:
-    """Print all data fields for ModelLog."""
-    fields_to_exclude = [
-        "layer_list",
-        "layer_dict_main_keys",
-        "layer_dict_all_keys",
-        "raw_layer_dict",
-        "decorated_to_orig_funcs_dict",
-    ]
-
-    for field in dir(self):
-        attr = getattr(self, field)
-        if not any([field.startswith("_"), field in fields_to_exclude, callable(attr)]):
-            print(f"{field}: {attr}")
-
-
 def _format_conditional_branch_stack(conditional_branch_stack: List[Tuple[int, str]]) -> str:
     """Render a compact string form for a conditional branch stack.
 
@@ -417,184 +305,3 @@ def _format_conditional_branch_stack(conditional_branch_stack: List[Tuple[int, s
         f"cond_{conditional_id}:{branch_kind}"
         for conditional_id, branch_kind in conditional_branch_stack
     )
-
-
-def to_pandas(self) -> pd.DataFrame:
-    """Returns a pandas dataframe with info about each layer.
-
-    Returns:
-        Pandas dataframe with info about each layer.
-
-    Raises:
-        RuntimeError: If called before the forward pass is complete.
-    """
-    if not self._pass_finished:
-        raise RuntimeError(
-            "to_pandas() cannot be called before the forward pass is complete. "
-            "Please wait until log_forward_pass has returned."
-        )
-    fields_for_df = [
-        "layer_label",
-        "layer_label_w_pass",
-        "layer_label_no_pass",
-        "layer_label_short",
-        "layer_label_w_pass_short",
-        "layer_label_no_pass_short",
-        "layer_type",
-        "layer_type_num",
-        "layer_total_num",
-        "num_passes",
-        "pass_num",
-        "operation_num",
-        "tensor_shape",
-        "tensor_dtype",
-        "tensor_memory",
-        "tensor_memory_str",
-        "func_name",
-        "func_config",
-        "func_time",
-        "func_is_inplace",
-        "grad_fn_name",
-        "is_input_layer",
-        "is_output_layer",
-        "is_buffer_layer",
-        "is_part_of_iterable_output",
-        "iterable_output_index",
-        "parent_layers",
-        "has_parents",
-        "root_ancestors",
-        "child_layers",
-        "has_children",
-        "output_descendants",
-        "sibling_layers",
-        "has_siblings",
-        "co_parent_layers",
-        "has_co_parents",
-        "is_internally_initialized",
-        "min_distance_from_input",
-        "max_distance_from_input",
-        "min_distance_from_output",
-        "max_distance_from_output",
-        "uses_params",
-        "num_params_total",
-        "parent_param_shapes",
-        "params_memory",
-        "params_memory_str",
-        "modules_entered",
-        "modules_exited",
-        "is_submodule_input",
-        "is_submodule_output",
-        "containing_module",
-        "containing_modules",
-        "conditional_branch_depth",
-        "bool_is_branch",
-        "bool_context_kind",
-        "bool_wrapper_kind",
-        "bool_conditional_id",
-        "conditional_branch_stack",
-        "cond_branch_then_children",
-        "cond_branch_elif_children",
-        "cond_branch_else_children",
-    ]
-
-    fields_to_change_type = {
-        "layer_type_num": int,
-        "layer_total_num": int,
-        "num_passes": int,
-        "pass_num": int,
-        "operation_num": int,
-        "func_is_inplace": bool,
-        "is_input_layer": bool,
-        "is_output_layer": bool,
-        "is_buffer_layer": bool,
-        "is_part_of_iterable_output": bool,
-        "has_parents": bool,
-        "has_children": bool,
-        "has_siblings": bool,
-        "has_co_parents": bool,
-        "uses_params": bool,
-        "num_params_total": int,
-        "params_memory": int,
-        "tensor_memory": int,
-        "is_submodule_input": bool,
-        "is_submodule_output": bool,
-        "conditional_branch_depth": int,
-        "bool_is_branch": bool,
-    }
-
-    model_df_dictlist = []
-    for layer_entry in self.layer_list:
-        layer_dict = {}
-        for field_name in fields_for_df:
-            if field_name == "conditional_branch_stack":
-                layer_dict[field_name] = _format_conditional_branch_stack(
-                    layer_entry.conditional_branch_stack
-                )
-            else:
-                layer_dict[field_name] = getattr(layer_entry, field_name)
-        model_df_dictlist.append(layer_dict)
-    model_df = pd.DataFrame(model_df_dictlist)
-
-    for field in fields_to_change_type:
-        model_df[field] = model_df[field].astype(fields_to_change_type[field])
-    model_df["bool_conditional_id"] = model_df["bool_conditional_id"].astype("Int64")
-
-    return model_df
-
-
-def to_csv(self: "ModelLog", filepath: str | PathLike[str], **kwargs: Any) -> None:
-    """Write the layer table to CSV.
-
-    Parameters
-    ----------
-    filepath:
-        Output CSV path.
-    **kwargs:
-        Additional keyword arguments forwarded to ``DataFrame.to_csv``.
-    """
-    self.to_pandas().to_csv(filepath, index=False, **kwargs)
-
-
-def to_parquet(self: "ModelLog", filepath: str | PathLike[str], **kwargs: Any) -> None:
-    """Write the layer table to Parquet.
-
-    Parameters
-    ----------
-    filepath:
-        Output Parquet path.
-    **kwargs:
-        Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
-
-    Raises
-    ------
-    ImportError
-        If ``pyarrow`` is unavailable.
-    """
-    try:
-        import pyarrow  # noqa: F401
-    except ImportError as exc:
-        raise ImportError(
-            "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
-        ) from exc
-    self.to_pandas().to_parquet(filepath, **kwargs)
-
-
-def to_json(
-    self: "ModelLog",
-    filepath: str | PathLike[str],
-    *,
-    orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
-    **kwargs: Any,
-) -> None:
-    """Write the layer table to JSON.
-
-    Parameters
-    ----------
-    filepath:
-        Output JSON path.
-    orient:
-        JSON orientation passed to ``DataFrame.to_json``.
-    **kwargs:
-        Additional keyword arguments forwarded to ``DataFrame.to_json``.
-    """
-    self.to_pandas().to_json(filepath, orient=orient, **kwargs)

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -17,11 +17,10 @@ Key design patterns:
   persists across the fast pass on purpose: fast-path postprocessing
   relies on the fully-populated lookup dicts from the exhaustive pass.
 
-* **Method importation** - Several heavy methods (``render_graph``,
-  ``save_new_activations``, ``validate_saved_activations``, etc.) are
-  defined in other modules and bound to ModelLog as class attributes at
-  the bottom of this file.  This keeps the class body small while giving
-  users ``model_log.render_graph(...)`` syntax.
+* **Explicit ModelLog methods** - Public methods are defined directly on
+  ``ModelLog``. Heavier implementations may delegate into subpackages
+  through local imports, but users still call them as
+  ``model_log.render_graph(...)`` or ``model_log.validate_forward_pass(...)``.
 
 * **_module_build_data** - A transient dict that accumulates module hierarchy
   information during the forward pass.  Consumed by ``_build_module_logs``
@@ -31,46 +30,42 @@ Key design patterns:
 
 import copy
 from collections import OrderedDict, defaultdict
-from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, TYPE_CHECKING, Tuple
+from os import PathLike
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Set, TYPE_CHECKING, Tuple
 
+import numpy as np
+import pandas as pd
 import torch
 
 if TYPE_CHECKING:
     from .._io.streaming import BundleStreamWriter
     from .buffer_log import BufferAccessor
     from .layer_log import LayerAccessor
+    from ..visualization.dagua_bridge import TorchLensRenderAudit
 
 from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
-from .cleanup import _remove_log_entry, _batch_remove_log_entries, cleanup, release_param_refs
+from .cleanup import (
+    _LIST_FIELDS_TO_CLEAN,
+    _clear_entry_attributes,
+    _label_for_reference_removal,
+    _remove_log_entry_references,
+    _scrub_conditional_fields_after_removal,
+    cleanup,
+)
 from .module_log import ModuleAccessor
 from .param_log import ParamAccessor
 from ..utils.display import human_readable_size
 from .interface import (
+    _format_conditional_branch_stack,
     _getitem_after_pass,
     _getitem_during_pass,
     _str_after_pass,
     _str_during_pass,
-    to_csv,
-    to_json,
-    to_parquet,
-    to_pandas,
-    print_all_fields,
 )
-from ..capture.trace import save_new_activations
-from ..postprocess import postprocess
 from .layer_log import LayerLog
 from .layer_pass_log import LayerPassLog, TensorLog
-from ..capture.trace import run_and_log_inputs_through_model
-from ..validation import validate_saved_activations
-from ..validation import check_metadata_invariants
-from ..visualization.rendering import render_graph
-from ..visualization.dagua_bridge import (
-    build_render_audit,
-    model_log_to_dagua_graph,
-    render_model_log_with_dagua,
-)
 
 
 def _init_module_build_data() -> dict:
@@ -695,30 +690,589 @@ class ModelLog:
         return self._buffer_accessor  # type: ignore[return-value]
 
     # ********************************************
-    # ******** Assign Imported Methods ***********
+    # ******** Public Convenience Methods ********
     # ********************************************
-    # These are functions defined in other modules, bound here as class
-    # attributes so they can be called as instance methods
-    # (e.g. ``model_log.render_graph(...)``).  This pattern keeps the
-    # ModelLog class body small while co-locating heavy logic in its
-    # own module (visualization, validation, capture, etc.).
 
-    render_graph = render_graph
-    render_dagua_graph = render_model_log_with_dagua
-    to_dagua_graph = model_log_to_dagua_graph
-    visualization_field_audit = build_render_audit
-    print_all_fields = print_all_fields
-    to_pandas = to_pandas
-    to_csv = to_csv
-    to_parquet = to_parquet
-    to_json = to_json
-    save_new_activations = save_new_activations
-    validate_saved_activations = validate_saved_activations
-    validate_forward_pass = validate_saved_activations  # user-facing alias
-    check_metadata_invariants = check_metadata_invariants
-    cleanup = cleanup
-    release_param_refs = release_param_refs
-    _postprocess = postprocess
-    _run_and_log_inputs_through_model = run_and_log_inputs_through_model
-    _remove_log_entry = _remove_log_entry
-    _batch_remove_log_entries = _batch_remove_log_entries
+    def render_graph(
+        self,
+        vis_mode: str = "unrolled",
+        vis_nesting_depth: int = 1000,
+        vis_outpath: str = "modelgraph",
+        vis_graph_overrides: Optional[Dict] = None,
+        vis_node_overrides: Optional[Dict] = None,
+        vis_nested_node_overrides: Optional[Dict] = None,
+        vis_edge_overrides: Optional[Dict] = None,
+        vis_gradient_edge_overrides: Optional[Dict] = None,
+        vis_module_overrides: Optional[Dict] = None,
+        vis_save_only: bool = False,
+        vis_fileformat: str = "pdf",
+        show_buffer_layers: bool = False,
+        direction: str = "bottomup",
+        vis_node_placement: str = "auto",
+        vis_renderer: str = "graphviz",
+        vis_theme: str = "torchlens",
+    ) -> str:
+        """Render the computational graph for this model log.
+
+        Parameters
+        ----------
+        vis_mode, vis_nesting_depth, vis_outpath, vis_graph_overrides, vis_node_overrides, \
+        vis_nested_node_overrides, vis_edge_overrides, vis_gradient_edge_overrides, \
+        vis_module_overrides, vis_save_only, vis_fileformat, show_buffer_layers, direction, \
+        vis_node_placement, vis_renderer, vis_theme:
+            Forwarded unchanged to :func:`torchlens.visualization.rendering.render_graph`.
+
+        Returns
+        -------
+        str
+            Graphviz DOT source or renderer-specific output.
+        """
+        from ..visualization.rendering import render_graph as _impl
+
+        return _impl(
+            self,
+            vis_mode=vis_mode,
+            vis_nesting_depth=vis_nesting_depth,
+            vis_outpath=vis_outpath,
+            vis_graph_overrides=vis_graph_overrides,
+            vis_node_overrides=vis_node_overrides,
+            vis_nested_node_overrides=vis_nested_node_overrides,
+            vis_edge_overrides=vis_edge_overrides,
+            vis_gradient_edge_overrides=vis_gradient_edge_overrides,
+            vis_module_overrides=vis_module_overrides,
+            vis_save_only=vis_save_only,
+            vis_fileformat=vis_fileformat,
+            show_buffer_layers=show_buffer_layers,
+            direction=direction,
+            vis_node_placement=vis_node_placement,
+            vis_renderer=vis_renderer,
+            vis_theme=vis_theme,
+        )
+
+    def render_dagua_graph(
+        self,
+        vis_mode: str = "unrolled",
+        vis_nesting_depth: int = 1000,
+        vis_outpath: str = "graph.gv",
+        vis_save_only: bool = False,
+        vis_fileformat: str = "pdf",
+        vis_buffer_layers: bool = False,
+        vis_direction: str = "bottomup",
+        vis_theme: str = "torchlens",
+    ) -> str:
+        """Render this model log with the Dagua backend.
+
+        Parameters
+        ----------
+        vis_mode, vis_nesting_depth, vis_outpath, vis_save_only, vis_fileformat, \
+        vis_buffer_layers, vis_direction, vis_theme:
+            Forwarded unchanged to
+            :func:`torchlens.visualization.dagua_bridge.render_model_log_with_dagua`.
+
+        Returns
+        -------
+        str
+            Serialized Dagua graph output or the rendered artifact path.
+        """
+        from ..visualization.dagua_bridge import render_model_log_with_dagua as _impl
+
+        return _impl(
+            self,
+            vis_mode=vis_mode,
+            vis_nesting_depth=vis_nesting_depth,
+            vis_outpath=vis_outpath,
+            vis_save_only=vis_save_only,
+            vis_fileformat=vis_fileformat,
+            vis_buffer_layers=vis_buffer_layers,
+            vis_direction=vis_direction,
+            vis_theme=vis_theme,
+        )
+
+    def to_dagua_graph(
+        self,
+        vis_mode: str = "unrolled",
+        vis_nesting_depth: int = 1000,
+        show_buffer_layers: bool = False,
+        direction: str = "bottomup",
+        include_gradient_edges: Optional[bool] = None,
+    ) -> Any:
+        """Translate this model log into a Dagua graph.
+
+        Parameters
+        ----------
+        vis_mode, vis_nesting_depth, show_buffer_layers, direction, include_gradient_edges:
+            Forwarded unchanged to
+            :func:`torchlens.visualization.dagua_bridge.model_log_to_dagua_graph`.
+
+        Returns
+        -------
+        Any
+            Dagua graph object.
+        """
+        from ..visualization.dagua_bridge import model_log_to_dagua_graph as _impl
+
+        return _impl(
+            self,
+            vis_mode=vis_mode,
+            vis_nesting_depth=vis_nesting_depth,
+            show_buffer_layers=show_buffer_layers,
+            direction=direction,
+            include_gradient_edges=include_gradient_edges,
+        )
+
+    def visualization_field_audit(self) -> "TorchLensRenderAudit":
+        """Return the visualization field-usage audit for this model log.
+
+        Returns
+        -------
+        TorchLensRenderAudit
+            Audit of used and unused fields in the visualization bridge.
+        """
+        from ..visualization.dagua_bridge import build_render_audit as _impl
+
+        return _impl(self)
+
+    def print_all_fields(self) -> None:
+        """Print all public non-callable fields on this model log.
+
+        Returns
+        -------
+        None
+            This method prints directly to stdout.
+        """
+        fields_to_exclude = [
+            "layer_list",
+            "layer_dict_main_keys",
+            "layer_dict_all_keys",
+            "raw_layer_dict",
+            "decorated_to_orig_funcs_dict",
+        ]
+
+        for attr_name in dir(self):
+            attr = getattr(self, attr_name)
+            if not any([attr_name.startswith("_"), attr_name in fields_to_exclude, callable(attr)]):
+                print(f"{attr_name}: {attr}")
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Return a dataframe containing one row per layer pass.
+
+        Returns
+        -------
+        pd.DataFrame
+            Layer-pass table for this model log.
+
+        Raises
+        ------
+        RuntimeError
+            If called before the forward pass has completed.
+        """
+        if not self._pass_finished:
+            raise RuntimeError(
+                "to_pandas() cannot be called before the forward pass is complete. "
+                "Please wait until log_forward_pass has returned."
+            )
+        fields_for_df = [
+            "layer_label",
+            "layer_label_w_pass",
+            "layer_label_no_pass",
+            "layer_label_short",
+            "layer_label_w_pass_short",
+            "layer_label_no_pass_short",
+            "layer_type",
+            "layer_type_num",
+            "layer_total_num",
+            "num_passes",
+            "pass_num",
+            "operation_num",
+            "tensor_shape",
+            "tensor_dtype",
+            "tensor_memory",
+            "tensor_memory_str",
+            "func_name",
+            "func_config",
+            "func_time",
+            "func_is_inplace",
+            "grad_fn_name",
+            "is_input_layer",
+            "is_output_layer",
+            "is_buffer_layer",
+            "is_part_of_iterable_output",
+            "iterable_output_index",
+            "parent_layers",
+            "has_parents",
+            "root_ancestors",
+            "child_layers",
+            "has_children",
+            "output_descendants",
+            "sibling_layers",
+            "has_siblings",
+            "co_parent_layers",
+            "has_co_parents",
+            "is_internally_initialized",
+            "min_distance_from_input",
+            "max_distance_from_input",
+            "min_distance_from_output",
+            "max_distance_from_output",
+            "uses_params",
+            "num_params_total",
+            "parent_param_shapes",
+            "params_memory",
+            "params_memory_str",
+            "modules_entered",
+            "modules_exited",
+            "is_submodule_input",
+            "is_submodule_output",
+            "containing_module",
+            "containing_modules",
+            "conditional_branch_depth",
+            "bool_is_branch",
+            "bool_context_kind",
+            "bool_wrapper_kind",
+            "bool_conditional_id",
+            "conditional_branch_stack",
+            "cond_branch_then_children",
+            "cond_branch_elif_children",
+            "cond_branch_else_children",
+        ]
+
+        fields_to_change_type = {
+            "layer_type_num": int,
+            "layer_total_num": int,
+            "num_passes": int,
+            "pass_num": int,
+            "operation_num": int,
+            "func_is_inplace": bool,
+            "is_input_layer": bool,
+            "is_output_layer": bool,
+            "is_buffer_layer": bool,
+            "is_part_of_iterable_output": bool,
+            "has_parents": bool,
+            "has_children": bool,
+            "has_siblings": bool,
+            "has_co_parents": bool,
+            "uses_params": bool,
+            "num_params_total": int,
+            "params_memory": int,
+            "tensor_memory": int,
+            "is_submodule_input": bool,
+            "is_submodule_output": bool,
+            "conditional_branch_depth": int,
+            "bool_is_branch": bool,
+        }
+
+        model_df_dictlist = []
+        for layer_entry in self.layer_list:
+            layer_dict = {}
+            for field_name in fields_for_df:
+                if field_name == "conditional_branch_stack":
+                    layer_dict[field_name] = _format_conditional_branch_stack(
+                        layer_entry.conditional_branch_stack
+                    )
+                else:
+                    layer_dict[field_name] = getattr(layer_entry, field_name)
+            model_df_dictlist.append(layer_dict)
+        model_df = pd.DataFrame(model_df_dictlist)
+
+        for column_name in fields_to_change_type:
+            model_df[column_name] = model_df[column_name].astype(fields_to_change_type[column_name])
+        model_df["bool_conditional_id"] = model_df["bool_conditional_id"].astype("Int64")
+
+        return model_df
+
+    def to_csv(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the layer table to CSV.
+
+        Parameters
+        ----------
+        filepath:
+            Output CSV path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_csv``.
+        """
+        self.to_pandas().to_csv(filepath, index=False, **kwargs)
+
+    def to_parquet(self, filepath: str | PathLike[str], **kwargs: Any) -> None:
+        """Write the layer table to Parquet.
+
+        Parameters
+        ----------
+        filepath:
+            Output Parquet path.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_parquet``.
+
+        Raises
+        ------
+        ImportError
+            If ``pyarrow`` is unavailable.
+        """
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "to_parquet requires pyarrow. Install with: pip install torchlens[io]"
+            ) from exc
+        self.to_pandas().to_parquet(filepath, **kwargs)
+
+    def to_json(
+        self,
+        filepath: str | PathLike[str],
+        *,
+        orient: Literal["split", "records", "index", "columns", "values", "table"] = "records",
+        **kwargs: Any,
+    ) -> None:
+        """Write the layer table to JSON.
+
+        Parameters
+        ----------
+        filepath:
+            Output JSON path.
+        orient:
+            JSON orientation passed to ``DataFrame.to_json``.
+        **kwargs:
+            Additional keyword arguments forwarded to ``DataFrame.to_json``.
+        """
+        self.to_pandas().to_json(filepath, orient=orient, **kwargs)
+
+    def save_new_activations(
+        self,
+        model: torch.nn.Module,
+        input_args: torch.Tensor | List[Any],
+        input_kwargs: Optional[Dict[Any, Any]] = None,
+        layers_to_save: str | List = "all",
+        random_seed: Optional[int] = None,
+    ) -> None:
+        """Re-run the model with new inputs, saving only activations.
+
+        Parameters
+        ----------
+        model, input_args, input_kwargs, layers_to_save, random_seed:
+            Forwarded unchanged to
+            :func:`torchlens.capture.trace.save_new_activations`.
+        """
+        from ..capture.trace import save_new_activations as _impl
+
+        return _impl(
+            self,
+            model=model,
+            input_args=input_args,
+            input_kwargs=input_kwargs,
+            layers_to_save=layers_to_save,
+            random_seed=random_seed,
+        )
+
+    def validate_saved_activations(
+        self,
+        ground_truth_output_tensors: List[torch.Tensor],
+        verbose: bool = False,
+        validate_metadata: bool = True,
+    ) -> bool:
+        """Validate saved activations against ground-truth model outputs.
+
+        Parameters
+        ----------
+        ground_truth_output_tensors, verbose, validate_metadata:
+            Forwarded unchanged to
+            :func:`torchlens.validation.core.validate_saved_activations`.
+
+        Returns
+        -------
+        bool
+            ``True`` if validation succeeds.
+        """
+        from ..validation.core import validate_saved_activations as _impl
+
+        return _impl(
+            self,
+            ground_truth_output_tensors=ground_truth_output_tensors,
+            verbose=verbose,
+            validate_metadata=validate_metadata,
+        )
+
+    def validate_forward_pass(
+        self,
+        ground_truth_output_tensors: List[torch.Tensor],
+        verbose: bool = False,
+        validate_metadata: bool = True,
+    ) -> bool:
+        """Alias for :meth:`validate_saved_activations`.
+
+        Parameters
+        ----------
+        ground_truth_output_tensors, verbose, validate_metadata:
+            Forwarded unchanged to :meth:`validate_saved_activations`.
+
+        Returns
+        -------
+        bool
+            ``True`` if validation succeeds.
+        """
+        from ..validation.core import validate_saved_activations as _impl
+
+        return _impl(
+            self,
+            ground_truth_output_tensors=ground_truth_output_tensors,
+            verbose=verbose,
+            validate_metadata=validate_metadata,
+        )
+
+    def check_metadata_invariants(self) -> bool:
+        """Run metadata invariant checks on this completed model log.
+
+        Returns
+        -------
+        bool
+            ``True`` if all invariants pass.
+        """
+        from ..validation.invariants import check_metadata_invariants as _impl
+
+        return _impl(self)
+
+    def cleanup(self) -> None:
+        """Delete log data, break cycles, and free cached GPU memory.
+
+        Returns
+        -------
+        None
+            This method mutates the model log in place.
+        """
+        return cleanup(self)
+
+    def release_param_refs(self) -> None:
+        """Release live ``nn.Parameter`` references held by ParamLogs.
+
+        Returns
+        -------
+        None
+            This method mutates ParamLogs in place.
+        """
+        for param_log in self.param_logs:
+            param_log.release_param_ref()
+
+    def _postprocess(
+        self,
+        output_tensors: List[torch.Tensor],
+        output_tensor_addresses: List[str],
+    ) -> None:
+        """Run postprocessing on a completed raw capture pass.
+
+        Parameters
+        ----------
+        output_tensors:
+            Output tensors returned by the model.
+        output_tensor_addresses:
+            Hierarchical addresses for those outputs.
+        """
+        from ..postprocess import postprocess as _impl
+
+        return _impl(
+            self,
+            output_tensors=output_tensors,
+            output_tensor_addresses=output_tensor_addresses,
+        )
+
+    def _run_and_log_inputs_through_model(
+        self,
+        model: torch.nn.Module,
+        input_args: torch.Tensor | List[Any],
+        input_kwargs: Optional[Dict[Any, Any]] = None,
+        layers_to_save: Optional[str | List[str | int]] = "all",
+        random_seed: Optional[int] = None,
+    ) -> None:
+        """Run a forward pass and capture it into this model log.
+
+        Parameters
+        ----------
+        model, input_args, input_kwargs, layers_to_save, random_seed:
+            Forwarded unchanged to
+            :func:`torchlens.capture.trace.run_and_log_inputs_through_model`.
+        """
+        from ..capture.trace import run_and_log_inputs_through_model as _impl
+
+        return _impl(
+            self,
+            model=model,
+            input_args=input_args,
+            input_kwargs=input_kwargs,
+            layers_to_save=layers_to_save,
+            random_seed=random_seed,
+        )
+
+    def _remove_log_entry(
+        self,
+        log_entry: LayerPassLog,
+        remove_references: bool = True,
+    ) -> None:
+        """Remove a single layer-pass entry and scrub graph references.
+
+        Parameters
+        ----------
+        log_entry:
+            Entry to remove.
+        remove_references:
+            Whether to scrub all graph references to the removed entry.
+        """
+        tensor_label = _label_for_reference_removal(log_entry, self._pass_finished)
+        if remove_references:
+            _remove_log_entry_references(self, tensor_label)
+        _clear_entry_attributes(log_entry)
+
+    def _batch_remove_log_entries(
+        self,
+        entries_to_remove: Iterable[LayerPassLog],
+        remove_references: bool = True,
+    ) -> None:
+        """Remove multiple layer-pass entries using single-pass filtering.
+
+        Parameters
+        ----------
+        entries_to_remove:
+            Entries to remove.
+        remove_references:
+            Whether to scrub all graph references to the removed entries.
+        """
+        entries_to_remove = list(entries_to_remove)
+        surviving_entries = [entry for entry in self if entry not in entries_to_remove]
+
+        labels_to_remove = set()
+        for entry in entries_to_remove:
+            labels_to_remove.add(_label_for_reference_removal(entry, self._pass_finished))
+            _clear_entry_attributes(entry)
+
+        if not remove_references:
+            return
+
+        _scrub_conditional_fields_after_removal(self, labels_to_remove, surviving_entries)
+
+        for field_name in _LIST_FIELDS_TO_CLEAN:
+            collection = getattr(self, field_name)
+            collection[:] = [label for label in collection if label not in labels_to_remove]
+
+        self.conditional_branch_edges = [
+            edge
+            for edge in self.conditional_branch_edges
+            if edge[0] not in labels_to_remove and edge[1] not in labels_to_remove
+        ]
+        self.conditional_then_edges = [
+            edge
+            for edge in self.conditional_then_edges
+            if edge[0] not in labels_to_remove and edge[1] not in labels_to_remove
+        ]
+
+        for param_group, tensor_labels in list(self.layers_with_params.items()):
+            self.layers_with_params[param_group] = [
+                label for label in tensor_labels if label not in labels_to_remove
+            ]
+        self.layers_with_params = {
+            param_group: tensor_labels
+            for param_group, tensor_labels in self.layers_with_params.items()
+            if len(tensor_labels) > 0
+        }
+
+        for equiv_group, equivalent_label_set in list(self.equivalent_operations.items()):
+            equivalent_label_set -= labels_to_remove
+        self.equivalent_operations = {
+            equiv_group: equivalent_label_set
+            for equiv_group, equivalent_label_set in self.equivalent_operations.items()
+            if len(equivalent_label_set) > 0
+        }

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -433,8 +433,10 @@ class ModelLog:
             return _str_during_pass(self)
 
     def __repr__(self) -> str:
-        """Same as __str__."""
-        return self.__str__()
+        """Short identity-card representation for REPL display."""
+        from .._summary import format_model_repr
+
+        return format_model_repr(self)
 
     def __iter__(self):
         """Loops through all tensors in the log."""
@@ -747,6 +749,67 @@ class ModelLog:
             vis_node_placement=vis_node_placement,
             vis_renderer=vis_renderer,
             vis_theme=vis_theme,
+        )
+
+    def summary(
+        self,
+        level: Literal[
+            "overview", "graph", "memory", "control_flow", "compute", "cost"
+        ] = "overview",
+        *,
+        fields: Optional[List[str]] = None,
+        mode: Literal["auto", "rolled", "unrolled"] = "auto",
+        show_ops: bool = False,
+        preset: Optional[
+            Literal["overview", "graph", "memory", "control_flow", "compute", "cost"]
+        ] = None,
+        columns: Optional[List[str]] = None,
+        include_ops: Optional[bool] = None,
+        max_rows: Optional[int] = 200,
+        print_to: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        """Render a concise text summary of the logged model.
+
+        Parameters
+        ----------
+        level:
+            Summary level to render.
+        fields:
+            Explicit column selection for the primary table.
+        mode:
+            Operation aggregation mode. ``"rolled"`` uses aggregate layer rows,
+            while ``"unrolled"`` uses per-pass operation rows.
+        show_ops:
+            Whether to append an operation table.
+        preset:
+            Alias for ``level`` retained for compatibility with the design spec.
+        columns:
+            Alias for ``fields``.
+        include_ops:
+            Alias for ``show_ops`` retained for compatibility with the design spec.
+        max_rows:
+            Maximum number of rows to render per table. ``None`` disables truncation.
+        print_to:
+            Optional callable that receives the rendered summary text.
+
+        Returns
+        -------
+        str
+            Rendered summary string.
+        """
+        from .._summary import render_model_summary
+
+        return render_model_summary(
+            self,
+            level=level,
+            preset=preset,
+            fields=fields,
+            columns=columns,
+            mode=mode,
+            show_ops=show_ops,
+            include_ops=include_ops,
+            max_rows=max_rows,
+            print_to=print_to,
         )
 
     def render_dagua_graph(

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -45,6 +45,13 @@ if TYPE_CHECKING:
     from .layer_log import LayerAccessor
     from ..visualization.dagua_bridge import TorchLensRenderAudit
 
+from .._deprecations import warn_deprecated_alias
+from .._literals import (
+    VisDirectionLiteral,
+    VisModeLiteral,
+    VisNodePlacementLiteral,
+    VisRendererLiteral,
+)
 from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from .cleanup import (
     _LIST_FIELDS_TO_CLEAN,
@@ -697,7 +704,7 @@ class ModelLog:
 
     def render_graph(
         self,
-        vis_mode: str = "unrolled",
+        vis_mode: VisModeLiteral = "unrolled",
         vis_nesting_depth: int = 1000,
         vis_outpath: str = "modelgraph",
         vis_graph_overrides: Optional[Dict] = None,
@@ -709,9 +716,9 @@ class ModelLog:
         vis_save_only: bool = False,
         vis_fileformat: str = "pdf",
         show_buffer_layers: bool = False,
-        direction: str = "bottomup",
-        vis_node_placement: str = "auto",
-        vis_renderer: str = "graphviz",
+        direction: VisDirectionLiteral = "bottomup",
+        vis_node_placement: VisNodePlacementLiteral = "auto",
+        vis_renderer: VisRendererLiteral = "graphviz",
         vis_theme: str = "torchlens",
     ) -> str:
         """Render the computational graph for this model log.
@@ -1130,23 +1137,23 @@ class ModelLog:
         verbose: bool = False,
         validate_metadata: bool = True,
     ) -> bool:
-        """Validate saved activations against ground-truth model outputs.
+        """Deprecated alias for :meth:`validate_forward_pass`.
 
         Parameters
         ----------
         ground_truth_output_tensors, verbose, validate_metadata:
-            Forwarded unchanged to
-            :func:`torchlens.validation.core.validate_saved_activations`.
+            Forwarded unchanged to :meth:`validate_forward_pass`.
 
         Returns
         -------
         bool
             ``True`` if validation succeeds.
         """
-        from ..validation.core import validate_saved_activations as _impl
-
-        return _impl(
-            self,
+        warn_deprecated_alias(
+            "ModelLog.validate_saved_activations",
+            "ModelLog.validate_forward_pass",
+        )
+        return self.validate_forward_pass(
             ground_truth_output_tensors=ground_truth_output_tensors,
             verbose=verbose,
             validate_metadata=validate_metadata,
@@ -1158,12 +1165,13 @@ class ModelLog:
         verbose: bool = False,
         validate_metadata: bool = True,
     ) -> bool:
-        """Alias for :meth:`validate_saved_activations`.
+        """Validate saved activations against ground-truth model outputs.
 
         Parameters
         ----------
         ground_truth_output_tensors, verbose, validate_metadata:
-            Forwarded unchanged to :meth:`validate_saved_activations`.
+            Forwarded unchanged to
+            :func:`torchlens.validation.core.validate_saved_activations`.
 
         Returns
         -------

--- a/torchlens/options.py
+++ b/torchlens/options.py
@@ -1,0 +1,502 @@
+"""Grouped option dataclasses for public TorchLens APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Final, Mapping, cast
+
+import torch
+
+from ._deprecations import MISSING, MissingType, warn_deprecated_alias
+from ._literals import (
+    VisDirectionLiteral,
+    VisModeLiteral,
+    VisNodePlacementLiteral,
+    VisRendererLiteral,
+)
+
+_VISUALIZATION_FIELDS: Final[tuple[str, ...]] = (
+    "mode",
+    "max_module_depth",
+    "output_path",
+    "save_only",
+    "file_format",
+    "show_buffers",
+    "direction",
+    "graph_overrides",
+    "node_overrides",
+    "nested_node_overrides",
+    "edge_overrides",
+    "gradient_edge_overrides",
+    "module_overrides",
+    "layout_engine",
+    "renderer",
+    "theme",
+)
+_STREAMING_FIELDS: Final[tuple[str, ...]] = (
+    "bundle_path",
+    "retain_in_memory",
+    "activation_callback",
+)
+_VISUALIZATION_FLAT_TO_GROUP: Final[dict[str, str]] = {
+    "vis_mode": "mode",
+    "vis_nesting_depth": "max_module_depth",
+    "vis_outpath": "output_path",
+    "vis_save_only": "save_only",
+    "vis_fileformat": "file_format",
+    "vis_buffer_layers": "show_buffers",
+    "vis_direction": "direction",
+    "vis_graph_overrides": "graph_overrides",
+    "vis_node_overrides": "node_overrides",
+    "vis_nested_node_overrides": "nested_node_overrides",
+    "vis_edge_overrides": "edge_overrides",
+    "vis_gradient_edge_overrides": "gradient_edge_overrides",
+    "vis_module_overrides": "module_overrides",
+    "vis_node_placement": "layout_engine",
+    "vis_renderer": "renderer",
+    "vis_theme": "theme",
+}
+_STREAMING_FLAT_TO_GROUP: Final[dict[str, str]] = {
+    "save_activations_to": "bundle_path",
+    "keep_activations_in_memory": "retain_in_memory",
+    "activation_sink": "activation_callback",
+}
+
+
+def _resolve_option_value(
+    field_name: str,
+    supplied_value: Any,
+    default_value: Any,
+    specified_fields: set[str],
+) -> Any:
+    """Resolve an option field while tracking explicit caller presence.
+
+    Parameters
+    ----------
+    field_name:
+        Dataclass field name being resolved.
+    supplied_value:
+        Value supplied by the caller, or ``MISSING``.
+    default_value:
+        Public default for the field.
+    specified_fields:
+        Mutable set populated with fields explicitly supplied by the caller.
+
+    Returns
+    -------
+    Any
+        Resolved field value.
+    """
+
+    if supplied_value is MISSING:
+        return default_value
+    specified_fields.add(field_name)
+    return supplied_value
+
+
+@dataclass(frozen=True, init=False)
+class VisualizationOptions:
+    """Grouped visualization options for ``log_forward_pass`` and ``show_model_graph``."""
+
+    mode: VisModeLiteral = "none"
+    max_module_depth: int = 1000
+    output_path: str = "graph.gv"
+    save_only: bool = False
+    file_format: str = "pdf"
+    show_buffers: bool = False
+    direction: VisDirectionLiteral = "bottomup"
+    graph_overrides: dict[str, Any] | None = None
+    node_overrides: dict[str, Any] | None = None
+    nested_node_overrides: dict[str, Any] | None = None
+    edge_overrides: dict[str, Any] | None = None
+    gradient_edge_overrides: dict[str, Any] | None = None
+    module_overrides: dict[str, Any] | None = None
+    layout_engine: VisNodePlacementLiteral = "auto"
+    renderer: VisRendererLiteral = "graphviz"
+    theme: str = "torchlens"
+    _specified_fields: frozenset[str] = field(
+        default_factory=frozenset,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __init__(
+        self,
+        mode: VisModeLiteral | MissingType = MISSING,
+        max_module_depth: int | MissingType = MISSING,
+        output_path: str | MissingType = MISSING,
+        save_only: bool | MissingType = MISSING,
+        file_format: str | MissingType = MISSING,
+        show_buffers: bool | MissingType = MISSING,
+        direction: VisDirectionLiteral | MissingType = MISSING,
+        graph_overrides: dict[str, Any] | None | MissingType = MISSING,
+        node_overrides: dict[str, Any] | None | MissingType = MISSING,
+        nested_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+        edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+        gradient_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+        module_overrides: dict[str, Any] | None | MissingType = MISSING,
+        layout_engine: VisNodePlacementLiteral | MissingType = MISSING,
+        renderer: VisRendererLiteral | MissingType = MISSING,
+        theme: str | MissingType = MISSING,
+    ) -> None:
+        """Initialize a frozen visualization option bundle.
+
+        Parameters
+        ----------
+        mode, max_module_depth, output_path, save_only, file_format, show_buffers, direction,
+        graph_overrides, node_overrides, nested_node_overrides, edge_overrides,
+        gradient_edge_overrides, module_overrides, layout_engine, renderer, theme:
+            Visualization option values. Explicitly supplied fields are tracked so
+            deprecated flat kwargs can detect same-field conflicts later.
+        """
+
+        specified_fields: set[str] = set()
+        values: dict[str, Any] = {
+            "mode": _resolve_option_value("mode", mode, "none", specified_fields),
+            "max_module_depth": _resolve_option_value(
+                "max_module_depth",
+                max_module_depth,
+                1000,
+                specified_fields,
+            ),
+            "output_path": _resolve_option_value(
+                "output_path", output_path, "graph.gv", specified_fields
+            ),
+            "save_only": _resolve_option_value("save_only", save_only, False, specified_fields),
+            "file_format": _resolve_option_value(
+                "file_format", file_format, "pdf", specified_fields
+            ),
+            "show_buffers": _resolve_option_value(
+                "show_buffers",
+                show_buffers,
+                False,
+                specified_fields,
+            ),
+            "direction": _resolve_option_value(
+                "direction",
+                direction,
+                "bottomup",
+                specified_fields,
+            ),
+            "graph_overrides": _resolve_option_value(
+                "graph_overrides",
+                graph_overrides,
+                None,
+                specified_fields,
+            ),
+            "node_overrides": _resolve_option_value(
+                "node_overrides",
+                node_overrides,
+                None,
+                specified_fields,
+            ),
+            "nested_node_overrides": _resolve_option_value(
+                "nested_node_overrides",
+                nested_node_overrides,
+                None,
+                specified_fields,
+            ),
+            "edge_overrides": _resolve_option_value(
+                "edge_overrides",
+                edge_overrides,
+                None,
+                specified_fields,
+            ),
+            "gradient_edge_overrides": _resolve_option_value(
+                "gradient_edge_overrides",
+                gradient_edge_overrides,
+                None,
+                specified_fields,
+            ),
+            "module_overrides": _resolve_option_value(
+                "module_overrides",
+                module_overrides,
+                None,
+                specified_fields,
+            ),
+            "layout_engine": _resolve_option_value(
+                "layout_engine",
+                layout_engine,
+                "auto",
+                specified_fields,
+            ),
+            "renderer": _resolve_option_value("renderer", renderer, "graphviz", specified_fields),
+            "theme": _resolve_option_value("theme", theme, "torchlens", specified_fields),
+        }
+        for field_name in _VISUALIZATION_FIELDS:
+            object.__setattr__(self, field_name, values[field_name])
+        object.__setattr__(self, "_specified_fields", frozenset(specified_fields))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the option values as a plain dictionary."""
+
+        return {field_name: getattr(self, field_name) for field_name in _VISUALIZATION_FIELDS}
+
+    def is_field_explicit(self, field_name: str) -> bool:
+        """Return whether a field was explicitly supplied by the caller."""
+
+        return field_name in self._specified_fields
+
+    @classmethod
+    def from_values(
+        cls,
+        values: Mapping[str, Any],
+        specified_fields: frozenset[str],
+    ) -> "VisualizationOptions":
+        """Build an instance from already-resolved field values."""
+
+        instance = object.__new__(cls)
+        for field_name in _VISUALIZATION_FIELDS:
+            object.__setattr__(instance, field_name, values[field_name])
+        object.__setattr__(instance, "_specified_fields", specified_fields)
+        return cast("VisualizationOptions", instance)
+
+
+@dataclass(frozen=True, init=False)
+class StreamingOptions:
+    """Grouped streaming-save options for ``log_forward_pass``."""
+
+    bundle_path: str | Path | None = None
+    retain_in_memory: bool = True
+    activation_callback: Callable[[str, torch.Tensor], None] | None = None
+    _specified_fields: frozenset[str] = field(
+        default_factory=frozenset,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __init__(
+        self,
+        bundle_path: str | Path | None | MissingType = MISSING,
+        retain_in_memory: bool | MissingType = MISSING,
+        activation_callback: Callable[[str, torch.Tensor], None] | None | MissingType = MISSING,
+    ) -> None:
+        """Initialize a frozen streaming option bundle.
+
+        Parameters
+        ----------
+        bundle_path, retain_in_memory, activation_callback:
+            Streaming option values. Explicitly supplied fields are tracked so
+            deprecated flat kwargs can detect same-field conflicts later.
+        """
+
+        specified_fields: set[str] = set()
+        values: dict[str, Any] = {
+            "bundle_path": _resolve_option_value(
+                "bundle_path", bundle_path, None, specified_fields
+            ),
+            "retain_in_memory": _resolve_option_value(
+                "retain_in_memory",
+                retain_in_memory,
+                True,
+                specified_fields,
+            ),
+            "activation_callback": _resolve_option_value(
+                "activation_callback",
+                activation_callback,
+                None,
+                specified_fields,
+            ),
+        }
+        for field_name in _STREAMING_FIELDS:
+            object.__setattr__(self, field_name, values[field_name])
+        object.__setattr__(self, "_specified_fields", frozenset(specified_fields))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the option values as a plain dictionary."""
+
+        return {field_name: getattr(self, field_name) for field_name in _STREAMING_FIELDS}
+
+    def is_field_explicit(self, field_name: str) -> bool:
+        """Return whether a field was explicitly supplied by the caller."""
+
+        return field_name in self._specified_fields
+
+    @classmethod
+    def from_values(
+        cls,
+        values: Mapping[str, Any],
+        specified_fields: frozenset[str],
+    ) -> "StreamingOptions":
+        """Build an instance from already-resolved field values."""
+
+        instance = object.__new__(cls)
+        for field_name in _STREAMING_FIELDS:
+            object.__setattr__(instance, field_name, values[field_name])
+        object.__setattr__(instance, "_specified_fields", specified_fields)
+        return cast("StreamingOptions", instance)
+
+
+def merge_visualization_options(
+    *,
+    function_default_mode: VisModeLiteral,
+    visualization: VisualizationOptions | None,
+    vis_mode: VisModeLiteral | MissingType = MISSING,
+    vis_nesting_depth: int | MissingType = MISSING,
+    vis_outpath: str | MissingType = MISSING,
+    vis_save_only: bool | MissingType = MISSING,
+    vis_fileformat: str | MissingType = MISSING,
+    vis_buffer_layers: bool | MissingType = MISSING,
+    vis_direction: VisDirectionLiteral | MissingType = MISSING,
+    vis_graph_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_nested_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_gradient_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_module_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_node_placement: VisNodePlacementLiteral | MissingType = MISSING,
+    vis_renderer: VisRendererLiteral | MissingType = MISSING,
+    vis_theme: str | MissingType = MISSING,
+) -> VisualizationOptions:
+    """Merge deprecated flat visualization kwargs into a grouped options object.
+
+    Parameters
+    ----------
+    function_default_mode:
+        Per-function default visualization mode when no explicit grouped object
+        was supplied.
+    visualization:
+        Caller-supplied grouped visualization options, if any.
+    vis_mode, vis_nesting_depth, vis_outpath, vis_save_only, vis_fileformat,
+    vis_buffer_layers, vis_direction, vis_graph_overrides, vis_node_overrides,
+    vis_nested_node_overrides, vis_edge_overrides, vis_gradient_edge_overrides,
+    vis_module_overrides, vis_node_placement, vis_renderer, vis_theme:
+        Deprecated flat visualization kwargs. Presence is tracked with
+        ``MISSING`` so explicit default-valued calls still count as supplied.
+
+    Returns
+    -------
+    VisualizationOptions
+        Resolved visualization options for the current call.
+
+    Raises
+    ------
+    TypeError
+        If the same visualization field was supplied via both grouped and flat
+        forms.
+    """
+
+    if visualization is None:
+        values = VisualizationOptions().as_dict()
+        values["mode"] = function_default_mode
+        specified_fields: frozenset[str] = frozenset()
+    else:
+        values = visualization.as_dict()
+        specified_fields = visualization._specified_fields
+
+    flat_values: dict[str, Any] = {
+        "vis_mode": vis_mode,
+        "vis_nesting_depth": vis_nesting_depth,
+        "vis_outpath": vis_outpath,
+        "vis_save_only": vis_save_only,
+        "vis_fileformat": vis_fileformat,
+        "vis_buffer_layers": vis_buffer_layers,
+        "vis_direction": vis_direction,
+        "vis_graph_overrides": vis_graph_overrides,
+        "vis_node_overrides": vis_node_overrides,
+        "vis_nested_node_overrides": vis_nested_node_overrides,
+        "vis_edge_overrides": vis_edge_overrides,
+        "vis_gradient_edge_overrides": vis_gradient_edge_overrides,
+        "vis_module_overrides": vis_module_overrides,
+        "vis_node_placement": vis_node_placement,
+        "vis_renderer": vis_renderer,
+        "vis_theme": vis_theme,
+    }
+    for flat_name, group_name in _VISUALIZATION_FLAT_TO_GROUP.items():
+        flat_value = flat_values[flat_name]
+        if flat_value is MISSING:
+            continue
+        if visualization is not None and group_name in specified_fields:
+            raise TypeError(f"Do not pass both `{flat_name}` and `visualization.{group_name}`.")
+        warn_deprecated_alias(flat_name, f"visualization.{group_name}")
+        values[group_name] = flat_value
+    return VisualizationOptions.from_values(values, specified_fields)
+
+
+def merge_streaming_options(
+    *,
+    streaming: StreamingOptions | None,
+    save_activations_to: str | Path | None | MissingType = MISSING,
+    keep_activations_in_memory: bool | MissingType = MISSING,
+    activation_sink: Callable[[str, torch.Tensor], None] | None | MissingType = MISSING,
+) -> StreamingOptions:
+    """Merge deprecated flat streaming kwargs into a grouped options object.
+
+    Parameters
+    ----------
+    streaming:
+        Caller-supplied grouped streaming options, if any.
+    save_activations_to, keep_activations_in_memory, activation_sink:
+        Deprecated flat streaming kwargs. Presence is tracked with ``MISSING``
+        so explicit default-valued calls still count as supplied.
+
+    Returns
+    -------
+    StreamingOptions
+        Resolved streaming options for the current call.
+
+    Raises
+    ------
+    TypeError
+        If the same streaming field was supplied via both grouped and flat
+        forms.
+    """
+
+    if streaming is None:
+        values = StreamingOptions().as_dict()
+        specified_fields: frozenset[str] = frozenset()
+    else:
+        values = streaming.as_dict()
+        specified_fields = streaming._specified_fields
+
+    flat_values: dict[str, Any] = {
+        "save_activations_to": save_activations_to,
+        "keep_activations_in_memory": keep_activations_in_memory,
+        "activation_sink": activation_sink,
+    }
+    for flat_name, group_name in _STREAMING_FLAT_TO_GROUP.items():
+        flat_value = flat_values[flat_name]
+        if flat_value is MISSING:
+            continue
+        if streaming is not None and group_name in specified_fields:
+            raise TypeError(f"Do not pass both `{flat_name}` and `streaming.{group_name}`.")
+        warn_deprecated_alias(flat_name, f"streaming.{group_name}")
+        values[group_name] = flat_value
+    return StreamingOptions.from_values(values, specified_fields)
+
+
+def visualization_to_render_kwargs(visualization: VisualizationOptions) -> dict[str, Any]:
+    """Translate grouped visualization options into ``ModelLog.render_graph`` kwargs.
+
+    Parameters
+    ----------
+    visualization:
+        Resolved grouped visualization options.
+
+    Returns
+    -------
+    dict[str, Any]
+        Keyword arguments expected by ``ModelLog.render_graph``.
+    """
+
+    return {
+        "vis_mode": visualization.mode,
+        "vis_nesting_depth": visualization.max_module_depth,
+        "vis_outpath": visualization.output_path,
+        "vis_graph_overrides": visualization.graph_overrides,
+        "vis_node_overrides": visualization.node_overrides,
+        "vis_nested_node_overrides": visualization.nested_node_overrides,
+        "vis_edge_overrides": visualization.edge_overrides,
+        "vis_gradient_edge_overrides": visualization.gradient_edge_overrides,
+        "vis_module_overrides": visualization.module_overrides,
+        "vis_save_only": visualization.save_only,
+        "vis_fileformat": visualization.file_format,
+        "show_buffer_layers": visualization.show_buffers,
+        "direction": visualization.direction,
+        "vis_node_placement": visualization.layout_engine,
+        "vis_renderer": visualization.renderer,
+        "vis_theme": visualization.theme,
+    }

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -119,7 +119,12 @@ def _run_model_and_save_specified_activations(
         input_args: Positional arguments to model.forward(); a single tensor or list.
         input_kwargs: Keyword arguments to model.forward().
         layers_to_save: Which layers to save activations for ('all', 'none'/None, or a list).
-        keep_unsaved_layers: If False, layers without saved activations are pruned from the log.
+        keep_unsaved_layers: If False, layers without saved activations are pruned from the
+            final log. When ``layers_to_save`` is a specific subset, TorchLens still runs the
+            initial exhaustive metadata pass with ``keep_unsaved_layers=True`` so it can resolve
+            names before the fast replay. Example: use
+            ``layers_to_save=['conv2d_1_1'], keep_unsaved_layers=False`` to keep only the
+            requested saved activations in the returned log.
         output_device: Device for saved tensors: 'same' (default), 'cpu', or 'cuda'.
         activation_postfunc: Optional transform applied to each activation before storage
             (e.g., channel-wise averaging to reduce memory).
@@ -133,8 +138,10 @@ def _run_model_and_save_specified_activations(
         num_context_lines: Number of source-code context lines stored per function call.
         optimizer: Optional optimizer - used to tag which parameters have optimizers attached.
         detect_loops: If True (default), run full isomorphic subgraph expansion to
-            detect repeated patterns (loops). If False, only group operations that
-            share the same parameters - much faster for very large graphs.
+            detect repeated patterns (loops). Set this to False when the forward pass has
+            more than about 1M operations and postprocessing speed matters; the False path
+            skips the expensive expansion step and only groups operations that share the
+            same parameters.
         save_activations_to: Optional portable bundle directory for streaming activation save.
         keep_activations_in_memory: Whether streamed activations should remain in memory
             after finalization.
@@ -268,7 +275,12 @@ def log_forward_pass(
         input_kwargs: Keyword args for ``model.forward()``.
         layers_to_save: Which layers to save activations for (see above).
         keep_unsaved_layers: If False, layers without saved activations are removed from
-            the returned ModelLog (they still exist during processing).
+            the returned ModelLog (they still exist during processing). When
+            ``layers_to_save`` is a specific subset, TorchLens still does an initial
+            exhaustive metadata pass with ``keep_unsaved_layers=True`` so it can resolve
+            names before the fast replay. Example: use
+            ``layers_to_save=['conv2d_1_1'], keep_unsaved_layers=False`` to keep only the
+            requested saved activations in the final log.
         output_device: Device for stored tensors: ``'same'``, ``'cpu'``, or ``'cuda'``.
         activation_postfunc: Optional function applied to each activation before saving.
         mark_input_output_distances: Deprecated alias for
@@ -278,16 +290,16 @@ def log_forward_pass(
             ``validate_forward_pass``).
         save_gradients: Capture gradients during a subsequent backward pass.
         save_source_context: Python call-stack identity is always recorded for each
-            tensor operation. If True, also capture rich source-text fields on each
-            ``FuncCallLocation`` (``source_context``, ``code_context``, etc.) plus
-            module source metadata. If False, identity fields (``file``,
+            tensor operation. If False (default), identity fields such as ``file``,
             ``line_number``, ``func_name``, ``code_firstlineno``,
-            ``code_qualname``, ``col_offset``) are still captured; only the
-            source-text properties return the existing empty-placeholder values.
+            ``code_qualname``, and ``col_offset`` are still captured, but the rich
+            source-text properties return their existing empty-placeholder values.
+            If True, TorchLens also captures source text on each ``FuncCallLocation``
+            (``source_context``, ``code_context``, etc.) plus module source metadata.
             Full ``if``/``elif``/``else`` and ternary branch attribution
             (``conditional_events``, ``conditional_arm_edges``,
-            ``conditional_edge_passes``, etc.) works regardless of this flag
-            because it relies only on those identity fields.
+            ``conditional_edge_passes``, etc.) works regardless of this flag because it
+            relies only on the always-captured identity fields.
         save_rng_states: If True, capture RNG states before each operation (needed for
             validation replay of stochastic ops like dropout). Auto-enabled when
             ``validate_forward_pass`` is used. Default False for speed.
@@ -324,8 +336,10 @@ def log_forward_pass(
         compute_input_output_distances: Compute BFS distances from inputs/outputs
             (expensive).
         detect_recurrent_patterns: If True (default), run full isomorphic
-            subgraph expansion. If False, only group operations that share the
-            same parameters.
+            subgraph expansion. Set this to False when the forward pass has more than
+            about 1M operations and postprocessing speed matters; the False path skips
+            the expensive expansion step and only groups operations that share the same
+            parameters.
         visualization: Grouped visualization options. When omitted,
             ``log_forward_pass`` defaults to ``VisualizationOptions(mode="none")``.
         streaming: Grouped streaming-save options.
@@ -635,7 +649,10 @@ def show_model_graph(
         random_seed: Fixed RNG seed for stochastic models.
         detect_loops: Deprecated alias for ``detect_recurrent_patterns``.
         detect_recurrent_patterns: If True (default), run full isomorphic
-            subgraph expansion.
+            subgraph expansion. Set this to False when the forward pass has more than
+            about 1M operations and postprocessing speed matters; the False path skips
+            the expensive expansion step and only groups operations that share the same
+            parameters.
         visualization: Grouped visualization options. When omitted,
             ``show_model_graph`` defaults to ``VisualizationOptions(mode="unrolled")``.
 

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -469,6 +469,48 @@ def get_model_metadata(
     return model_log
 
 
+def summary(
+    model: nn.Module,
+    input_args: Union[torch.Tensor, List[Any], Tuple[Any]],
+    input_kwargs: Optional[Dict[Any, Any]] = None,
+    **summary_kwargs: Any,
+) -> str:
+    """Run a metadata-only forward pass and return a rendered summary string.
+
+    Parameters
+    ----------
+    model:
+        PyTorch model to inspect.
+    input_args:
+        Positional args for ``model.forward()``.
+    input_kwargs:
+        Keyword args for ``model.forward()``.
+    **summary_kwargs:
+        Forwarded to ``ModelLog.summary``.
+
+    Returns
+    -------
+    str
+        Rendered summary text.
+    """
+    model = _unwrap_data_parallel(model)
+    if input_kwargs is None:
+        input_kwargs = {}
+
+    model_log = _run_model_and_save_specified_activations(
+        model=model,
+        input_args=input_args,  # type: ignore[arg-type]
+        input_kwargs=input_kwargs,
+        layers_to_save=None,
+        keep_unsaved_layers=True,
+        detect_loops=True,
+    )
+    try:
+        return model_log.summary(**summary_kwargs)
+    finally:
+        model_log.cleanup()
+
+
 def show_model_graph(
     model: nn.Module,
     input_args: Union[torch.Tensor, List, Tuple],

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -4,7 +4,8 @@ This module contains every user-facing function:
   - ``log_forward_pass``  - the main entry point (runs model, returns ModelLog)
   - ``validate_forward_pass`` - replay-based correctness check
   - ``show_model_graph`` - visualization convenience wrapper
-  - ``get_model_metadata`` - metadata-only convenience wrapper (deprecated path)
+  - ``log_model_metadata`` - metadata-only convenience wrapper
+  - ``get_model_metadata`` - deprecated alias for ``log_model_metadata``
   - ``validate_batch_of_models_and_inputs`` - bulk validation harness
 
 **Two-pass strategy** (``log_forward_pass`` with selective layers):
@@ -27,15 +28,30 @@ import torch
 from torch import nn
 from tqdm import tqdm
 
-from .utils.introspection import get_vars_of_type_from_obj
-from .utils.rng import set_random_seed
-from .utils.display import warn_parallel, _vprint
-from .utils.arg_handling import safe_copy_args, safe_copy_kwargs, normalize_input_args
+from ._deprecations import MISSING, MissingType, resolve_renamed_kwarg, warn_deprecated_alias
 from ._io import TorchLensIOError
 from ._io.streaming import BundleStreamWriter
+from ._literals import (
+    OutputDeviceLiteral,
+    VisDirectionLiteral,
+    VisModeLiteral,
+    VisNodePlacementLiteral,
+    VisRendererLiteral,
+)
 from .data_classes.model_log import (
     ModelLog,
 )
+from .options import (
+    StreamingOptions,
+    VisualizationOptions,
+    merge_streaming_options,
+    merge_visualization_options,
+    visualization_to_render_kwargs,
+)
+from .utils.arg_handling import normalize_input_args, safe_copy_args, safe_copy_kwargs
+from .utils.display import _vprint, warn_parallel
+from .utils.introspection import get_vars_of_type_from_obj
+from .utils.rng import set_random_seed
 
 
 def _unwrap_data_parallel(model: nn.Module) -> nn.Module:
@@ -74,7 +90,7 @@ def _run_model_and_save_specified_activations(
     input_kwargs: Dict[Any, Any],
     layers_to_save: Optional[Union[str, List[Union[int, str]]]] = "all",
     keep_unsaved_layers: bool = True,
-    output_device: str = "same",
+    output_device: OutputDeviceLiteral = "same",
     activation_postfunc: Optional[Callable] = None,
     mark_input_output_distances: bool = False,
     detach_saved_tensors: bool = False,
@@ -180,39 +196,44 @@ def log_forward_pass(
     input_kwargs: Optional[Dict[Any, Any]] = None,
     layers_to_save: Optional[Union[str, List]] = "all",
     keep_unsaved_layers: bool = True,
-    output_device: str = "same",
+    output_device: OutputDeviceLiteral = "same",
     activation_postfunc: Optional[Callable] = None,
-    mark_input_output_distances: bool = False,
+    mark_input_output_distances: bool | MissingType = MISSING,
     detach_saved_tensors: bool = False,
     save_function_args: bool = False,
     save_gradients: bool = False,
     save_source_context: bool = False,
     save_rng_states: bool = False,
-    vis_mode: str = "none",
-    vis_nesting_depth: int = 1000,
-    vis_outpath: str = "graph.gv",
-    vis_save_only: bool = False,
-    vis_fileformat: str = "pdf",
-    vis_buffer_layers: bool = False,
-    vis_direction: str = "bottomup",
-    vis_graph_overrides: Optional[Dict] = None,
-    vis_node_overrides: Optional[Dict] = None,
-    vis_nested_node_overrides: Optional[Dict] = None,
-    vis_edge_overrides: Optional[Dict] = None,
-    vis_gradient_edge_overrides: Optional[Dict] = None,
-    vis_module_overrides: Optional[Dict] = None,
-    vis_node_placement: str = "auto",
-    vis_renderer: str = "graphviz",
-    vis_theme: str = "torchlens",
+    vis_mode: VisModeLiteral | MissingType = MISSING,
+    vis_nesting_depth: int | MissingType = MISSING,
+    vis_outpath: str | MissingType = MISSING,
+    vis_save_only: bool | MissingType = MISSING,
+    vis_fileformat: str | MissingType = MISSING,
+    vis_buffer_layers: bool | MissingType = MISSING,
+    vis_direction: VisDirectionLiteral | MissingType = MISSING,
+    vis_graph_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_nested_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_gradient_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_module_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_node_placement: VisNodePlacementLiteral | MissingType = MISSING,
+    vis_renderer: VisRendererLiteral | MissingType = MISSING,
+    vis_theme: str | MissingType = MISSING,
     random_seed: Optional[int] = None,
-    num_context_lines: int = 7,
+    num_context_lines: int | MissingType = MISSING,
     optimizer=None,
-    detect_loops: bool = True,
-    save_activations_to: str | Path | None = None,
-    keep_activations_in_memory: bool = True,
-    activation_sink: Callable[[str, torch.Tensor], None] | None = None,
+    detect_loops: bool | MissingType = MISSING,
+    save_activations_to: str | Path | None | MissingType = MISSING,
+    keep_activations_in_memory: bool | MissingType = MISSING,
+    activation_sink: Callable[[str, torch.Tensor], None] | None | MissingType = MISSING,
     unwrap_when_done: bool = False,
     verbose: bool = False,
+    source_context_lines: int | MissingType = MISSING,
+    compute_input_output_distances: bool | MissingType = MISSING,
+    detect_recurrent_patterns: bool | MissingType = MISSING,
+    visualization: VisualizationOptions | None = None,
+    streaming: StreamingOptions | None = None,
 ) -> ModelLog:
     """Run a forward pass through *model*, log every operation, and return a ModelLog.
 
@@ -250,10 +271,11 @@ def log_forward_pass(
             the returned ModelLog (they still exist during processing).
         output_device: Device for stored tensors: ``'same'``, ``'cpu'``, or ``'cuda'``.
         activation_postfunc: Optional function applied to each activation before saving.
-        mark_input_output_distances: Compute BFS distances from inputs/outputs (expensive).
+        mark_input_output_distances: Deprecated alias for
+            ``compute_input_output_distances``.
         detach_saved_tensors: If True, detach saved tensors from the autograd graph.
         save_function_args: Store non-tensor args for each function call (needed for
-            ``validate_saved_activations``).
+            ``validate_forward_pass``).
         save_gradients: Capture gradients during a subsequent backward pass.
         save_source_context: Python call-stack identity is always recorded for each
             tensor operation. If True, also capture rich source-text fields on each
@@ -269,44 +291,44 @@ def log_forward_pass(
         save_rng_states: If True, capture RNG states before each operation (needed for
             validation replay of stochastic ops like dropout). Auto-enabled when
             ``validate_forward_pass`` is used. Default False for speed.
-        vis_mode: ``'none'`` (default), ``'rolled'``, or ``'unrolled'`` visualization.
-        vis_nesting_depth: Max module nesting depth shown in visualization.
-        vis_outpath: Output file path for the graph visualization.
-        vis_save_only: If True, save the visualization file without displaying it.
-        vis_fileformat: Image format (``'pdf'``, ``'png'``, ``'jpg'``, etc.).
-        vis_buffer_layers: Include buffer layers in the visualization.
-        vis_direction: Layout direction: ``'bottomup'``, ``'topdown'``, or ``'leftright'``.
-        vis_graph_overrides: Graphviz graph-level attribute overrides.
-        vis_node_overrides: Graphviz node attribute overrides.
-        vis_nested_node_overrides: Graphviz attribute overrides for nested (module) nodes.
-        vis_edge_overrides: Graphviz edge attribute overrides.
-        vis_gradient_edge_overrides: Graphviz attribute overrides for gradient edges.
-        vis_module_overrides: Graphviz subgraph (module cluster) attribute overrides.
-        vis_node_placement: Layout engine: ``'auto'`` (default), ``'dot'``, ``'elk'``,
-            or ``'sfdp'``.  ``'auto'`` uses dot for small graphs and ELK/sfdp for large.
-        vis_renderer: Visualization backend: ``'graphviz'`` (default) or ``'dagua'``.
-        vis_theme: Named Dagua theme when ``vis_renderer='dagua'``.
+        vis_mode: Deprecated alias for ``visualization.mode``.
+        vis_nesting_depth: Deprecated alias for ``visualization.max_module_depth``.
+        vis_outpath: Deprecated alias for ``visualization.output_path``.
+        vis_save_only: Deprecated alias for ``visualization.save_only``.
+        vis_fileformat: Deprecated alias for ``visualization.file_format``.
+        vis_buffer_layers: Deprecated alias for ``visualization.show_buffers``.
+        vis_direction: Deprecated alias for ``visualization.direction``.
+        vis_graph_overrides: Deprecated alias for ``visualization.graph_overrides``.
+        vis_node_overrides: Deprecated alias for ``visualization.node_overrides``.
+        vis_nested_node_overrides: Deprecated alias for
+            ``visualization.nested_node_overrides``.
+        vis_edge_overrides: Deprecated alias for ``visualization.edge_overrides``.
+        vis_gradient_edge_overrides: Deprecated alias for
+            ``visualization.gradient_edge_overrides``.
+        vis_module_overrides: Deprecated alias for ``visualization.module_overrides``.
+        vis_node_placement: Deprecated alias for ``visualization.layout_engine``.
+        vis_renderer: Deprecated alias for ``visualization.renderer``.
+        vis_theme: Deprecated alias for ``visualization.theme``.
         random_seed: Fixed RNG seed for reproducibility with stochastic models.
-        num_context_lines: Lines of source context to capture per function call.
+        num_context_lines: Deprecated alias for ``source_context_lines``.
         optimizer: Optional optimizer to annotate which params are being optimized.
-        detect_loops: If True (default), run full isomorphic subgraph expansion.
-        save_activations_to: Optional portable bundle directory for streaming activation
-            save. When set, TorchLens writes each saved activation to disk during the
-            forward pass and finalizes a directory bundle at the end. Streaming is
-            always strict, requires ``safetensors``, and is mutually exclusive with
-            ``activation_sink``.
-        keep_activations_in_memory: Only applies when ``save_activations_to`` is set.
-            If True (default), the returned log keeps the in-memory tensors and also
-            attaches ``activation_ref`` handles to the finalized bundle. If False,
-            activations are evicted after finalization and must be materialized back
-            from disk on demand.
-        activation_sink: Optional callback invoked with ``(label, tensor)`` for each
-            saved activation instead of writing a portable bundle. This is useful for
-            custom streaming consumers and cannot be combined with
-            ``save_activations_to``.
+        detect_loops: Deprecated alias for ``detect_recurrent_patterns``.
+        save_activations_to: Deprecated alias for ``streaming.bundle_path``.
+        keep_activations_in_memory: Deprecated alias for
+            ``streaming.retain_in_memory``.
+        activation_sink: Deprecated alias for ``streaming.activation_callback``.
         unwrap_when_done: If True, restore original torch callables after logging.
             Default False - torch stays wrapped for subsequent calls.
         verbose: If True, print timed progress messages at each major pipeline stage.
+        source_context_lines: Lines of source context to capture per function call.
+        compute_input_output_distances: Compute BFS distances from inputs/outputs
+            (expensive).
+        detect_recurrent_patterns: If True (default), run full isomorphic
+            subgraph expansion. If False, only group operations that share the
+            same parameters.
+        visualization: Grouped visualization options. When omitted,
+            ``log_forward_pass`` defaults to ``VisualizationOptions(mode="none")``.
+        streaming: Grouped streaming-save options.
 
     Returns:
         A ``ModelLog`` containing layer activations (if requested) and full metadata.
@@ -315,19 +337,70 @@ def log_forward_pass(
     warn_parallel()
     model = _unwrap_data_parallel(model)
 
-    if vis_mode not in ["none", "rolled", "unrolled"]:
+    source_context_lines = resolve_renamed_kwarg(
+        old_name="num_context_lines",
+        new_name="source_context_lines",
+        old_value=num_context_lines,
+        new_value=source_context_lines,
+        default=7,
+    )
+    compute_input_output_distances = resolve_renamed_kwarg(
+        old_name="mark_input_output_distances",
+        new_name="compute_input_output_distances",
+        old_value=mark_input_output_distances,
+        new_value=compute_input_output_distances,
+        default=False,
+    )
+    detect_recurrent_patterns = resolve_renamed_kwarg(
+        old_name="detect_loops",
+        new_name="detect_recurrent_patterns",
+        old_value=detect_loops,
+        new_value=detect_recurrent_patterns,
+        default=True,
+    )
+    visualization_options = merge_visualization_options(
+        function_default_mode="none",
+        visualization=visualization,
+        vis_mode=vis_mode,
+        vis_nesting_depth=vis_nesting_depth,
+        vis_outpath=vis_outpath,
+        vis_save_only=vis_save_only,
+        vis_fileformat=vis_fileformat,
+        vis_buffer_layers=vis_buffer_layers,
+        vis_direction=vis_direction,
+        vis_graph_overrides=vis_graph_overrides,
+        vis_node_overrides=vis_node_overrides,
+        vis_nested_node_overrides=vis_nested_node_overrides,
+        vis_edge_overrides=vis_edge_overrides,
+        vis_gradient_edge_overrides=vis_gradient_edge_overrides,
+        vis_module_overrides=vis_module_overrides,
+        vis_node_placement=vis_node_placement,
+        vis_renderer=vis_renderer,
+        vis_theme=vis_theme,
+    )
+    streaming_options = merge_streaming_options(
+        streaming=streaming,
+        save_activations_to=save_activations_to,
+        keep_activations_in_memory=keep_activations_in_memory,
+        activation_sink=activation_sink,
+    )
+
+    if visualization_options.mode not in ["none", "rolled", "unrolled"]:
         raise ValueError("Visualization option must be either 'none', 'rolled', or 'unrolled'.")
 
     if output_device not in ["same", "cpu", "cuda"]:
         raise ValueError("output_device must be either 'same', 'cpu', or 'cuda'.")
-    if save_activations_to is not None and activation_sink is not None:
+    if (
+        streaming_options.bundle_path is not None
+        and streaming_options.activation_callback is not None
+    ):
         raise ValueError("save_activations_to and activation_sink are mutually exclusive.")
 
     if type(layers_to_save) is str:
         layers_to_save = layers_to_save.lower()
 
     uses_two_pass = layers_to_save not in ["all", "none", None, []]
-    if save_activations_to is not None and uses_two_pass:
+    if streaming_options.bundle_path is not None and uses_two_pass:
         raise TorchLensIOError(
             'save_activations_to is only supported with layers_to_save="all" in this '
             "release. For selective streaming use activation_sink=callable, or capture "
@@ -346,19 +419,19 @@ def log_forward_pass(
             keep_unsaved_layers=keep_unsaved_layers,
             output_device=output_device,
             activation_postfunc=activation_postfunc,
-            mark_input_output_distances=mark_input_output_distances,
+            mark_input_output_distances=compute_input_output_distances,
             detach_saved_tensors=detach_saved_tensors,
             save_function_args=save_function_args,
             save_gradients=save_gradients,
             random_seed=random_seed,
-            num_context_lines=num_context_lines,
+            num_context_lines=source_context_lines,
             optimizer=optimizer,
             save_source_context=save_source_context,
             save_rng_states=save_rng_states,
-            detect_loops=detect_loops,
-            save_activations_to=save_activations_to,
-            keep_activations_in_memory=keep_activations_in_memory,
-            activation_sink=activation_sink,
+            detect_loops=detect_recurrent_patterns,
+            save_activations_to=streaming_options.bundle_path,
+            keep_activations_in_memory=streaming_options.retain_in_memory,
+            activation_sink=streaming_options.activation_callback,
             verbose=verbose,
         )
     else:
@@ -376,19 +449,19 @@ def log_forward_pass(
             keep_unsaved_layers=True,
             output_device=output_device,
             activation_postfunc=activation_postfunc,
-            mark_input_output_distances=mark_input_output_distances,
+            mark_input_output_distances=compute_input_output_distances,
             detach_saved_tensors=detach_saved_tensors,
             save_function_args=save_function_args,
             save_gradients=save_gradients,
             random_seed=random_seed,
-            num_context_lines=num_context_lines,
+            num_context_lines=source_context_lines,
             optimizer=optimizer,
             save_source_context=save_source_context,
             save_rng_states=save_rng_states,
-            detect_loops=detect_loops,
-            save_activations_to=save_activations_to,
-            keep_activations_in_memory=keep_activations_in_memory,
-            activation_sink=activation_sink,
+            detect_loops=detect_recurrent_patterns,
+            save_activations_to=streaming_options.bundle_path,
+            keep_activations_in_memory=streaming_options.retain_in_memory,
+            activation_sink=streaming_options.activation_callback,
             verbose=verbose,
         )
         # Pass 2 (fast): Now that layer labels exist, resolve the user's requested
@@ -412,25 +485,8 @@ def log_forward_pass(
     )
 
     # Visualize if desired.
-    if vis_mode != "none":
-        model_log.render_graph(
-            vis_mode,
-            vis_nesting_depth,
-            vis_outpath,
-            vis_graph_overrides,
-            vis_node_overrides,
-            vis_nested_node_overrides,
-            vis_edge_overrides,
-            vis_gradient_edge_overrides,
-            vis_module_overrides,
-            vis_save_only,
-            vis_fileformat,
-            vis_buffer_layers,
-            vis_direction,
-            vis_node_placement=vis_node_placement,
-            vis_renderer=vis_renderer,
-            vis_theme=vis_theme,
-        )
+    if visualization_options.mode != "none":
+        model_log.render_graph(**visualization_to_render_kwargs(visualization_options))
 
     if unwrap_when_done:
         from .decoration import unwrap_torch
@@ -440,7 +496,7 @@ def log_forward_pass(
     return model_log
 
 
-def get_model_metadata(
+def log_model_metadata(
     model: nn.Module,
     input_args: Union[torch.Tensor, List[Any], Tuple[Any]],
     input_kwargs: Optional[Dict[Any, Any]] = None,
@@ -448,8 +504,7 @@ def get_model_metadata(
     """Return model metadata without saving any activations.
 
     Equivalent to ``log_forward_pass(model, input_args, input_kwargs, layers_to_save=None,
-    mark_input_output_distances=True)``.  Prefer using ``log_forward_pass`` directly -
-    this wrapper exists for backward compatibility and may be removed in a future release.
+    compute_input_output_distances=True)``.
 
     Args:
         model: PyTorch model to inspect.
@@ -464,9 +519,20 @@ def get_model_metadata(
         input_args,
         input_kwargs,
         layers_to_save=None,
-        mark_input_output_distances=True,
+        compute_input_output_distances=True,
     )
     return model_log
+
+
+def get_model_metadata(
+    model: nn.Module,
+    input_args: Union[torch.Tensor, List[Any], Tuple[Any]],
+    input_kwargs: Optional[Dict[Any, Any]] = None,
+) -> ModelLog:
+    """Deprecated alias for :func:`log_model_metadata`."""
+
+    warn_deprecated_alias("get_model_metadata", "log_model_metadata")
+    return log_model_metadata(model, input_args, input_kwargs)
 
 
 def summary(
@@ -515,25 +581,27 @@ def show_model_graph(
     model: nn.Module,
     input_args: Union[torch.Tensor, List, Tuple],
     input_kwargs: Optional[Dict[Any, Any]] = None,
-    vis_mode: str = "unrolled",
-    vis_nesting_depth: int = 1000,
-    vis_outpath: str = "graph.gv",
-    vis_graph_overrides: Optional[Dict] = None,
-    vis_node_overrides: Optional[Dict] = None,
-    vis_nested_node_overrides: Optional[Dict] = None,
-    vis_edge_overrides: Optional[Dict] = None,
-    vis_gradient_edge_overrides: Optional[Dict] = None,
-    vis_module_overrides: Optional[Dict] = None,
-    vis_save_only: bool = False,
-    vis_fileformat: str = "pdf",
-    vis_buffer_layers: bool = False,
-    vis_direction: str = "bottomup",
-    vis_node_placement: str = "auto",
-    vis_renderer: str = "graphviz",
-    vis_theme: str = "torchlens",
+    vis_mode: VisModeLiteral | MissingType = MISSING,
+    vis_nesting_depth: int | MissingType = MISSING,
+    vis_outpath: str | MissingType = MISSING,
+    vis_graph_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_nested_node_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_gradient_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_module_overrides: dict[str, Any] | None | MissingType = MISSING,
+    vis_save_only: bool | MissingType = MISSING,
+    vis_fileformat: str | MissingType = MISSING,
+    vis_buffer_layers: bool | MissingType = MISSING,
+    vis_direction: VisDirectionLiteral | MissingType = MISSING,
+    vis_node_placement: VisNodePlacementLiteral | MissingType = MISSING,
+    vis_renderer: VisRendererLiteral | MissingType = MISSING,
+    vis_theme: str | MissingType = MISSING,
     random_seed: Optional[int] = None,
-    detect_loops: bool = True,
+    detect_loops: bool | MissingType = MISSING,
     verbose: bool = False,
+    detect_recurrent_patterns: bool | MissingType = MISSING,
+    visualization: VisualizationOptions | None = None,
 ) -> None:
     """Convenience wrapper: visualize the computational graph without saving activations.
 
@@ -546,16 +614,30 @@ def show_model_graph(
         model: PyTorch model.
         input_args: Positional args for ``model.forward()``.
         input_kwargs: Keyword args for ``model.forward()``.
-        vis_mode: ``'rolled'`` or ``'unrolled'`` (``'none'`` is accepted but a no-op).
-        vis_nesting_depth: Max module nesting depth shown (default 1000 = all).
-        vis_outpath: Output file path for the visualization.
-        vis_save_only: If True, save without displaying.
-        vis_fileformat: Image format (``'pdf'``, ``'png'``, ``'jpg'``, etc.).
-        vis_buffer_layers: Include buffer layers in the visualization.
-        vis_direction: ``'bottomup'``, ``'topdown'``, or ``'leftright'``.
-        vis_renderer: Visualization backend: ``'graphviz'`` (default) or ``'dagua'``.
-        vis_theme: Named Dagua theme when ``vis_renderer='dagua'``.
+        vis_mode: Deprecated alias for ``visualization.mode``.
+        vis_nesting_depth: Deprecated alias for ``visualization.max_module_depth``.
+        vis_outpath: Deprecated alias for ``visualization.output_path``.
+        vis_graph_overrides: Deprecated alias for ``visualization.graph_overrides``.
+        vis_node_overrides: Deprecated alias for ``visualization.node_overrides``.
+        vis_nested_node_overrides: Deprecated alias for
+            ``visualization.nested_node_overrides``.
+        vis_edge_overrides: Deprecated alias for ``visualization.edge_overrides``.
+        vis_gradient_edge_overrides: Deprecated alias for
+            ``visualization.gradient_edge_overrides``.
+        vis_module_overrides: Deprecated alias for ``visualization.module_overrides``.
+        vis_save_only: Deprecated alias for ``visualization.save_only``.
+        vis_fileformat: Deprecated alias for ``visualization.file_format``.
+        vis_buffer_layers: Deprecated alias for ``visualization.show_buffers``.
+        vis_direction: Deprecated alias for ``visualization.direction``.
+        vis_node_placement: Deprecated alias for ``visualization.layout_engine``.
+        vis_renderer: Deprecated alias for ``visualization.renderer``.
+        vis_theme: Deprecated alias for ``visualization.theme``.
         random_seed: Fixed RNG seed for stochastic models.
+        detect_loops: Deprecated alias for ``detect_recurrent_patterns``.
+        detect_recurrent_patterns: If True (default), run full isomorphic
+            subgraph expansion.
+        visualization: Grouped visualization options. When omitted,
+            ``show_model_graph`` defaults to ``VisualizationOptions(mode="unrolled")``.
 
     Returns:
         None.
@@ -564,7 +646,35 @@ def show_model_graph(
     if not input_kwargs:
         input_kwargs = {}
 
-    if vis_mode not in ["none", "rolled", "unrolled"]:
+    detect_recurrent_patterns = resolve_renamed_kwarg(
+        old_name="detect_loops",
+        new_name="detect_recurrent_patterns",
+        old_value=detect_loops,
+        new_value=detect_recurrent_patterns,
+        default=True,
+    )
+    visualization_options = merge_visualization_options(
+        function_default_mode="unrolled",
+        visualization=visualization,
+        vis_mode=vis_mode,
+        vis_nesting_depth=vis_nesting_depth,
+        vis_outpath=vis_outpath,
+        vis_save_only=vis_save_only,
+        vis_fileformat=vis_fileformat,
+        vis_buffer_layers=vis_buffer_layers,
+        vis_direction=vis_direction,
+        vis_graph_overrides=vis_graph_overrides,
+        vis_node_overrides=vis_node_overrides,
+        vis_nested_node_overrides=vis_nested_node_overrides,
+        vis_edge_overrides=vis_edge_overrides,
+        vis_gradient_edge_overrides=vis_gradient_edge_overrides,
+        vis_module_overrides=vis_module_overrides,
+        vis_node_placement=vis_node_placement,
+        vis_renderer=vis_renderer,
+        vis_theme=vis_theme,
+    )
+
+    if visualization_options.mode not in ["none", "rolled", "unrolled"]:
         raise ValueError("Visualization option must be either 'none', 'rolled', or 'unrolled'.")
 
     model_log = _run_model_and_save_specified_activations(
@@ -577,30 +687,13 @@ def show_model_graph(
         detach_saved_tensors=False,
         save_gradients=False,
         random_seed=random_seed,
-        detect_loops=detect_loops,
+        detect_loops=detect_recurrent_patterns,
         verbose=verbose,
     )
     # Render in a try/finally so temporary tl_ attributes on the model are
     # always cleaned up, even if Graphviz rendering raises.
     try:
-        model_log.render_graph(
-            vis_mode,
-            vis_nesting_depth,
-            vis_outpath,
-            vis_graph_overrides,
-            vis_node_overrides,
-            vis_nested_node_overrides,
-            vis_edge_overrides,
-            vis_gradient_edge_overrides,
-            vis_module_overrides,
-            vis_save_only,
-            vis_fileformat,
-            vis_buffer_layers,
-            vis_direction,
-            vis_node_placement=vis_node_placement,
-            vis_renderer=vis_renderer,
-            vis_theme=vis_theme,
-        )
+        model_log.render_graph(**visualization_to_render_kwargs(visualization_options))
     finally:
         model_log.cleanup()
 
@@ -620,7 +713,7 @@ def validate_forward_pass(
     1. Run model.forward() *without* TorchLens to get ground-truth output tensors.
     2. Run ``log_forward_pass`` with ``save_function_args=True`` and ``layers_to_save='all'``
        to capture every activation and its creating function's arguments.
-    3. Call ``ModelLog.validate_saved_activations`` which replays the forward pass
+    3. Call ``ModelLog.validate_forward_pass`` which replays the forward pass
        layer-by-layer from saved activations, checking that the output matches
        ground truth.  It also injects random activations and verifies the output
        changes (proving the saved activations are actually used, not just ignored).
@@ -703,7 +796,7 @@ def validate_forward_pass(
     )
     # Step 3: Validate by replaying the forward pass from saved activations.
     try:
-        activations_are_valid = model_log.validate_saved_activations(
+        activations_are_valid = model_log.validate_forward_pass(
             ground_truth_output_tensors, verbose, validate_metadata=validate_metadata
         )
     finally:
@@ -718,17 +811,18 @@ def validate_saved_activations(
     input_kwargs: Optional[Dict[Any, Any]] = None,
     random_seed: Union[int, None] = None,
     verbose: bool = False,
+    validate_metadata: bool = True,
 ) -> bool:
-    """Deprecated: use ``validate_forward_pass`` instead."""
-    import warnings
+    """Deprecated alias for :func:`validate_forward_pass`."""
 
-    warnings.warn(
-        "validate_saved_activations is deprecated, use validate_forward_pass instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    warn_deprecated_alias("validate_saved_activations", "validate_forward_pass")
     return validate_forward_pass(
-        model, input_args, input_kwargs, random_seed=random_seed, verbose=verbose
+        model,
+        input_args,
+        input_kwargs,
+        random_seed=random_seed,
+        verbose=verbose,
+        validate_metadata=validate_metadata,
     )
 
 

--- a/torchlens/visualization/rendering.py
+++ b/torchlens/visualization/rendering.py
@@ -38,6 +38,12 @@ from typing import Any, Optional, Dict, List, Set, TYPE_CHECKING, Tuple, Union
 
 import graphviz
 
+from .._literals import (
+    VisDirectionLiteral,
+    VisModeLiteral,
+    VisNodePlacementLiteral,
+    VisRendererLiteral,
+)
 from ..data_classes.internal_types import VisualizationOverrides
 from ..utils.display import in_notebook, int_list_to_compact_str, _vprint
 from ..data_classes.layer_pass_log import LayerPassLog
@@ -69,7 +75,7 @@ COMMUTE_FUNCS = ["add", "mul", "cat", "eq", "ne"]
 
 def render_graph(
     self: "ModelLog",
-    vis_mode: str = "unrolled",
+    vis_mode: VisModeLiteral = "unrolled",
     vis_nesting_depth: int = 1000,
     vis_outpath: str = "modelgraph",
     vis_graph_overrides: Optional[Dict] = None,
@@ -81,9 +87,9 @@ def render_graph(
     vis_save_only: bool = False,
     vis_fileformat: str = "pdf",
     show_buffer_layers: bool = False,
-    direction: str = "bottomup",
-    vis_node_placement: str = "auto",
-    vis_renderer: str = "graphviz",
+    direction: VisDirectionLiteral = "bottomup",
+    vis_node_placement: VisNodePlacementLiteral = "auto",
+    vis_renderer: VisRendererLiteral = "graphviz",
     vis_theme: str = "torchlens",
 ) -> str:
     """Render the computational graph as a Graphviz Digraph.


### PR DESCRIPTION
## Summary

End-to-end UX cleanup sprint. All changes additive — no breakage, old names keep working with `DeprecationWarning`.

| Commit | What |
|---|---|
| `b82f176` | Inlined 19 cross-file ModelLog method bindings (`model_log.py:706-724` pattern) into explicit `def X(self, ...)` methods + new `data_classes/_lookup_keys.py` to break a latent circular import |
| `6a64cf1` | New `ModelLog.summary()` with 5 presets (`overview`/`graph`/`memory`/`control_flow`/`cost`), compact `__repr__`, top-level `torchlens.summary()` convenience |
| `1d737b7` | Renames (`get_model_metadata` → `log_model_metadata`, `num_context_lines` → `source_context_lines`, `mark_input_output_distances` → `compute_input_output_distances`, `detect_loops` → `detect_recurrent_patterns`, `ModelLog.validate_saved_activations` → `.validate_forward_pass`) + `VisualizationOptions` / `StreamingOptions` dataclasses (replace 16+3 flat kwargs) |
| `46a8555` | Defaults docstring clarifications (`detect_recurrent_patterns` speedup note, `save_source_context` identity-fields-always-captured split, `keep_unsaved_layers` usage example) + regression guard tests |

## Key design decisions

- **Additive only.** Old names all continue to work and emit `DeprecationWarning` once per name per process. Removals gated on a future major release.
- **No defaults flipped.** The audit concluded every current default is well-placed. Three docstrings improved instead.
- **Scope tightened where the adversarial review flagged risk:**
  - Field renames (`activation_ref`, `gradient_ref`, `io_role`) dropped — they persist in bundles and would need a serialization migration plan.
  - Class renames (`LayerPassLog` → `OperationLog`) deferred — too much ecosystem churn.
  - Literal value renames skipped — established vocabulary.
  - `CaptureOptions` / `ValidationOptions` deferred — deeper semantic coupling; ship the two safest groups first.
- **Summary preset fidelity:** dropped invented columns that would have overclaimed:
  - Removed `% of peak` from `memory` preset (no live-alloc tracking in TorchLens).
  - Removed `Device` column from `cost` preset (only `output_device`, not per-op execution device).
- **`torchlens/_summary/`** is underscore-prefixed to avoid shadowing `torchlens.summary` the function.
- **Per-function visualization defaults**: `log_forward_pass` defaults to `mode="none"`; `show_model_graph` defaults to `mode="unrolled"` (matches prior behavior).

## Sample of the new UX

```python
>>> log = tl.log_forward_pass(resnet18(weights=None), x, layers_to_save=None)
>>> log
<ModelLog ResNet>
layers=111 params=11.7 M ops=69 saved=0 B forward=1.536s

>>> print(log.summary(level="overview", max_rows=8))
Model: ResNet
+---------------------+----------------+---------+-------+
| Layer               | Output Shape   | Params  | Train |
+---------------------+----------------+---------+-------+
| input               | [1,3,224,224]  | 0       | -     |
| conv1 (Conv2d)      | [1,64,112,112] | 9.4 K   | yes   |
| bn1 (BatchNorm2d)   | [1,64,112,112] | 128     | yes   |
| ...                                                   |
+---------------------+----------------+---------+-------+
Params: 11,689,512 unique; trainable: 11,689,512
Ops: 69 total
Forward FLOPs: 3.6 B  MACs: 1.8 B

>>> tl.show_model_graph(model, x, visualization=VisualizationOptions(mode="rolled"))
```

Mixing flat + grouped for the same field raises `TypeError`:
```python
>>> tl.log_forward_pass(..., visualization=VisualizationOptions(mode="rolled"), vis_mode="unrolled")
TypeError: Do not pass both `vis_mode` and `visualization.mode`.
```

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy torchlens/` — no issues (66 source files)
- [x] `pytest tests/ -m smoke -x --tb=short` — 28 passed
- [x] `pytest tests/test_summary.py` — 11 new tests passed
- [x] `pytest tests/test_api_renames.py` — 61 new tests passed
- [x] `pytest tests/test_defaults.py` — 7 new tests passed
- [x] `pytest tests/test_cross_file_refactor.py` — AST guard passes
- [x] `pytest tests/ -m "not slow" -x` — **1144 passed, 21 skipped, 189 deselected**
- [x] Live smoke: all 5 presets render correctly on resnet18; DeprecationWarnings fire exactly once per renamed kwarg.

## Follow-ups (not in this PR)

1. Field renames (`activation_ref` → `lazy_activation_ref`, etc.) — needs bundle serialization migration plan. Target 2.0.
2. `CaptureOptions` + `ValidationOptions` groups — ship after feedback on `VisualizationOptions`/`StreamingOptions`.
3. `ModelLog.__init__` constructor default for `mark_input_output_distances` — still `True` internally while public wrapper resolves `False`. Minor follow-up (visible only when instantiating `ModelLog` directly).
4. Test suite still exercises old flat kwargs → expected DeprecationWarning noise. Migrate opportunistically or add `pytest.mark.filterwarnings` scope.