### PR TITLE
feat(visualization): focus visualization on a single module

### DIFF
--- a/tests/test_module_focus.py
+++ b/tests/test_module_focus.py
@@ -1,0 +1,244 @@
+"""Tests for single-module focus visualization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.data_classes.layer_log import LayerLog
+
+
+def _render_dot(log: tl.ModelLog, tmp_path: Path, **kwargs: Any) -> str:
+    """Render a ModelLog to DOT using a temporary SVG output path."""
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    return log.render_graph(
+        vis_save_only=True,
+        vis_fileformat="svg",
+        vis_outpath=str(tmp_path / "graph"),
+        **kwargs,
+    )
+
+
+def _boundary_node_count(dot_source: str, kind: str) -> int:
+    """Count synthetic focus boundary node declarations."""
+
+    return sum(
+        1
+        for line in dot_source.splitlines()
+        if f"__module_focus_{kind}_" in line and " [label=" in line
+    )
+
+
+def _layer_labels(log: tl.ModelLog, layer_type: str) -> list[str]:
+    """Return layer labels with the requested layer type."""
+
+    return [
+        layer_log.layer_label
+        for layer_log in log.layer_logs.values()
+        if layer_log.layer_type == layer_type
+    ]
+
+
+class _TwoBlockModel(nn.Module):
+    """Small model with a named focusable block."""
+
+    def __init__(self) -> None:
+        """Initialize modules."""
+
+        super().__init__()
+        self.stem = nn.Linear(4, 4)
+        self.block1 = nn.Sequential(nn.Linear(4, 4), nn.ReLU())
+        self.head = nn.Linear(4, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass."""
+
+        return self.head(self.block1(self.stem(x)))
+
+
+class _NestedFocusBlock(nn.Module):
+    """Focusable module with an internal Sequential."""
+
+    def __init__(self) -> None:
+        """Initialize modules."""
+
+        super().__init__()
+        self.inner = nn.Sequential(nn.Linear(4, 4), nn.ReLU())
+        self.tail = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass."""
+
+        return self.tail(self.inner(x))
+
+
+class _NestedBlock(nn.Module):
+    """Model with an internal Sequential for collapse tests."""
+
+    def __init__(self) -> None:
+        """Initialize modules."""
+
+        super().__init__()
+        self.stem = nn.Linear(4, 4)
+        self.block1 = _NestedFocusBlock()
+        self.head = nn.Linear(4, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass."""
+
+        return self.head(self.block1(self.stem(x)))
+
+
+class _AddBlock(nn.Module):
+    """Focusable block with two external upstream tensors."""
+
+    def __init__(self) -> None:
+        """Initialize modules."""
+
+        super().__init__()
+        self.relu = nn.ReLU()
+
+    def forward(self, left: torch.Tensor, right: torch.Tensor) -> torch.Tensor:
+        """Combine two tensors inside the block."""
+
+        return self.relu(left + right)
+
+
+class _BranchingBoundaryModel(nn.Module):
+    """Model that feeds two external upstreams into one module."""
+
+    def __init__(self) -> None:
+        """Initialize modules."""
+
+        super().__init__()
+        self.left = nn.Linear(4, 4)
+        self.right = nn.Linear(4, 4)
+        self.block = _AddBlock()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass."""
+
+        return self.block(self.left(x), self.right(x))
+
+
+def test_module_focus_by_modulelog(tmp_path: Path) -> None:
+    """Focusing by ModuleLog should show only that module plus boundaries."""
+
+    log = tl.log_forward_pass(_TwoBlockModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, module=log.modules["block1"])
+
+    assert "@block1" in dot
+    assert "\tlinear_1_1 [" not in dot
+    assert "\tlinear_2_4 [" not in dot
+    assert _boundary_node_count(dot, "input") == 1
+    assert _boundary_node_count(dot, "output") == 1
+    assert "input" in dot
+    assert "output" in dot
+
+
+def test_module_focus_by_address_string(tmp_path: Path) -> None:
+    """Focusing by module address should resolve the same module."""
+
+    log = tl.log_forward_pass(_TwoBlockModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, module="block1")
+
+    assert "@block1" in dot
+    assert _boundary_node_count(dot, "input") == 1
+    assert _boundary_node_count(dot, "output") == 1
+
+
+def test_module_focus_invalid_address_raises(tmp_path: Path) -> None:
+    """Unknown module address strings should fail clearly."""
+
+    log = tl.log_forward_pass(_TwoBlockModel(), torch.randn(1, 4))
+
+    with pytest.raises(ValueError, match="nonexistent"):
+        _render_dot(log, tmp_path, module="nonexistent")
+
+
+def test_module_focus_with_collapse_fn(tmp_path: Path) -> None:
+    """Module focus should compose with collapsing a child module."""
+
+    log = tl.log_forward_pass(_NestedBlock(), torch.randn(1, 4))
+
+    def collapse_fn(module_log: Any) -> bool:
+        """Collapse the inner Sequential."""
+
+        return module_log.address == "block1.inner"
+
+    dot = _render_dot(log, tmp_path, module="block1", collapse_fn=collapse_fn)
+
+    assert "@block1.inner" in dot
+    assert "shape=box3d" in dot
+    assert "relu_1_3 [" not in dot
+    assert "linear_3_5 [" not in dot
+
+
+def test_module_focus_with_skip_fn(tmp_path: Path) -> None:
+    """Module focus should compose with skipping internal ReLU layers."""
+
+    log = tl.log_forward_pass(_TwoBlockModel(), torch.randn(1, 4))
+    block_linear = _layer_labels(log, "linear")[1]
+
+    def skip_fn(layer_log: LayerLog) -> bool:
+        """Skip ReLU layers."""
+
+        return layer_log.layer_type == "relu"
+
+    dot = _render_dot(log, tmp_path, module="block1", skip_fn=skip_fn)
+
+    assert "relu_1_3 [" not in dot
+    assert f"{block_linear} -> __module_focus_output_" in dot
+
+
+def test_module_focus_with_skip_and_collapse_fn(tmp_path: Path) -> None:
+    """Module focus should compose with skip_fn and collapse_fn together."""
+
+    log = tl.log_forward_pass(_NestedBlock(), torch.randn(1, 4))
+
+    def skip_fn(layer_log: LayerLog) -> bool:
+        """Skip ReLU layers."""
+
+        return layer_log.layer_type == "relu"
+
+    def collapse_fn(module_log: Any) -> bool:
+        """Collapse the internal tail module."""
+
+        return module_log.address == "block1.tail"
+
+    dot = _render_dot(log, tmp_path, module="block1", skip_fn=skip_fn, collapse_fn=collapse_fn)
+
+    assert "relu_1_3 [" not in dot
+    assert "@block1.tail" in dot
+
+
+def test_modulelog_show_graph_method(tmp_path: Path) -> None:
+    """ModuleLog.show_graph should match ModelLog.render_graph with module=self."""
+
+    log = tl.log_forward_pass(_TwoBlockModel(), torch.randn(1, 4))
+    module_log = log.modules["block1"]
+    direct = _render_dot(log, tmp_path / "direct", module=module_log)
+    method = module_log.show_graph(
+        vis_save_only=True,
+        vis_fileformat="svg",
+        vis_outpath=str(tmp_path / "method" / "graph"),
+    )
+
+    assert method == direct
+
+
+def test_module_focus_branching_boundaries(tmp_path: Path) -> None:
+    """Multiple external upstreams should render as distinct input boundaries."""
+
+    log = tl.log_forward_pass(_BranchingBoundaryModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, module="block")
+
+    assert _boundary_node_count(dot, "input") == 2
+    assert "ext: linear_1_1" in dot
+    assert "ext: linear_2_2" in dot

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from .._io.streaming import BundleStreamWriter
     from .buffer_log import BufferAccessor
     from .layer_log import LayerAccessor
+    from .module_log import ModuleLog
     from ..visualization.dagua_bridge import TorchLensRenderAudit
 
 from .._deprecations import warn_deprecated_alias
@@ -709,6 +710,7 @@ class ModelLog:
         vis_nesting_depth: int = 1000,
         vis_outpath: str = "modelgraph",
         vis_graph_overrides: Optional[Dict] = None,
+        module: "ModuleLog | str | None" = None,
         node_mode: VisNodeModeLiteral = "default",
         node_spec_fn: Optional[Callable] = None,
         collapsed_node_spec_fn: Optional[Callable] = None,
@@ -729,8 +731,8 @@ class ModelLog:
 
         Parameters
         ----------
-        vis_mode, vis_nesting_depth, vis_outpath, vis_graph_overrides, node_mode, node_spec_fn, \
-        collapsed_node_spec_fn, collapse_fn, skip_fn, vis_edge_overrides, \
+        vis_mode, vis_nesting_depth, vis_outpath, vis_graph_overrides, module, node_mode, \
+        node_spec_fn, collapsed_node_spec_fn, collapse_fn, skip_fn, vis_edge_overrides, \
         vis_gradient_edge_overrides, vis_module_overrides, vis_save_only, vis_fileformat, \
         show_buffer_layers, direction, vis_node_placement, vis_renderer, vis_theme:
             Forwarded unchanged to :func:`torchlens.visualization.rendering.render_graph`.
@@ -748,6 +750,7 @@ class ModelLog:
             vis_nesting_depth=vis_nesting_depth,
             vis_outpath=vis_outpath,
             vis_graph_overrides=vis_graph_overrides,
+            module=module,
             node_mode=node_mode,
             node_spec_fn=node_spec_fn,
             collapsed_node_spec_fn=collapsed_node_spec_fn,

--- a/torchlens/data_classes/module_log.py
+++ b/torchlens/data_classes/module_log.py
@@ -32,6 +32,7 @@ from ..constants import MODULE_PASS_LOG_FIELD_ORDER
 from ..utils.display import human_readable_size
 
 if TYPE_CHECKING:
+    from .model_log import ModelLog
     from .param_log import ParamAccessor
 
 
@@ -570,6 +571,30 @@ class ModuleLog:
         if self._source_model_log is None:
             return iter(self.all_layers)
         return iter(self._source_model_log[label] for label in self.all_layers)
+
+    def show_graph(self, **kwargs: Any) -> str:
+        """Render this module's focused graph.
+
+        Parameters
+        ----------
+        **kwargs:
+            Keyword arguments forwarded to ``ModelLog.render_graph``.
+
+        Returns
+        -------
+        str
+            Graphviz DOT source string.
+
+        Raises
+        ------
+        RuntimeError
+            If this ModuleLog is not bound to a ModelLog.
+        """
+
+        model_log: ModelLog | None = self._source_model_log
+        if model_log is None:
+            raise RuntimeError("ModuleLog not bound to a ModelLog")
+        return model_log.render_graph(module=self, **kwargs)
 
     def to_pandas(self) -> "pd.DataFrame":
         """Export this module's layers as a pandas DataFrame.

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -21,7 +21,7 @@ import collections.abc
 import os
 import random
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import torch
@@ -54,6 +54,9 @@ from .utils.arg_handling import normalize_input_args, safe_copy_args, safe_copy_
 from .utils.display import _vprint, warn_parallel
 from .utils.introspection import get_vars_of_type_from_obj
 from .utils.rng import set_random_seed
