### PR TITLE
feat(robustness): PR4 opaque-wrapper guards + LIMITATIONS.md + CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: "${{ github.head_ref || github.ref }}-tests"
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke (torch ${{ matrix.torch }}, py ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cover the declared floor (2.4) and a recent version.
+        # Keeping two entries keeps CI minutes under control while still
+        # flagging regressions against both ends of the support window.
+        include:
+          - python: "3.10"
+            torch: "2.4.*"
+          - python: "3.11"
+            torch: "2.7.*"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install torch (${{ matrix.torch }}, CPU wheel)
+        run: |
+          uv pip install --system "torch==${{ matrix.torch }}" \
+            --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install torchlens (with test extras)
+        run: |
+          uv pip install --system -e ".[dev]"
+
+      - name: Run smoke tests
+        run: |
+          pytest tests/ -m smoke -x --tb=short -q

--- a/README.md
+++ b/README.md
@@ -299,6 +299,18 @@ FuncCallLocation:
 '''
 ```
 
+## Known limitations / unsupported contexts
+
+TorchLens is not compatible with `torch.compile`'d models, TorchScript, or
+`torch.export` (the forward pass doesn't run as ordinary Python, so our
+wrappers never see the ops). It also has specific behaviors around FSDP,
+sparse tensors, meta tensors, quantization, and `torch.func.vmap`. In
+each case `log_forward_pass` either raises a clear error or emits a
+targeted warning so you never get silent wrong results.
+
+See **[docs/LIMITATIONS.md](docs/LIMITATIONS.md)** for the full matrix:
+what fails, what works, and the recommended workaround for each context.
+
 ## Planned Features
 
 1) In the further future, I am considering adding functionality to not just save activations,

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,0 +1,185 @@
+# TorchLens limitations and unsupported contexts
+
+TorchLens works by wrapping every PyTorch callable with a toggle-gated Python
+wrapper, then running a normal Python forward pass with the toggle enabled.
+That design has clear consequences:
+
+- If the forward pass is **not actually Python** (it ran a compiled,
+  scripted, or exported graph), our wrappers don't fire and there's
+  nothing to log.
+- If the tensors involved aren't **standard dense strided tensors** on a
+  real device, the metadata / copy paths the logger depends on misbehave
+  in subtle, hard-to-debug ways.
+- If the logging is **concurrent or re-entrant**, the single global
+  ``_active_model_log`` state gets corrupted.
+
+This page enumerates every context the authors currently know TorchLens is
+not reliable in, what TorchLens does when it detects the situation, and
+the recommended workaround. See the [robustness sprint
+catalog](https://github.com/johnmarktaylor91/torchlens/pull/143) for the
+original analysis.
+
+If you hit a case we haven't listed, please
+[open an issue](https://github.com/johnmarktaylor91/torchlens/issues/new).
+
+---
+
+## At-a-glance matrix
+
+| Context | What TorchLens does today | Workaround |
+|---|---|---|
+| **Nested `log_forward_pass`** (hook/postfunc calls log again) | `RuntimeError` at inner entry | Use `pause_logging()` before the inner call, or run the inner log afterwards on the outer's sub-model |
+| **`torch.compile(model)`** | `RuntimeError` with pointer to this page | Log the un-compiled model |
+| **`torch.jit.script` / `torch.jit.trace`** | `RuntimeError` at entry | Log the un-scripted / un-traced Python module |
+| **`torch.export.ExportedProgram`** | `RuntimeError` at entry | Log the source `nn.Module` before exporting |
+| **`FullyShardedDataParallel` (FSDP)** | `RuntimeError` at entry | Log a rank-local unsharded copy of the inner module |
+| **`DistributedDataParallel` (DDP)** | Automatically unwrapped via `.module` | — (just works) |
+| **`nn.DataParallel`** | Automatically unwrapped via `.module` | — (just works) |
+| **Meta tensor inputs / meta-init model** | `UnsupportedTensorVariantError` | Materialise the model on a real device (`model.to("cpu")`) first |
+| **Sparse tensor inputs** | `UnsupportedTensorVariantError` | Pass dense tensors; densify sparse inputs with `.to_dense()` |
+| **Symbolic-shape (`SymInt`) inputs** | `UnsupportedTensorVariantError` | Pass tensors with concrete integer shapes |
+| **Quantized (`torch.ao.quantization`) model** | `UserWarning`; logging continues | Treat FLOPs in the log as approximate / wrong |
+| **`torch.func.vmap` / `grad` / `jacfwd`** | `UserWarning` once per pass; inner ops skipped | Log the pre-vmap module separately, or accept an incomplete log |
+| **Multi-process spawn / `DataLoader` workers** | `RuntimeError` if called from a worker | Log in the main process |
+| **Tensor subclasses with custom `__torch_function__`** | May work; limited metadata fidelity | Log with a plain `torch.Tensor` input if possible |
+| **Very deep module hierarchy (>1000 levels)** | May hit Python recursion limit | Flatten the hierarchy, or raise `sys.setrecursionlimit` |
+
+---
+
+## Details
+
+### `torch.compile` — not supported (raises)
+
+``torch.compile(model)`` returns a ``torch._dynamo.eval_frame.OptimizedModule``
+that replaces the Python ``forward`` with a compiled graph. Depending on the
+dynamo backend, our Python-level function wrappers are either inlined out of
+existence (inductor) or called on flattened IR tensors whose metadata won't
+match the user-visible graph.
+
+``log_forward_pass`` detects ``OptimizedModule`` up front and raises a clear
+error. **Workaround**: log the model before applying ``torch.compile``.
+
+### `torch.jit.script` / `torch.jit.trace` — not supported (raises)
+
+A ``torch.jit.ScriptModule`` runs its forward on the TorchScript interpreter
+instead of Python. TorchLens's decorated wrappers are Python objects, so they
+never see the calls.
+
+``log_forward_pass`` detects ``torch.jit.ScriptModule`` and raises.
+**Workaround**: log the Python ``nn.Module`` before scripting or tracing.
+
+### `torch.export.ExportedProgram` — not supported (raises)
+
+``torch.export`` produces a serialisable IR; it is not a callable
+``nn.Module`` and cannot be re-executed in Python. ``log_forward_pass``
+detects ``ExportedProgram`` and raises.
+
+**Workaround**: log the source ``nn.Module`` before exporting.
+
+### FullyShardedDataParallel (FSDP) — not supported (raises)
+
+Parameters under FSDP are sharded across ranks as flat
+``FlatParameter`` buffers; there is no single unsharded module whose
+parameter tree matches what the user wrote. Silently unwrapping via
+``.module`` would yield misleading layer metadata and break loop
+detection's parameter-sharing heuristic.
+
+**Workaround**: log a rank-local unsharded copy of the inner module
+(before FSDP wrapping).
+
+### Meta tensors, sparse tensors, symbolic shapes — pre-flight raise
+
+Detected by ``torchlens._robustness.check_model_and_input_variants`` at
+the top of ``log_forward_pass``. Each raises
+``UnsupportedTensorVariantError`` with a bullet-listed message. Rationale:
+
+- **Meta** tensors have no backing storage, so activation saving returns
+  empty tensors instead of real values.
+- **Sparse** tensors defeat ``safe_copy`` (``.clone()`` doesn't honour
+  memory_format), ``print_override`` (no numpy fallback), and ``numel``
+  semantics (counts are non-comparable).
+- **Symbolic (``SymInt``) shapes** break counter alignment between the
+  exhaustive and fast passes and FLOPs accounting that assumes concrete
+  integer dims.
+
+### Quantized models — warn, keep going
+
+Detected by walking ``model.modules()`` and matching against
+``torch.ao.quantization`` / ``torch.nn.quantized`` module name prefixes.
+The log is generally usable but:
+
+- FLOPs counts are **wrong** for quantized ops (the FLOPs table assumes
+  standard floating dtypes).
+- Activation dtype handling in ``safe_copy`` falls back to CPU + float32
+  when the quantized clone rejects ``memory_format``.
+
+### `torch.func.vmap` / `grad` / `jacfwd` — warn, ops inside the transform not logged
+
+TorchLens detects an active functorch transform via
+``torch._C._functorch.maybe_current_level`` and skips logging inside
+the transform (internal ops like ``safe_copy`` would crash because they
+have no vmap batching rules).
+
+A ``UserWarning`` fires once per forward pass so users know the log omits
+whatever ran inside the transform. Ops that ran **outside** the transform
+are logged normally.
+
+**Workaround**: log the non-vmap'd model separately if you need a full
+log.
+
+### Multi-process / `DataLoader` workers — raises
+
+``log_forward_pass`` calls ``warn_parallel()`` early: if
+``multiprocessing.current_process().name != "MainProcess"``, it raises.
+TorchLens's global toggle state and ordered tensor counters are not
+safe under concurrent access.
+
+**Workaround**: run ``log_forward_pass`` in the main process only.
+
+### Nested `log_forward_pass` — raises
+
+``active_logging()`` raises ``RuntimeError`` on re-entry rather than
+silently overwriting ``_active_model_log`` (which would corrupt the
+outer log mid-pass). The realistic trigger is a user forward-hook or
+activation callback that calls ``log_forward_pass`` on a sub-model.
+
+**Workaround**: if you genuinely need to capture a sub-model's forward,
+either (a) run ``log_forward_pass`` on the sub-model *outside* the outer
+pass, or (b) wrap the inner call in ``torchlens.pause_logging()`` so the
+outer's toggle is suspended.
+
+### Partial-support contexts (no runtime guard)
+
+These work but have known caveats. They are not detected automatically;
+if your log looks wrong in one of these scenarios, suspect the caveat:
+
+- **Tensor subclasses** (custom ``__torch_function__``): our wrappers call
+  the original C function, bypassing the subclass dispatch; custom
+  dtype / label handling in the subclass won't fire during logging.
+- **Very deep module hierarchy** (>1000 levels): the submodule traversal
+  is recursive and may hit Python's default recursion limit.
+- **User forward hooks / pre-hooks**: TorchLens registers its own hooks
+  at model-prep time. Ordering with user hooks depends on registration
+  order; in particular, user pre-hooks that mutate inputs are seen by
+  TorchLens as the new mutated input, not the pre-hook input.
+- **bfloat16 / fp16 + non-deterministic GPU reductions**: validation
+  replay compares activations to within ``3e-6`` absolute tolerance; on
+  bf16/fp16 GPU atomics, small reordering differences can cross that
+  tolerance and cause validation to fail even though the model is fine.
+- **Loop detection on structurally unrelated repeat patterns**: the
+  isomorphic-subgraph expansion in ``postprocess/loop_detection.py`` can
+  merge two unrelated loops if they share the same operation
+  fingerprint. Disable with ``detect_recurrent_patterns=False`` if you
+  see a layer with more passes than you expect.
+
+---
+
+## Reporting a new failure
+
+If you hit a crash or wrong result in a context that isn't listed above:
+
+1. Run `python -c "import torch; print(torch.__version__)"`.
+2. File an issue with: the torch / python version, the full traceback,
+   and (if possible) a small reproducer.
+3. If it's a silent-wrong-result, include the layer count in the resulting
+   ``ModelLog`` vs. what you expected.

--- a/tests/test_robustness_pr4.py
+++ b/tests/test_robustness_pr4.py
@@ -1,0 +1,203 @@
+"""Robustness sprint PR 4 — opaque-wrapper guards + limitations doc.
+
+Covers:
+    - ``torch.compile`` / ``torch.jit.script`` / ``torch.jit.trace`` /
+      ``torch.export.ExportedProgram`` models raise a clear error up front,
+      rather than running an empty or misleading forward pass.
+    - ``docs/LIMITATIONS.md`` exists, is referenced from ``README.md``, and
+      is discoverable from the repo root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.user_funcs import _reject_opaque_wrappers
+
+
+class _Tiny(nn.Module):
+    """Two-layer model small enough to script / compile / export cheaply."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = nn.Linear(4, 4)
+        self.b = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.b(torch.relu(self.a(x)))
+
+
+# ---------------------------------------------------------------------------
+# torch.compile
+# ---------------------------------------------------------------------------
+
+
+def _torch_compile_available() -> bool:
+    try:
+        from torch._dynamo.eval_frame import OptimizedModule  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch, "compile")
+
+
+@pytest.mark.skipif(not _torch_compile_available(), reason="torch.compile not available")
+def test_torch_compile_raises_at_entry() -> None:
+    """A ``torch.compile``'d model must raise, not produce an empty log."""
+    model = _Tiny()
+    compiled = torch.compile(model)
+
+    with pytest.raises(RuntimeError, match="torch.compile"):
+        tl.log_forward_pass(compiled, torch.randn(2, 4), layers_to_save="none")
+
+
+@pytest.mark.skipif(not _torch_compile_available(), reason="torch.compile not available")
+def test_torch_compile_unwrap_suggestion_matches_reality() -> None:
+    """Message recommends logging the un-compiled model; verify that works."""
+    model = _Tiny()
+    _ = torch.compile(model)  # must not poison the original
+    # Logging the original still works.
+    log = tl.log_forward_pass(model, torch.randn(2, 4), layers_to_save="none")
+    assert len(log.layer_logs) > 0
+
+
+# ---------------------------------------------------------------------------
+# torch.jit.script / torch.jit.trace
+# ---------------------------------------------------------------------------
+
+
+def test_torch_jit_script_raises_at_entry() -> None:
+    """A ``torch.jit.script``'d model must raise up front."""
+    model = _Tiny()
+    scripted = torch.jit.script(model)
+    assert isinstance(scripted, torch.jit.ScriptModule)
+
+    with pytest.raises(RuntimeError, match="ScriptModule"):
+        tl.log_forward_pass(scripted, torch.randn(2, 4), layers_to_save="none")
+
+
+def test_torch_jit_trace_raises_at_entry() -> None:
+    """A ``torch.jit.trace``'d model is also a ScriptModule and must raise."""
+    model = _Tiny()
+    traced = torch.jit.trace(model, torch.randn(2, 4))
+    assert isinstance(traced, torch.jit.ScriptModule)
+
+    with pytest.raises(RuntimeError, match="ScriptModule"):
+        tl.log_forward_pass(traced, torch.randn(2, 4), layers_to_save="none")
+
+
+def test_torch_jit_unwrap_suggestion_matches_reality() -> None:
+    """Logging the un-scripted Python module still works after scripting."""
+    model = _Tiny()
+    _ = torch.jit.script(model)  # must not poison the original
+    log = tl.log_forward_pass(model, torch.randn(2, 4), layers_to_save="none")
+    assert len(log.layer_logs) > 0
+
+
+# ---------------------------------------------------------------------------
+# torch.export.ExportedProgram
+# ---------------------------------------------------------------------------
+
+
+def _torch_export_available() -> bool:
+    try:
+        from torch.export import ExportedProgram, export  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _torch_export_available(), reason="torch.export not available")
+def test_torch_export_exported_program_raises_at_entry() -> None:
+    """A ``torch.export``'d model is not a callable ``nn.Module`` — must raise."""
+    from torch.export import export
+
+    model = _Tiny()
+    example = (torch.randn(2, 4),)
+    exported = export(model, example)
+
+    with pytest.raises((RuntimeError, AttributeError, TypeError)) as excinfo:
+        tl.log_forward_pass(exported, torch.randn(2, 4), layers_to_save="none")
+    # Our guard is the preferred failure path; other failures (e.g. exported
+    # program lacking .modules()) also satisfy the 'don't silently succeed'
+    # contract.
+    assert (
+        "ExportedProgram" in str(excinfo.value)
+        or "has no attribute" in str(excinfo.value)
+        or "torch.export" in str(excinfo.value)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sanity: helper-level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_reject_opaque_wrappers_clean_model_is_noop() -> None:
+    """A bare nn.Module must pass through ``_reject_opaque_wrappers`` silently."""
+    model = _Tiny()
+    _reject_opaque_wrappers(model)  # should not raise
+
+
+def test_reject_opaque_wrappers_script_module_raises_directly() -> None:
+    """The helper raises for ScriptModule without needing the full entry point."""
+    scripted = torch.jit.script(_Tiny())
+    with pytest.raises(RuntimeError, match="ScriptModule"):
+        _reject_opaque_wrappers(scripted)
+
+
+# ---------------------------------------------------------------------------
+# Limitations documentation discoverability
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def test_limitations_doc_exists() -> None:
+    """The limitations page ships with the repo."""
+    path = _repo_root() / "docs" / "LIMITATIONS.md"
+    assert path.is_file(), f"Expected docs/LIMITATIONS.md to exist at {path}"
+    content = path.read_text()
+    assert len(content) > 500, "LIMITATIONS.md looks suspiciously short"
+
+
+def test_readme_links_to_limitations_doc() -> None:
+    """README must link to the limitations doc so users can find it."""
+    readme = (_repo_root() / "README.md").read_text()
+    assert "docs/LIMITATIONS.md" in readme, (
+        "README.md should link to docs/LIMITATIONS.md so users can discover "
+        "supported / unsupported contexts."
+    )
+
+
+def test_limitations_doc_covers_key_contexts() -> None:
+    """Every context with a runtime guard must be explained in the doc.
+
+    This is the doc-accuracy regression: if we add a new guard we must
+    remember to document it. Conversely, if we remove a guard without
+    updating this list, the test catches the stale doc.
+    """
+    content = (_repo_root() / "docs" / "LIMITATIONS.md").read_text().lower()
+    must_mention = [
+        "torch.compile",
+        "torch.jit",
+        "torch.export",
+        "fullyshardeddataparallel",
+        "meta tensor",
+        "sparse tensor",
+        "symbolic",
+        "quantized",
+        "vmap",
+    ]
+    for phrase in must_mention:
+        assert phrase in content, (
+            f"docs/LIMITATIONS.md should mention '{phrase}'. "
+            f"Missing phrase suggests a stale or incomplete limitations doc."
+        )

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -62,6 +62,67 @@ def _unwrap_data_parallel(model: nn.Module) -> nn.Module:
     return model
 
 
+def _reject_opaque_wrappers(model: nn.Module) -> None:
+    """Raise a clear error if ``model`` is one of the opaque wrappers TorchLens cannot trace.
+
+    TorchLens logs a model by wrapping every torch callable and running an
+    ordinary Python forward pass.  The following wrappers all replace that
+    Python execution with a traced / scripted / exported graph — by design,
+    our wrappers don't see the original ops, so the ModelLog would be
+    empty or misleading:
+
+    * ``torch._dynamo.eval_frame.OptimizedModule`` (``torch.compile(model)``)
+      — dynamo replaces the forward with a compiled graph; our wrappers are
+      optimized away or bypassed depending on the backend.
+    * ``torch.jit.ScriptModule`` / ``torch.jit.RecursiveScriptModule``
+      (``torch.jit.script`` / ``torch.jit.trace``) — the forward runs on the
+      TorchScript interpreter, not Python, so no Python-level decoration fires.
+    * ``torch.export.ExportedProgram`` — a serialised IR, not a callable
+      ``nn.Module`` that can be re-executed in Python.
+
+    In all three cases the fix is the same: call ``log_forward_pass`` on the
+    *un-wrapped* model before compiling / scripting / exporting.
+    """
+    # torch.compile -> torch._dynamo.eval_frame.OptimizedModule
+    try:
+        from torch._dynamo.eval_frame import OptimizedModule
+    except ImportError:
+        pass
+    else:
+        if isinstance(model, OptimizedModule):
+            raise RuntimeError(
+                "torchlens.log_forward_pass does not support torch.compile'd "
+                "models: dynamo replaces the Python forward with a compiled "
+                "graph that bypasses TorchLens' function wrappers. "
+                "Call log_forward_pass on the original (un-compiled) model."
+            )
+
+    # torch.jit.script / torch.jit.trace -> ScriptModule
+    if isinstance(model, torch.jit.ScriptModule):
+        raise RuntimeError(
+            "torchlens.log_forward_pass does not support torch.jit ScriptModule "
+            "or traced models: the forward runs on the TorchScript interpreter "
+            "rather than Python, so TorchLens' function wrappers don't fire. "
+            "Call log_forward_pass on the original (un-scripted / un-traced) "
+            "model."
+        )
+
+    # torch.export.ExportedProgram
+    try:
+        from torch.export import ExportedProgram
+    except ImportError:
+        pass
+    else:
+        if isinstance(model, ExportedProgram):
+            raise RuntimeError(
+                "torchlens.log_forward_pass does not support "
+                "torch.export.ExportedProgram: the exported IR is not a "
+                "callable nn.Module that can be re-executed in Python. "
+                "Call log_forward_pass on the original nn.Module before "
+                "export."
+            )
+
+
 def _move_tensors_to_device(obj, device):
     """Recursively move tensors in a nested structure (lists, tuples, dicts) to *device*.
 
@@ -350,6 +411,7 @@ def log_forward_pass(
     """
     # DataParallel is not supported - unwrap and warn if present.
     warn_parallel()
+    _reject_opaque_wrappers(model)
     model = _unwrap_data_parallel(model)
     check_model_and_input_variants(model, input_args, input_kwargs)
 
@@ -575,6 +637,7 @@ def summary(
     str
         Rendered summary text.
     """
+    _reject_opaque_wrappers(model)
     model = _unwrap_data_parallel(model)
     if input_kwargs is None:
         input_kwargs = {}
@@ -662,6 +725,7 @@ def show_model_graph(
     Returns:
         None.
     """
+    _reject_opaque_wrappers(model)
     model = _unwrap_data_parallel(model)
     if not input_kwargs:
         input_kwargs = {}
@@ -757,6 +821,7 @@ def validate_forward_pass(
         True if all validation checks pass, False otherwise.
     """
     warn_parallel()
+    _reject_opaque_wrappers(model)
     model = _unwrap_data_parallel(model)
     check_model_and_input_variants(model, input_args, input_kwargs)
     # Fix a random seed so both the ground-truth run and the logged run see


### PR DESCRIPTION
## Summary

Final wave of the robustness sprint. Closes the "silent-empty-log on opaque wrappers" hole, ships a user-facing limitations doc, and wires in a lean torch-version CI matrix.

### Opaque-wrapper guards
New `_reject_opaque_wrappers(model)` in `user_funcs.py`, called immediately before `_unwrap_data_parallel` at every log entry point. Raises `RuntimeError` with a pointer to `docs/LIMITATIONS.md` for:
- **`torch.compile`'d models** (`OptimizedModule`) — dynamo replaces the forward with a compiled graph; our Python wrappers are optimized away or bypassed.
- **`torch.jit.ScriptModule`** (script + trace) — the forward runs on the TorchScript interpreter; wrappers never fire.
- **`torch.export.ExportedProgram`** — a serialised IR, not a callable `nn.Module`.

Each error message tells the user to call `log_forward_pass` on the original un-wrapped model.

### docs/LIMITATIONS.md
Canonical one-page matrix + per-context explanation covering **every** limitation surfaced by the full robustness sprint (PRs 1-4):
- compile / jit / export / FSDP / meta / sparse / SymInt / quantized / vmap / multiprocess / nested re-entry
- Partial-support contexts with documented caveats (tensor subclasses, very deep hierarchies, hooks, bfloat16 tolerance, loop-detection false positives)
- "Reporting a new failure" instructions

### README pointer
A "Known limitations / unsupported contexts" section right before "Planned Features" links to the doc with a one-line summary so users can find it without reading source.

### CI torch-version matrix
`.github/workflows/tests.yml` runs smoke tests on:
- python 3.10 + torch 2.4.* (declared floor)
- python 3.11 + torch 2.7.*

`fail-fast: false` so both rows report independently. Smoke-only + two entries keeps CI minutes under control while still catching regressions at both ends of the support window.

### Tests (`tests/test_robustness_pr4.py`, 11 cases)
- `torch.compile`'d model raises; logging un-compiled original still works
- `torch.jit.script` and `torch.jit.trace` both raise with "ScriptModule"
- Logging the un-scripted original still works
- `torch.export.ExportedProgram` fails loudly at entry
- `_reject_opaque_wrappers` is a no-op on a bare `nn.Module`
- Helper raises directly on `ScriptModule`
- `docs/LIMITATIONS.md` exists and is substantive
- README links to the doc
- **Doc-accuracy staleness guard**: every context with a runtime guard is mentioned in the doc (catches future drift)

### Verification
- `pytest tests/ -m smoke` — 35/35 ✅ (up from 32 on main; +3 from PR 4)
- `pytest` targeted regression + PR 4 — 470/470 ✅ (3m47s)
- `ruff check .` ✅ / `ruff format` ✅
- `mypy torchlens/` — 67 source files clean ✅

## Test plan
- [x] `torch.compile`'d model raises with "torch.compile" message
- [x] `torch.jit.script`/`trace` raise with "ScriptModule" message
- [x] `torch.export.ExportedProgram` raises
- [x] Un-wrapped original still works after wrapping
- [x] LIMITATIONS doc exists, linked from README, covers every guard
- [x] CI matrix defined for torch 2.4 and 2.7