### PR TITLE
feat(robustness): PR1 correctness guards + torch>=2.4 floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,15 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "numpy",
     "pandas",
-    "torch",
+    # torch>=2.4 required: torch.is_autocast_enabled(device_type) and
+    # torch.get_autocast_dtype(device_type) (used in torchlens/utils/rng.py)
+    # only accept a device_type argument on torch 2.4+.
+    "torch>=2.4",
     "safetensors>=0.4",
     "tqdm",
     "ipython",

--- a/tests/test_robustness_pr1.py
+++ b/tests/test_robustness_pr1.py
@@ -1,0 +1,218 @@
+"""Robustness sprint PR 1 — regression coverage for correctness guards.
+
+Covers:
+    - Nested ``log_forward_pass`` / ``active_logging`` must raise rather than
+      silently corrupt the outer ModelLog.
+    - functorch / vmap / grad transforms emit a one-shot UserWarning so the
+      user knows their log is incomplete (rather than silently empty).
+    - pyproject pins ``torch>=2.4`` (matching the autocast API already in use)
+      and advertises Python 3.13 support.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens import _state
+
+
+class _Tiny(nn.Module):
+    """Two-layer model small enough to log cheaply in many test variations."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = nn.Linear(4, 4)
+        self.b = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.b(torch.relu(self.a(x)))
+
+
+# ---------------------------------------------------------------------------
+# Nested log_forward_pass guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_nested_active_logging_raises_runtime_error() -> None:
+    """Entering ``active_logging`` while one is already active must raise.
+
+    Previously this silently overwrote ``_active_model_log`` and cleared it on
+    inner exit, corrupting the outer log mid-pass. The guard turns silent
+    data corruption into a loud error.
+    """
+    outer = object()  # active_logging only reads the reference; None sentinel
+    inner = object()
+
+    with pytest.raises(RuntimeError, match="not re-entrant"):
+        with _state.active_logging(outer):  # type: ignore[arg-type]
+            with _state.active_logging(inner):  # type: ignore[arg-type]
+                pass
+
+
+@pytest.mark.smoke
+def test_nested_log_forward_pass_via_forward_hook_raises() -> None:
+    """A user forward hook that calls log_forward_pass must fail loudly.
+
+    This is the realistic nested-logging trigger: the hook runs during the
+    outer's ``active_logging`` context (during the forward pass, inside the
+    decorated wrapper), so the inner ``log_forward_pass`` hits the guard.
+    """
+    outer = _Tiny()
+    inner_model = _Tiny()
+    x = torch.randn(2, 4)
+
+    def evil_hook(_module, _inputs, _output):
+        tl.log_forward_pass(inner_model, x)
+
+    outer.a.register_forward_hook(evil_hook)
+
+    with pytest.raises(RuntimeError, match="not re-entrant"):
+        tl.log_forward_pass(outer, x, layers_to_save="none")
+
+
+def test_logging_state_cleared_after_guard_fires() -> None:
+    """After the nested-call guard raises, the outer session must still exit cleanly."""
+    model = _Tiny()
+    x = torch.randn(2, 4)
+
+    with pytest.raises(RuntimeError, match="not re-entrant"):
+        with _state.active_logging(object()):  # type: ignore[arg-type]
+            with _state.active_logging(object()):  # type: ignore[arg-type]
+                pass
+
+    assert _state._logging_enabled is False
+    assert _state._active_model_log is None
+
+    # Follow-up forward pass should succeed — the outer `with` cleaned up.
+    log = tl.log_forward_pass(model, x, layers_to_save="none")
+    assert len(log.layer_logs) > 0
+
+
+# ---------------------------------------------------------------------------
+# Functorch / vmap skip-warning
+# ---------------------------------------------------------------------------
+
+
+_HAS_FUNCTORCH_VMAP = hasattr(torch, "func") and hasattr(torch.func, "vmap")
+
+
+@pytest.mark.skipif(not _HAS_FUNCTORCH_VMAP, reason="torch.func.vmap not available")
+def test_vmap_emits_userwarning_once_per_session() -> None:
+    """When a model's forward uses torch.func.vmap, TorchLens skips the inner ops
+    but must warn once so the user knows the log is incomplete.
+    """
+
+    class VmappedSum(nn.Module):
+        """Uses vmap internally but returns a tensor from a normal (loggable) op
+        so the output path still exercises tl_* tagging.
+        """
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            v = torch.func.vmap(lambda row: row.sum())(x)
+            return v + 1  # normal op outside vmap, tagged by TorchLens
+
+    model = VmappedSum()
+    x = torch.randn(4, 8)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(model, x, layers_to_save="none")
+
+    vmap_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "functorch" in str(w.message).lower()
+    ]
+    assert len(vmap_warnings) == 1, (
+        f"Expected exactly one functorch warning, got {len(vmap_warnings)}: "
+        f"{[str(w.message) for w in vmap_warnings]}"
+    )
+
+
+@pytest.mark.skipif(not _HAS_FUNCTORCH_VMAP, reason="torch.func.vmap not available")
+def test_vmap_warning_flag_resets_between_sessions() -> None:
+    """Each call to log_forward_pass starts with a fresh warning flag."""
+
+    class VmappedSum(nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            v = torch.func.vmap(lambda row: row.sum())(x)
+            return v + 1
+
+    model = VmappedSum()
+    x = torch.randn(4, 8)
+
+    with warnings.catch_warnings(record=True) as first:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(model, x, layers_to_save="none")
+    with warnings.catch_warnings(record=True) as second:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(model, x, layers_to_save="none")
+
+    first_count = sum(1 for w in first if "functorch" in str(w.message).lower())
+    second_count = sum(1 for w in second if "functorch" in str(w.message).lower())
+    assert first_count == 1
+    assert second_count == 1, "warning flag should reset between sessions"
+
+
+def test_non_vmap_forward_pass_emits_no_functorch_warning() -> None:
+    """A normal forward pass must not produce spurious functorch warnings."""
+    model = _Tiny()
+    x = torch.randn(2, 4)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tl.log_forward_pass(model, x, layers_to_save="none")
+
+    functorch_warnings = [w for w in caught if "functorch" in str(w.message).lower()]
+    assert functorch_warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Version floor + classifiers
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_pins_torch_floor() -> None:
+    """The torch dependency must pin >=2.4 — earlier versions lack the autocast
+    API signatures that TorchLens already uses (torch/amp refactor, 2.4).
+    """
+    from pathlib import Path
+
+    try:
+        import tomllib
+    except ImportError:  # python 3.10 fallback
+        import tomli as tomllib  # type: ignore[import-not-found]
+
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    deps = data["project"]["dependencies"]
+    torch_pins = [d for d in deps if d.startswith("torch") and "=" in d]
+    assert torch_pins, f"Expected a pinned torch dependency; got deps={deps}"
+    # The pin should be torch>=2.4 (or higher) — not a bare 'torch'.
+    pin = torch_pins[0]
+    assert ">=2.4" in pin or ">=2.5" in pin or ">=2.6" in pin, f"torch floor too loose: {pin!r}"
+
+
+def test_pyproject_advertises_python_313_classifier() -> None:
+    """Python 3.13 is stable and torch 2.5+ supports it; classifier should reflect that."""
+    from pathlib import Path
+
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[import-not-found]
+
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    classifiers = data["project"]["classifiers"]
+    assert "Programming Language :: Python :: 3.13" in classifiers

--- a/torchlens/_state.py
+++ b/torchlens/_state.py
@@ -149,6 +149,11 @@ _collect_usage_stats: bool = False
 ``_function_call_counts`` during logged forward passes.  Used by the
 test suite to verify ArgSpec lookup table coverage."""
 
+_functorch_warning_emitted: bool = False
+"""True if a warning about skipped functorch/vmap ops has been emitted for
+the current logging session.  Reset to False at the start of every
+``active_logging()`` context so each forward pass gets at most one warning."""
+
 _function_call_counts: Dict[str, int] = {}
 """func_name -> total calls across all logged forward passes."""
 
@@ -193,12 +198,25 @@ def active_logging(model_log: "ModelLog"):
         - On exit: clear the toggle *before* the model_log, for the same reason.
 
     This context manager is NOT nestable.  Only one forward pass may be logged
-    at a time (single-threaded design).
+    at a time (single-threaded design).  Entering a second ``active_logging``
+    while another is already active raises ``RuntimeError`` — silently
+    corrupting the outer log (overwriting ``_active_model_log`` and then
+    clearing it on inner exit) is worse than failing loudly.
     """
-    global _logging_enabled, _active_model_log
+    global _logging_enabled, _active_model_log, _functorch_warning_emitted
+    if _logging_enabled:
+        raise RuntimeError(
+            "torchlens.log_forward_pass / active_logging is not re-entrant: "
+            "another forward pass is already being logged. Nested logging "
+            "would silently corrupt the outer ModelLog. If you need to log a "
+            "model's forward pass from inside another log_forward_pass call "
+            "(e.g., a custom activation_postfunc), first drop out with "
+            "torchlens.pause_logging()."
+        )
     # Model log must be visible before the toggle flips — wrappers will
     # immediately read _active_model_log once _logging_enabled is True.
     _active_model_log = model_log
+    _functorch_warning_emitted = False
     _logging_enabled = True
     try:
         yield

--- a/torchlens/decoration/torch_funcs.py
+++ b/torchlens/decoration/torch_funcs.py
@@ -344,7 +344,21 @@ def torch_func_decorator(func: Callable, func_name: str):
         # Skip logging inside vmap/functorch transforms — internal TorchLens
         # operations (safe_copy, torch.equal, .item()) don't have vmap batching
         # rules and will crash. The original function is already vmap-compatible.
+        # Warn once per forward pass so the user knows their ModelLog is
+        # missing whatever runs inside the transform.
         if _is_inside_functorch_transform():
+            if not _state._functorch_warning_emitted:
+                _state._functorch_warning_emitted = True
+                import warnings
+
+                warnings.warn(
+                    "TorchLens detected a functorch/vmap/grad/jacfwd transform "
+                    "during this forward pass. Operations that run inside the "
+                    "transform are not logged. The returned ModelLog will only "
+                    "contain operations that ran OUTSIDE the transform.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             return func(*args, **kwargs)
 
         # Usage stats: count every decorated function call during logging.


### PR DESCRIPTION
## Summary

Wave 1 of 4 in the robustness sprint. Correctness-critical hardening only; no behavior change for non-pathological forward passes.

### What changes
- **Re-entrant `active_logging()` guard** — nested entry raises `RuntimeError` instead of silently corrupting the outer `ModelLog` (the docstring already declared the context non-nestable; now the runtime enforces it). Realistic trigger: a user forward-hook or activation pipeline that calls `log_forward_pass` on a sub-model.
- **functorch/vmap skip warning** — inside `vmap`/`grad`/`jacfwd`, TorchLens continues to skip logging (internal ops like `safe_copy` have no vmap batching rules), but now emits a one-shot `UserWarning` per forward pass so users know the resulting log omits whatever ran inside the transform.
- **`torch>=2.4` dependency pin** — `torchlens/utils/rng.py` already calls `torch.is_autocast_enabled(device_type)` and `torch.get_autocast_dtype(device_type)`, which only accept the device argument from torch 2.4+. The bare `torch` dep was permitting installs that would fail at runtime on older torch.
- **Python 3.13 classifier** — stable since 2024-10, supported by torch 2.5+.

### Motivation
Claude catalog identified 25 runtime contexts where TorchLens can fail; this PR takes the correctness-critical subset (silent data corruption on nested calls, silent empty log on vmap) and the easy version-floor cleanup. The bigger TABLE_WITH_GUARD items ship in PR 2-4.

### Tests
New `tests/test_robustness_pr1.py` (8 cases):
- direct `active_logging` nesting raises with the non-re-entrant message
- a forward-hook that re-enters `log_forward_pass` raises and the outer session state cleans up
- a vmap-containing forward pass emits exactly one functorch warning per session; flag resets between sessions
- non-vmap passes emit no functorch warning
- pyproject torch dep pins `>=2.4` and Python 3.13 is a classifier

### Verification
- `pytest tests/ -m smoke` — 30/30 ✅
- `pytest tests/test_decoration.py tests/test_internals.py tests/test_defaults.py tests/test_api_renames.py tests/test_cross_file_refactor.py tests/test_robustness_pr1.py` — 209/209 ✅
- `ruff check .` ✅
- `mypy torchlens/` — 66 files clean ✅

## Test plan
- [x] Nested-call guard fires from both direct context-manager and forward-hook triggers
- [x] Functorch warning appears once per session, not per operation
- [x] Non-vmap passes emit no functorch warning (no spurious noise)
- [x] Outer session state cleans up after guard fires so subsequent calls work
- [x] `torch>=2.4` pin validated in pyproject
- [x] Python 3.13 classifier validated in pyproject