+
+if TYPE_CHECKING:
+    from .data_classes.module_log import ModuleLog
 
 
 def _unwrap_data_parallel(model: nn.Module) -> nn.Module:
@@ -703,6 +706,7 @@ def show_model_graph(
     vis_nesting_depth: int | MissingType = MISSING,
     vis_outpath: str | MissingType = MISSING,
     vis_graph_overrides: dict[str, Any] | None | MissingType = MISSING,
+    module: "ModuleLog | str | None" = None,
     vis_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
     vis_gradient_edge_overrides: dict[str, Any] | None | MissingType = MISSING,
     vis_module_overrides: dict[str, Any] | None | MissingType = MISSING,
@@ -735,6 +739,8 @@ def show_model_graph(
         vis_nesting_depth: Deprecated alias for ``visualization.max_module_depth``.
         vis_outpath: Deprecated alias for ``visualization.output_path``.
         vis_graph_overrides: Deprecated alias for ``visualization.graph_overrides``.
+        module: Optional module focus. Pass a ModuleLog or module address string
+            to render only layers that ran inside that module.
         vis_edge_overrides: Deprecated alias for ``visualization.edge_overrides``.
         vis_gradient_edge_overrides: Deprecated alias for
             ``visualization.gradient_edge_overrides``.
@@ -812,7 +818,12 @@ def show_model_graph(
     # Render in a try/finally so temporary tl_ attributes on the model are
     # always cleaned up, even if Graphviz rendering raises.
     try:
-        model_log.render_graph(**visualization_to_render_kwargs(visualization_options))
+        render_kwargs = visualization_to_render_kwargs(visualization_options)
+        if module is not None:
+            from .data_classes.module_log import ModuleLog
+
+            render_kwargs["module"] = module.address if isinstance(module, ModuleLog) else module
+        model_log.render_graph(**render_kwargs)
     finally:
         model_log.cleanup()
 

--- a/torchlens/visualization/CLAUDE.md
+++ b/torchlens/visualization/CLAUDE.md
@@ -25,6 +25,22 @@ with Graphviz using an optional ELK layout backend for large graphs.
 - **`vis_mode='unrolled'`**: Shows every pass separately (uses LayerPassLog entries)
 - **`vis_mode='rolled'`**: Collapses repeated layers into single nodes (uses LayerLog)
 
+## Module Focus
+`ModelLog.render_graph(module=...)` and `show_model_graph(..., module=...)` can
+render one module's subgraph in the same visual format as the full model.
+
+- `module=None`: render the whole model.
+- `module="block.address"`: focus the ModuleLog with that address.
+- `module=module_log`: focus that ModuleLog; it must belong to the rendered ModelLog.
+- `ModuleLog.show_graph(**kwargs)`: convenience wrapper for
+  `module_log._source_model_log.render_graph(module=module_log, **kwargs)`.
+
+The focus pass runs before `skip_fn` and `collapse_fn`. It keeps layers whose
+`containing_modules` path includes the target module address, drops outside
+layers, and inserts synthetic green/red boundary nodes for external upstreams
+and downstreams. Child module clusters inside the focused module are still
+available for normal collapse behavior.
+
 ## Node Mode Presets
 `VisualizationOptions.node_mode` applies a built-in NodeSpec preset before any
 user-supplied `node_spec_fn`, so user callbacks always win. Public flat alias:

--- a/torchlens/visualization/rendering.py
+++ b/torchlens/visualization/rendering.py
@@ -31,10 +31,11 @@ Key mechanisms:
   reference absent layers.
 """
 
+import copy
 import subprocess
 import warnings
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -69,7 +70,93 @@ if TYPE_CHECKING:
     from ..data_classes.model_log import ModelLog
     from ..data_classes.module_log import ModuleLog
 
-GraphNode = Union["LayerPassLog", "LayerLog"]
+BaseGraphNode = Union["LayerPassLog", "LayerLog"]
+
+
+@dataclass
+class FocusNode:
+    """Mutable render proxy for a focused LayerLog or LayerPassLog.
+
+    Parameters
+    ----------
+    original:
+        Source graph node whose metadata should be rendered.
+    parent_layers:
+        Focus-rewritten incoming labels.
+    child_layers:
+        Focus-rewritten outgoing labels.
+    containing_modules:
+        Copied module path for cluster placement.
+    """
+
+    original: BaseGraphNode
+    parent_layers: list[str]
+    child_layers: list[str]
+    containing_modules: list[str]
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate unknown attributes to the source node."""
+
+        return getattr(self.original, name)
+
+
+@dataclass
+class BoundaryNode:
+    """Synthetic node representing a focused module boundary.
+
+    Parameters
+    ----------
+    layer_label:
+        DOT-safe synthetic label.
+    display_label:
+        Human-readable label shown in the node.
+    boundary_kind:
+        ``"input"`` for external upstreams, ``"output"`` for external sinks.
+    child_layers:
+        Outgoing rendered labels.
+    parent_layers:
+        Incoming rendered labels.
+    containing_modules:
+        Module path used for cluster placement.
+    """
+
+    layer_label: str
+    display_label: str
+    boundary_kind: str
+    child_layers: list[str]
+    parent_layers: list[str]
+    containing_modules: list[str]
+    is_buffer_layer: bool = False
+    has_input_ancestor: bool = True
+    is_final_output: bool = False
+    is_leaf_module_output: bool = False
+    modules_exited: list[str] = field(default_factory=list)
+    is_input_layer: bool = False
+    is_output_layer: bool = False
+    is_terminal_bool_layer: bool = False
+    uses_params: bool = False
+    num_param_tensors: int = 0
+    parent_param_logs: list[Any] = field(default_factory=list)
+    parent_param_shapes: list[tuple[Any, ...]] = field(default_factory=list)
+    num_passes: int = 1
+    pass_num: int = 1
+    layer_type_num: int = 1
+    layer_total_num: int = 1
+    tensor_shape: tuple[Any, ...] = ()
+    tensor_memory_str: str = "0 B"
+    io_role: str = ""
+    layer_type: str = "input"
+
+    def __post_init__(self) -> None:
+        """Fill mutable defaults and role flags."""
+
+        self.is_input_layer = self.boundary_kind == "input"
+        self.is_output_layer = self.boundary_kind == "output"
+        self.layer_type = self.boundary_kind
+        self.io_role = self.boundary_kind
+
+
+GraphNode = Union[BaseGraphNode, BoundaryNode, FocusNode]
 NodeSpecFn = Callable[["LayerLog", NodeSpec], NodeSpec | None]
 CollapsedNodeSpecFn = Callable[["ModuleLog", NodeSpec], NodeSpec | None]
 CollapseFn = Callable[["ModuleLog"], bool]
@@ -119,6 +206,7 @@ def render_graph(
     vis_nesting_depth: int = 1000,
     vis_outpath: str = "modelgraph",
     vis_graph_overrides: Optional[Dict] = None,
+    module: "ModuleLog | str | None" = None,
     node_mode: VisNodeModeLiteral = "default",
     node_spec_fn: NodeSpecFn | None = None,
     collapsed_node_spec_fn: CollapsedNodeSpecFn | None = None,
@@ -151,6 +239,8 @@ def render_graph(
             Use 0 to show all layers without collapsing.
         vis_outpath: Output file path (extension auto-stripped).
         vis_graph_overrides: Graphviz graph-level attribute overrides.
+        module: Optional module focus. A ModuleLog focuses that module; a string
+            is interpreted as a module address.
         node_mode: Preset applied to default ``NodeSpec`` objects before
             user callbacks run.
         node_spec_fn: Optional callback receiving ``(layer_log, default_spec)``.
@@ -238,11 +328,20 @@ def render_graph(
     # Rolled: iterate LayerLog objects (one node per logical layer, multi-pass
     # collapsed into a single node with edge annotations).
     if vis_mode == "unrolled":
-        entries_to_plot = self.layer_dict_main_keys
+        entries_to_plot: dict[str, GraphNode] = dict(self.layer_dict_main_keys)
     elif vis_mode == "rolled":
-        entries_to_plot = self.layer_logs  # type: ignore[assignment]
+        entries_to_plot = dict(self.layer_logs)
     else:
         raise ValueError("vis_mode must be either 'rolled' or 'unrolled'")
+
+    if module is not None:
+        target_module = _resolve_focus_module(self, module)
+        entries_to_plot = _build_module_focus_entries(
+            self,
+            entries_to_plot,
+            target_module,
+            vis_mode=vis_mode,
+        )
 
     if direction == "bottomup":
         rankdir = "BT"
@@ -460,6 +559,8 @@ def _build_skip_filtered_edge_map(
     skipped_labels: set[str] = set()
     if skip_fn is not None:
         for node in visible_entries.values():
+            if isinstance(node, BoundaryNode):
+                continue
             layer_log = _layer_log_for_node(model_log, node)
             if not skip_fn(layer_log):
                 continue
@@ -481,6 +582,245 @@ def _build_skip_filtered_edge_map(
             vis_mode,
         )
     return edge_map, skipped_labels
+
+
+def _resolve_focus_module(
+    model_log: "ModelLog",
+    module: "ModuleLog | str",
+) -> "ModuleLog":
+    """Resolve and validate a module focus argument.
+
+    Parameters
+    ----------
+    model_log:
+        Model log being rendered.
+    module:
+        ModuleLog instance or module address string.
+
+    Returns
+    -------
+    ModuleLog
+        Module to focus.
+
+    Raises
+    ------
+    ValueError
+        If the module cannot be found or belongs to a different ModelLog.
+    """
+
+    from ..data_classes.module_log import ModuleLog
+
+    if isinstance(module, str):
+        if module not in model_log.modules:
+            raise ValueError(f"Module address '{module}' was not found in this ModelLog.")
+        resolved = model_log.modules[module]
+        if not isinstance(resolved, ModuleLog):
+            raise ValueError(
+                f"Module address '{module}' resolved to a module pass, not a ModuleLog."
+            )
+        return resolved
+    if not isinstance(module, ModuleLog):
+        raise ValueError("module must be a ModuleLog, module address string, or None.")
+    if module._source_model_log is not model_log:
+        raise ValueError("ModuleLog focus must belong to the ModelLog being rendered.")
+    return module
+
+
+def _build_module_focus_entries(
+    model_log: "ModelLog",
+    entries_to_plot: Mapping[str, GraphNode],
+    target_module: "ModuleLog",
+    *,
+    vis_mode: str,
+) -> dict[str, GraphNode]:
+    """Return render entries focused on one module plus synthetic boundaries.
+
+    Parameters
+    ----------
+    model_log:
+        ModelLog being rendered.
+    entries_to_plot:
+        Original entries for the current render mode.
+    target_module:
+        Module whose internal forward operations should be shown.
+    vis_mode:
+        ``"unrolled"`` or ``"rolled"``.
+
+    Returns
+    -------
+    dict[str, GraphNode]
+        Focused entries with boundary nodes inserted.
+
+    Raises
+    ------
+    ValueError
+        If the module contains no rendered layers.
+    """
+
+    focus_labels = {
+        node.layer_label
+        for node in entries_to_plot.values()
+        if _node_is_inside_module(node, target_module.address)
+    }
+    if not focus_labels:
+        raise ValueError(
+            f"Module '{target_module.address}' has no layers to render. "
+            "Empty modules cannot be focused."
+        )
+
+    focused_entries: dict[str, GraphNode] = {
+        label: _copy_focus_node(node)
+        for label, node in entries_to_plot.items()
+        if node.layer_label in focus_labels
+    }
+    input_boundaries: dict[str, BoundaryNode] = {}
+    output_boundaries: dict[str, BoundaryNode] = {}
+
+    for render_node in list(focused_entries.values()):
+        node = cast(FocusNode, render_node)
+        new_parents: list[str] = []
+        for parent_label in node.parent_layers:
+            if parent_label in focus_labels:
+                new_parents.append(parent_label)
+                continue
+            parent_node = entries_to_plot.get(parent_label)
+            if parent_node is None:
+                continue
+            boundary = _get_or_create_boundary_node(
+                input_boundaries,
+                parent_node,
+                target_module,
+                vis_mode=vis_mode,
+                boundary_kind="input",
+                child_label=node.layer_label,
+            )
+            if node.layer_label not in boundary.child_layers:
+                boundary.child_layers.append(node.layer_label)
+            new_parents.append(boundary.layer_label)
+        node.parent_layers = new_parents
+
+        new_children: list[str] = []
+        for child_label in node.child_layers:
+            if child_label in focus_labels:
+                new_children.append(child_label)
+                continue
+            child_node = entries_to_plot.get(child_label)
+            if child_node is None:
+                continue
+            boundary = _get_or_create_boundary_node(
+                output_boundaries,
+                child_node,
+                target_module,
+                vis_mode=vis_mode,
+                boundary_kind="output",
+                parent_label=node.layer_label,
+            )
+            if node.layer_label not in boundary.parent_layers:
+                boundary.parent_layers.append(node.layer_label)
+            new_children.append(boundary.layer_label)
+        node.child_layers = new_children
+
+    _simplify_boundary_labels(input_boundaries, "input")
+    _simplify_boundary_labels(output_boundaries, "output")
+    for boundary_dict in (input_boundaries, output_boundaries):
+        for label, boundary in boundary_dict.items():
+            focused_entries[label] = boundary
+
+    return focused_entries
+
+
+def _node_is_inside_module(node: GraphNode, module_address: str) -> bool:
+    """Return whether ``node`` ran inside ``module_address``."""
+
+    return any(module.split(":", 1)[0] == module_address for module in node.containing_modules)
+
+
+def _unwrap_focus_node(node: GraphNode) -> GraphNode:
+    """Return the source node behind a focus proxy."""
+
+    if isinstance(node, FocusNode):
+        return node.original
+    return node
+
+
+def _base_node_for_metadata(node: GraphNode) -> BaseGraphNode:
+    """Return a non-boundary graph node for metadata helpers."""
+
+    unwrapped = _unwrap_focus_node(node)
+    if isinstance(unwrapped, BoundaryNode):
+        raise ValueError("Boundary nodes do not carry edge metadata.")
+    return cast(BaseGraphNode, unwrapped)
+
+
+def _copy_focus_node(node: GraphNode) -> GraphNode:
+    """Return a shallow render copy whose edge lists can be rewritten."""
+
+    if isinstance(node, BoundaryNode):
+        return copy.copy(node)
+    if isinstance(node, FocusNode):
+        original = node.original
+    else:
+        original = node
+    return FocusNode(
+        original=original,
+        parent_layers=list(node.parent_layers),
+        child_layers=list(node.child_layers),
+        containing_modules=list(node.containing_modules),
+    )
+
+
+def _get_or_create_boundary_node(
+    boundary_nodes: dict[str, BoundaryNode],
+    external_node: GraphNode,
+    target_module: "ModuleLog",
+    *,
+    vis_mode: str,
+    boundary_kind: str,
+    child_label: str | None = None,
+    parent_label: str | None = None,
+) -> BoundaryNode:
+    """Create or return a boundary node for one external layer."""
+
+    external_label = external_node.layer_label.replace(":", "pass")
+    boundary_label = f"__module_focus_{boundary_kind}_{external_label}"
+    boundary = boundary_nodes.get(boundary_label)
+    if boundary is not None:
+        return boundary
+
+    module_path = _boundary_module_path(target_module, vis_mode)
+    boundary = BoundaryNode(
+        layer_label=boundary_label,
+        display_label=f"ext: {external_node.layer_label}",
+        boundary_kind=boundary_kind,
+        child_layers=[] if child_label is None else [child_label],
+        parent_layers=[] if parent_label is None else [parent_label],
+        containing_modules=module_path,
+    )
+    boundary_nodes[boundary_label] = boundary
+    return boundary
+
+
+def _boundary_module_path(target_module: "ModuleLog", vis_mode: str) -> list[str]:
+    """Return a module path for focus boundary node cluster placement."""
+
+    module_path = []
+    parts = target_module.address.split(".") if target_module.address != "self" else ["self"]
+    for idx in range(len(parts)):
+        address = ".".join(parts[: idx + 1])
+        module_path.append(address if vis_mode == "rolled" else f"{address}:1")
+    return module_path
+
+
+def _simplify_boundary_labels(
+    boundary_nodes: dict[str, BoundaryNode],
+    fallback_label: str,
+) -> None:
+    """Use simple labels when a focus side has exactly one boundary."""
+
+    if len(boundary_nodes) != 1:
+        return
+    only_boundary = next(iter(boundary_nodes.values()))
+    only_boundary.display_label = fallback_label
 
 
 def _expand_edges_through_skipped(
@@ -734,6 +1074,9 @@ def _collapse_module_address_for_node(
         Pass-qualified module address for unrolled lookup, or ``None``.
     """
 
+    if isinstance(node, BoundaryNode):
+        return None
+
     containing_modules = list(node.containing_modules)
     if getattr(node, "is_leaf_module_output", False):
         containing_modules = containing_modules[:-1]
@@ -829,6 +1172,22 @@ def _build_layer_node(
     Returns:
         The node color string used for this node.
     """
+    if isinstance(node, BoundaryNode):
+        fillcolor = INPUT_COLOR if node.boundary_kind == "input" else OUTPUT_COLOR
+        spec = NodeSpec(
+            lines=[node.display_label],
+            shape="oval",
+            fillcolor=fillcolor,
+            fontcolor="black",
+            color="black",
+            style="filled,solid",
+            extra_attrs={"ordering": "out"},
+        )
+        node_args = _node_spec_to_graphviz_args(spec)
+        node_args["name"] = node.layer_label
+        graphviz_graph.node(**node_args)
+        return "black"
+
     # Get the address, shape, color, and line style:
 
     node_address, node_shape, node_color = _get_node_address_shape_color(
@@ -1010,7 +1369,7 @@ def _build_collapsed_module_node(
 
 def _get_node_address_shape_color(
     self: "ModelLog",
-    node: Union["LayerPassLog", "LayerLog"],
+    node: GraphNode,
     show_buffer_layers: bool,
 ) -> Tuple[str, str, str]:
     """Gets the node shape, address, and color for the graphviz figure.
@@ -1023,13 +1382,16 @@ def _get_node_address_shape_color(
         node_shape: shape of the node
         node_color: color of the node
     """
+    source_node = _unwrap_focus_node(node)
+    if isinstance(source_node, BoundaryNode):
+        raise ValueError("Boundary nodes are rendered by the boundary path.")
     if not show_buffer_layers:
         only_non_buffer_layer = _is_only_non_buffer_in_module(self, node)
     else:
         only_non_buffer_layer = False
 
     if (node.is_leaf_module_output or only_non_buffer_layer) and (len(node.containing_modules) > 0):
-        if isinstance(node, LayerPassLog):
+        if isinstance(source_node, LayerPassLog):
             module_pass_exited = node.containing_modules[-1]
             module, _ = module_pass_exited.split(":")
             if self.modules[module].num_passes == 1:  # type: ignore[union-attr]
@@ -1045,12 +1407,12 @@ def _get_node_address_shape_color(
         node_shape = "box"
         node_color = "black"
     elif node.is_buffer_layer:
-        if (self.buffer_num_passes[node.buffer_address] == 1) or (
-            isinstance(node, LayerLog) and node.num_passes > 1
+        if (self.buffer_num_passes[source_node.buffer_address] == 1) or (
+            isinstance(source_node, LayerLog) and node.num_passes > 1
         ):
-            buffer_address = node.buffer_address
+            buffer_address = source_node.buffer_address
         else:
-            buffer_address = f"{node.buffer_address}:{node.buffer_pass}"
+            buffer_address = f"{source_node.buffer_address}:{source_node.buffer_pass}"
         node_address = "<br/>@" + buffer_address
         node_shape = "box"
         node_color = BUFFER_NODE_COLOR
@@ -1066,9 +1428,7 @@ def _get_node_address_shape_color(
     return node_address, node_shape, node_color
 
 
-def _is_only_non_buffer_in_module(
-    self: "ModelLog", node: Union["LayerPassLog", "LayerLog"]
-) -> bool:
+def _is_only_non_buffer_in_module(self: "ModelLog", node: GraphNode) -> bool:
     """Returns True if a layer is the only non-buffer layer in a leaf module.
 
     Leaf modules are those with no child submodules. Container modules with
@@ -1095,7 +1455,10 @@ def _is_only_non_buffer_in_module(
     # If any aren't, return False.
 
     for parent_layer_label in node.parent_layers:
-        if isinstance(node, LayerPassLog):
+        if parent_layer_label.startswith("__module_focus_"):
+            continue
+        source_node = _unwrap_focus_node(node)
+        if isinstance(source_node, LayerPassLog):
             parent_layer = self[parent_layer_label]
         else:
             parent_layer = self.layer_logs[parent_layer_label]  # type: ignore[assignment]
@@ -1108,7 +1471,7 @@ def _is_only_non_buffer_in_module(
     return True
 
 
-def _get_node_bg_color(self: "ModelLog", node: Union["LayerPassLog", "LayerLog"]) -> str:
+def _get_node_bg_color(self: "ModelLog", node: GraphNode) -> str:
     """Returns the background color hex string for a graph node based on its type.
 
     Maps node types to colors: input=green, output=red, boolean=orange,
@@ -1200,6 +1563,9 @@ def _layer_log_for_node(model_log: "ModelLog", node: GraphNode) -> "LayerLog":
         Aggregate layer log for callbacks.
     """
 
+    node = _unwrap_focus_node(node)
+    if isinstance(node, BoundaryNode):
+        raise ValueError("Synthetic boundary nodes do not have LayerLog metadata.")
     if isinstance(node, LayerLog):
         return node
     if node.parent_layer_log is not None:
@@ -1261,6 +1627,10 @@ def compute_default_node_lines(
     list[str]
         Plain-text rows for ``NodeSpec.lines``.
     """
+
+    layer_log = _unwrap_focus_node(layer_log)
+    if isinstance(layer_log, BoundaryNode):
+        return [layer_log.display_label]
 
     if (layer_log.num_passes > 1) and (vis_mode == "unrolled"):
         pass_label = f":{layer_log.pass_num}"
@@ -1684,7 +2054,7 @@ def _add_edges_for_node(
 
         # Edge deduplication: multiple layers mapping to the same collapsed
         # module node would produce duplicate edges without this check.
-        if tail_name == head_name and metadata_child is not child_node:
+        if tail_name == head_name:
             continue
         if (tail_name, head_name) in edges_used:
             continue
@@ -1700,23 +2070,48 @@ def _add_edges_for_node(
             "labelfontsize": "8",
         }
 
-        if not child_is_collapsed_module:
+        edge_has_boundary = isinstance(parent_node, BoundaryNode) or isinstance(
+            child_node, BoundaryNode
+        )
+
+        if not child_is_collapsed_module and not edge_has_boundary:
+            metadata_base = (
+                _base_node_for_metadata(metadata_child) if metadata_child is not None else None
+            )
             edge_label = (
-                _compute_edge_label(parent_node, metadata_child, self, vis_mode)
-                if metadata_child is not None
+                _compute_edge_label(
+                    _base_node_for_metadata(parent_node),
+                    metadata_base,
+                    self,
+                    vis_mode,
+                )
+                if metadata_base is not None
                 else None
             )
             if edge_label is not None:
                 edge_dict["label"] = edge_label
 
         # Annotate passes for rolled node edge if it varies across passes
-        if vis_mode == "rolled" and metadata_child is not None:
-            _label_rolled_pass_nums(metadata_child, parent_node, edge_dict)  # type: ignore[arg-type]
+        if vis_mode == "rolled" and metadata_child is not None and not edge_has_boundary:
+            metadata_base_for_pass = _base_node_for_metadata(metadata_child)
+            parent_base_for_pass = _base_node_for_metadata(parent_node)
+            if isinstance(metadata_base_for_pass, LayerLog) and isinstance(
+                parent_base_for_pass, LayerLog
+            ):
+                _label_rolled_pass_nums(
+                    metadata_base_for_pass,
+                    parent_base_for_pass,
+                    edge_dict,
+                )
 
         # Label the arguments to the next node if multiple inputs
-        if not child_is_collapsed_module and metadata_child is not None:
+        if not child_is_collapsed_module and metadata_child is not None and not edge_has_boundary:
             _label_node_arguments_if_needed(
-                self, parent_node, metadata_child, edge_dict, show_buffer_layers
+                self,
+                _base_node_for_metadata(parent_node),
+                _base_node_for_metadata(metadata_child),
+                edge_dict,
+                show_buffer_layers,
             )
 
         for arg_name, arg_val in overrides.edge.items():  # type: ignore[union-attr]
@@ -1726,9 +2121,20 @@ def _add_edges_for_node(
                 edge_dict[arg_name] = str(arg_val)
 
         # Add it to the appropriate module cluster (most nested one containing both nodes)
-        containing_module = _get_lowest_containing_module_for_two_nodes(
-            parent_node, child_node, both_nodes_collapsed_modules, vis_nesting_depth
-        )
+        if edge_has_boundary:
+            containing_module = _get_lowest_containing_module_for_two_render_nodes(
+                parent_node,
+                child_node,
+                both_nodes_collapsed_modules,
+                vis_nesting_depth,
+            )
+        else:
+            containing_module = _get_lowest_containing_module_for_two_nodes(
+                _base_node_for_metadata(parent_node),
+                _base_node_for_metadata(child_node),
+                both_nodes_collapsed_modules,
+                vis_nesting_depth,
+            )
         if containing_module != -1:
             module_edge_dict[containing_module]["edges"].append(edge_dict)
             if parent_node.has_input_ancestor or child_node.has_input_ancestor:
@@ -1747,7 +2153,9 @@ def _add_edges_for_node(
             graphviz_graph.edge(**edge_dict)
 
         # Finally, add a backwards edge if both tensors have stored gradients.
-        if vis_mode == "unrolled":
+        if vis_mode == "unrolled" and not (
+            isinstance(parent_node, BoundaryNode) or isinstance(child_node, BoundaryNode)
+        ):
             _add_gradient_edge(
                 self,
                 parent_node,
@@ -2341,6 +2749,22 @@ def _label_rolled_pass_nums(
     # Mark the head label with the argument if need be:
     if child_node.edges_vary_across_passes:
         edge_dict["headlabel"] = f"  In {int_list_to_compact_str(child_pass_nums)}  "
+
+
+def _get_lowest_containing_module_for_two_render_nodes(
+    node1: GraphNode,
+    node2: GraphNode,
+    both_nodes_collapsed_modules: bool,
+    vis_nesting_depth: int,
+) -> Union[str, int]:
+    """Find the deepest module subgraph for render nodes including boundaries."""
+
+    return _get_lowest_containing_module_for_two_nodes(
+        cast(Union["LayerPassLog", "LayerLog"], node1),
+        cast(Union["LayerPassLog", "LayerLog"], node2),
+        both_nodes_collapsed_modules,
+        vis_nesting_depth,
+    )
 
 
 def _get_lowest_containing_module_for_two_nodes(


### PR DESCRIPTION
## Summary

Phase 3 of the visualization sprint. Adds the ability to render only a single module's subgraph in the same visual format as the full model.

### New API

- \`\`show_model_graph(..., module=ModuleLog | str | None)\`\`  -- focus on a module by ModuleLog instance or address string.
- \`\`ModelLog.render_graph(..., module=...)\`\`  -- same arg on the rolled/unrolled render path.
- \`\`ModuleLog.show_graph(**kwargs)\`\`  -- thin wrapper that calls render_graph with module=self.

Synthetic input/output boundary nodes show external upstream/downstream layers, styled like the model-level input/output. \`\`collapse_fn\`\`, \`\`skip_fn\`\`, and the mode presets compose normally inside the focused subgraph.

### Test plan

- [x] tests/test_module_focus.py (244 lines) covers ModuleLog and address-string focus, invalid address raises, branching boundaries, and composition with collapse_fn / skip_fn / ModuleLog.show_graph
- [x] mypy / ruff clean
- [x] smoke tests pass
- [x] prior-phase viz tests still pass

### Notes

Pre-existing timm real-world validation failures (test_timm_gluon_resnext101_32x4d, test_timm_ecaresnet101d) reproduce on the base branch and are unrelated to this PR.