### PR TITLE
feat(visualization): side-by-side code panel

### DIFF
--- a/tests/test_code_panel.py
+++ b/tests/test_code_panel.py
@@ -1,0 +1,125 @@
+"""Tests for source-code panel visualization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+import torchlens as tl
+
+
+def _render_dot(log: tl.ModelLog, tmp_path: Path, **kwargs: Any) -> str:
+    """Render a ModelLog to DOT using a temporary SVG output path.
+
+    Parameters
+    ----------
+    log:
+        Model log to render.
+    tmp_path:
+        Temporary directory supplied by pytest.
+    **kwargs:
+        Additional render options.
+
+    Returns
+    -------
+    str
+        DOT source returned by ``ModelLog.render_graph``.
+    """
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    return log.render_graph(
+        vis_save_only=True,
+        vis_fileformat="svg",
+        vis_outpath=str(tmp_path / "graph"),
+        **kwargs,
+    )
+
+
+class _CodePanelModel(nn.Module):
+    """Small model with inspectable source for code-panel tests."""
+
+    def __init__(self) -> None:
+        """Initialize modules."""
+
+        super().__init__()
+        self.linear = nn.Linear(4, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass."""
+
+        return self.linear(x).relu()
+
+
+def test_code_panel_false_no_panel(tmp_path: Path) -> None:
+    """Default rendering should not include a code-panel cluster."""
+
+    log = tl.log_forward_pass(_CodePanelModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path)
+
+    assert "cluster_torchlens_code_panel" not in dot
+    assert "__tl_code_panel_node" not in dot
+
+
+def test_code_panel_true_emits_forward_source(tmp_path: Path) -> None:
+    """The True shorthand should render forward source."""
+
+    log = tl.log_forward_pass(_CodePanelModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, code_panel=True)
+
+    assert "def forward" in dot
+    assert "return self.linear(x).relu()" in dot
+
+
+def test_code_panel_class_emits_class_source(tmp_path: Path) -> None:
+    """The class mode should render the model class definition."""
+
+    log = tl.log_forward_pass(_CodePanelModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, code_panel="class")
+
+    assert "class _CodePanelModel" in dot
+
+
+def test_code_panel_init_plus_forward(tmp_path: Path) -> None:
+    """The init+forward mode should include both method definitions."""
+
+    log = tl.log_forward_pass(_CodePanelModel(), torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, code_panel="init+forward")
+
+    assert "def __init__" in dot
+    assert "def forward" in dot
+
+
+def test_code_panel_callable_overrides(tmp_path: Path) -> None:
+    """Callable code-panel options should use returned text verbatim."""
+
+    model = _CodePanelModel()
+    log = tl.log_forward_pass(model, torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, code_panel=lambda model: "CUSTOM_TEXT_TOKEN")
+
+    assert "CUSTOM_TEXT_TOKEN" in dot
+
+
+def test_code_panel_html_escape(tmp_path: Path) -> None:
+    """Code-panel text should escape Graphviz HTML metacharacters."""
+
+    model = _CodePanelModel()
+    log = tl.log_forward_pass(model, torch.randn(1, 4))
+    dot = _render_dot(log, tmp_path, code_panel=lambda model: "x < y > z & q")
+
+    assert "x &lt; y &gt; z &amp; q" in dot
+
+
+def test_code_panel_truncates_long_source(tmp_path: Path) -> None:
+    """Long code-panel text should be capped with a truncation marker."""
+
+    model = _CodePanelModel()
+    log = tl.log_forward_pass(model, torch.randn(1, 4))
+    source_text = "\n".join(f"line {idx}" for idx in range(125))
+    dot = _render_dot(log, tmp_path, code_panel=lambda model: source_text)
+
+    assert "... 5 more lines" in dot
+    assert "line 119" in dot
+    assert "line 120" not in dot

--- a/tests/test_output_aesthetics.py
+++ b/tests/test_output_aesthetics.py
@@ -1349,7 +1349,14 @@ def test_generate_pdf_report():
 
 
 def _vis(
-    model, x, filename, vis_mode="unrolled", depth=1000, direction="bottomup", buffer_layers=False
+    model,
+    x,
+    filename,
+    vis_mode="unrolled",
+    depth=1000,
+    direction="bottomup",
+    buffer_layers=False,
+    code_panel=False,
 ):
     """Generate a single visualization PDF."""
     show_model_graph(
@@ -1362,6 +1369,7 @@ def _vis(
         vis_fileformat="pdf",
         vis_buffer_layers=buffer_layers,
         vis_direction=direction,
+        code_panel=code_panel,
         random_seed=42,
     )
 
@@ -1410,6 +1418,7 @@ def test_aesthetic_shared_module_visualizations():
     x = torch.rand(1, 8)
 
     _vis(model, x, "shared_unrolled")
+    _vis(model, x, "shared_code_panel", code_panel=True)
     _vis(model, x, "shared_rolled", vis_mode="rolled")
     _vis(model, x, "shared_rolled_depth1", vis_mode="rolled", depth=1)
 

--- a/torchlens/constants.py
+++ b/torchlens/constants.py
@@ -53,6 +53,8 @@ MODEL_LOG_FIELD_ORDER = [
     "has_gradients",
     "activation_postfunc",
     "activation_postfunc_repr",
+    "_source_code_blob",
+    "_source_model_ref",
     "mark_input_output_distances",
     # Model structure info (is_recurrent, max_recurrent_loops,
     # is_branching, has_conditional_branching are computed @properties)

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -33,14 +33,17 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass, field
 from os import PathLike
 from pathlib import Path
+import weakref
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Set, TYPE_CHECKING, Tuple
 
 import numpy as np
 import pandas as pd
 import torch
+from torch import nn
 
 if TYPE_CHECKING:
     from .._io.streaming import BundleStreamWriter
+    from ..visualization.code_panel import CodePanelOption
     from .buffer_log import BufferAccessor
     from .layer_log import LayerAccessor
     from .module_log import ModuleLog
@@ -146,6 +149,8 @@ class ModelLog:
         "keep_unsaved_layers": FieldPolicy.KEEP,
         "activation_postfunc": FieldPolicy.DROP,
         "activation_postfunc_repr": FieldPolicy.KEEP,
+        "_source_code_blob": FieldPolicy.KEEP,
+        "_source_model_ref": FieldPolicy.DROP,
         "current_function_call_barcode": FieldPolicy.KEEP,
         "random_seed_used": FieldPolicy.KEEP,
         "output_device": FieldPolicy.KEEP,
@@ -291,6 +296,8 @@ class ModelLog:
         self.activation_postfunc_repr = (
             repr(activation_postfunc) if activation_postfunc is not None else None
         )
+        self._source_code_blob: dict[str, str] = {}
+        self._source_model_ref: weakref.ReferenceType[nn.Module] | None = None
         self.current_function_call_barcode = None
         self.random_seed_used = None
         self.output_device = output_device
@@ -488,6 +495,7 @@ class ModelLog:
         state["_module_logs"] = None
         state["_buffer_accessor"] = None
         state["_module_build_data"] = None
+        state["_source_model_ref"] = None
         state["_raw_layer_type_counter"] = dict(self._raw_layer_type_counter)
         state["activation_postfunc_repr"] = (
             repr(self.activation_postfunc) if self.activation_postfunc is not None else None
@@ -510,6 +518,8 @@ class ModelLog:
                 "_keep_activations_in_memory": True,
                 "_activation_sink": None,
                 "_in_exhaustive_pass": False,
+                "_source_code_blob": {},
+                "_source_model_ref": None,
             },
         )
         self.__dict__.update(state)
@@ -726,6 +736,7 @@ class ModelLog:
         vis_node_placement: VisNodePlacementLiteral = "auto",
         vis_renderer: VisRendererLiteral = "graphviz",
         vis_theme: str = "torchlens",
+        code_panel: "CodePanelOption" = False,
     ) -> str:
         """Render the computational graph for this model log.
 
@@ -734,7 +745,7 @@ class ModelLog:
         vis_mode, vis_nesting_depth, vis_outpath, vis_graph_overrides, module, node_mode, \
         node_spec_fn, collapsed_node_spec_fn, collapse_fn, skip_fn, vis_edge_overrides, \
         vis_gradient_edge_overrides, vis_module_overrides, vis_save_only, vis_fileformat, \
-        show_buffer_layers, direction, vis_node_placement, vis_renderer, vis_theme:
+        show_buffer_layers, direction, vis_node_placement, vis_renderer, vis_theme, code_panel:
             Forwarded unchanged to :func:`torchlens.visualization.rendering.render_graph`.
 
         Returns
@@ -766,6 +777,7 @@ class ModelLog:
             vis_node_placement=vis_node_placement,
             vis_renderer=vis_renderer,
             vis_theme=vis_theme,
+            code_panel=code_panel,
         )
 
     def summary(

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -54,6 +54,11 @@ from .utils.arg_handling import normalize_input_args, safe_copy_args, safe_copy_
 from .utils.display import _vprint, warn_parallel
 from .utils.introspection import get_vars_of_type_from_obj
 from .utils.rng import set_random_seed
+from .visualization.code_panel import (
+    CodePanelOption,
+    capture_model_source_code,
+    make_weak_model_ref,
+)
 
 if TYPE_CHECKING:
     from .data_classes.module_log import ModuleLog
@@ -285,6 +290,8 @@ def _run_model_and_save_specified_activations(
         detect_loops,
         verbose,
     )
+    model_log._source_code_blob = capture_model_source_code(model)
+    model_log._source_model_ref = make_weak_model_ref(model)
     model_log._activation_sink = activation_sink
     model_log._keep_activations_in_memory = keep_activations_in_memory
     model_log._in_exhaustive_pass = True
@@ -718,6 +725,7 @@ def show_model_graph(
     vis_renderer: VisRendererLiteral | MissingType = MISSING,
     vis_theme: str | MissingType = MISSING,
     vis_node_mode: VisNodeModeLiteral | MissingType = MISSING,
+    code_panel: CodePanelOption = False,
     random_seed: Optional[int] = None,
     detect_loops: bool | MissingType = MISSING,
     verbose: bool = False,
@@ -752,6 +760,10 @@ def show_model_graph(
         vis_node_placement: Deprecated alias for ``visualization.layout_engine``.
         vis_renderer: Deprecated alias for ``visualization.renderer``.
         vis_theme: Deprecated alias for ``visualization.theme``.
+        code_panel: Optional source-code panel mode. ``True`` is equivalent to
+            ``"forward"``. Built-in modes use source captured at log time;
+            callable modes receive the live model object and are only available
+            while that object is still alive.
         vis_node_mode: Deprecated alias for ``visualization.node_mode``.
         random_seed: Fixed RNG seed for stochastic models.
         detect_loops: Deprecated alias for ``detect_recurrent_patterns``.
@@ -823,6 +835,8 @@ def show_model_graph(
             from .data_classes.module_log import ModuleLog
 
             render_kwargs["module"] = module.address if isinstance(module, ModuleLog) else module
+        if code_panel is not False:
+            render_kwargs["code_panel"] = code_panel
         model_log.render_graph(**render_kwargs)
     finally:
         model_log.cleanup()

--- a/torchlens/visualization/CLAUDE.md
+++ b/torchlens/visualization/CLAUDE.md
@@ -11,6 +11,7 @@ layout engine for large graphs, and an optional dagua renderer. Called via
 |------|--------|---------|
 | `rendering.py` | 1900+ | Graphviz rendering: nodes, skip-aware edges, module subgraphs, IF/THEN labels, NodeSpec callbacks |
 | `elk_layout.py` | 1300+ | ELK-based layout engine for large graphs (150k+ nodes), Worker thread, sfdp fallback |
+| `code_panel.py` | n/a | Source-code capture and Graphviz side-panel rendering helpers |
 | `node_spec.py` | — | Public NodeSpec dataclass and HTML-label row renderer |
 | `modes.py` | — | NodeSpec preset registry for default/profiling/vision/attention node modes |
 | `dagua_bridge.py` | — | ModelLog → DaguaGraph conversion for dagua renderer (opt-in) |
@@ -20,6 +21,24 @@ layout engine for large graphs, and an optional dagua renderer. Called via
 Called by `user_funcs.py:show_model_graph()`. Reads LayerLog/LayerPassLog from ModelLog
 to build graph nodes and edges. Two independent rendering paths (Graphviz vs dagua),
 with Graphviz using an optional ELK layout backend for large graphs.
+
+## Code Panel
+`ModelLog.render_graph(code_panel=...)` and `show_model_graph(..., code_panel=...)`
+can add a right-side source-code panel next to the computational graph.
+
+- `False`: no panel.
+- `True` / `"forward"`: use captured `model.forward` source.
+- `"class"`: use captured full model class source.
+- `"init+forward"`: use captured `__init__` plus `forward` source.
+- Callable: called as `fn(model)` at render time. This only works while the
+  original model object is still alive; saved ModelLogs should use built-in modes.
+
+Built-in source snippets are captured at `log_forward_pass()` time and stored on
+`ModelLog._source_code_blob`. The panel is pure Graphviz: `code_panel.py` adds a
+`cluster_torchlens_code_panel` subgraph with an HTML-like monospace table label,
+expands tabs to 4 spaces, escapes `<`, `>`, and `&`, and truncates after
+`MAX_CODE_PANEL_LINES` lines. Because ELK direct rendering bypasses `Digraph`
+construction, code-panel renders stay on the Graphviz path.
 
 ## Visualization Modes
 - **`vis_mode='unrolled'`**: Shows every pass separately (uses LayerPassLog entries)

--- a/torchlens/visualization/code_panel.py
+++ b/torchlens/visualization/code_panel.py
@@ -1,0 +1,241 @@
+"""Source-code panel helpers for Graphviz visualizations."""
+
+from __future__ import annotations
+
+import html
+import inspect
+import textwrap
+import weakref
+from collections.abc import Callable
+from typing import Any, Literal, TypeAlias, cast
+
+import graphviz
+from torch import nn
+
+CodePanelMode: TypeAlias = Literal["forward", "class", "init+forward"]
+CodePanelOption: TypeAlias = bool | CodePanelMode | Callable[[nn.Module], str]
+CodePanelSide: TypeAlias = Literal["right", "left"]
+
+MAX_CODE_PANEL_LINES = 120
+MIN_CODE_PANEL_DISPLAY_LINES = 36
+
+
+def capture_model_source_code(model: nn.Module) -> dict[str, str]:
+    """Capture source text for built-in code-panel modes.
+
+    Parameters
+    ----------
+    model:
+        Model whose class and forward source should be captured.
+
+    Returns
+    -------
+    dict[str, str]
+        Source snippets keyed by ``"forward"``, ``"class"``, and
+        ``"init+forward"`` when introspection succeeds.
+    """
+
+    source_blob: dict[str, str] = {}
+    forward_source = _get_source_or_empty(model.forward)
+    class_source = _get_source_or_empty(model.__class__)
+    init_source = _get_source_or_empty(model.__class__.__init__)
+    if forward_source:
+        source_blob["forward"] = forward_source
+    if class_source:
+        source_blob["class"] = class_source
+    if init_source or forward_source:
+        source_blob["init+forward"] = "\n\n".join(
+            source for source in (init_source, forward_source) if source
+        )
+    return source_blob
+
+
+def make_weak_model_ref(model: nn.Module) -> weakref.ReferenceType[nn.Module] | None:
+    """Return a weak reference to a model when the object supports weakrefs.
+
+    Parameters
+    ----------
+    model:
+        Model to reference without extending its lifetime.
+
+    Returns
+    -------
+    weakref.ReferenceType[nn.Module] | None
+        Weak reference, or ``None`` if the model type cannot be weakly referenced.
+    """
+
+    try:
+        return weakref.ref(model)
+    except TypeError:
+        return None
+
+
+def resolve_code_panel_source(
+    code_panel: CodePanelOption,
+    source_code_blob: dict[str, str],
+    model_ref: weakref.ReferenceType[nn.Module] | None,
+) -> str | None:
+    """Resolve a code-panel option to displayable source text.
+
+    Parameters
+    ----------
+    code_panel:
+        User-facing code-panel option.
+    source_code_blob:
+        Captured source snippets stored on the ModelLog.
+    model_ref:
+        Optional weak reference to the live model for callable options.
+
+    Returns
+    -------
+    str | None
+        Source text to render, or ``None`` when the panel is disabled.
+
+    Raises
+    ------
+    ValueError
+        If a requested built-in mode was not captured or the option is invalid.
+    RuntimeError
+        If a callable option is used after the live model is unavailable.
+    TypeError
+        If a callable option does not return a string.
+    """
+
+    if code_panel is False:
+        return None
+    if callable(code_panel):
+        model = model_ref() if model_ref is not None else None
+        if model is None:
+            raise RuntimeError(
+                "Callable code_panel options require the original model object to "
+                "still be alive. Use a built-in code_panel mode for saved ModelLog "
+                "rendering."
+            )
+        source_text = code_panel(model)
+        if not isinstance(source_text, str):
+            raise TypeError("Callable code_panel options must return a string.")
+        return source_text
+    mode: CodePanelMode
+    if code_panel is True:
+        mode = "forward"
+    elif code_panel in {"forward", "class", "init+forward"}:
+        mode = code_panel
+    else:
+        raise ValueError(
+            "code_panel must be False, True, 'forward', 'class', 'init+forward', or a callable."
+        )
+    captured_source = source_code_blob.get(mode)
+    if captured_source is None:
+        raise ValueError(f"Source code for code_panel={mode!r} was not captured.")
+    return captured_source
+
+
+def render_code_panel_subgraph(
+    dot: graphviz.Digraph,
+    source_text: str,
+    *,
+    side: CodePanelSide = "right",
+) -> None:
+    """Add a source-code panel cluster to a Graphviz digraph.
+
+    Parameters
+    ----------
+    dot:
+        Graphviz digraph to mutate.
+    source_text:
+        Source code to render in the panel.
+    side:
+        Requested side relative to the computational graph.
+
+    Returns
+    -------
+    None
+        The input ``dot`` is mutated in place.
+    """
+
+    if side not in {"right", "left"}:
+        raise ValueError("side must be either 'right' or 'left'.")
+
+    rows = _source_text_to_html_rows(source_text)
+    header_row = "<TR><TD ALIGN='LEFT'><B>Source code</B></TD></TR>"
+    label = (
+        "<<TABLE BORDER='0' CELLBORDER='0' CELLSPACING='0' CELLPADDING='2'>"
+        f"{header_row}{''.join(rows)}"
+        "</TABLE>>"
+    )
+    # Pure Graphviz keeps graph and code in one output file. The invisible edge
+    # gives the otherwise detached code cluster a directional relationship to the
+    # main graph without adding a rendering dependency or second composition pass.
+    dot.node("__tl_graph_panel_anchor", label="", shape="point", style="invis", width="0")
+    with dot.subgraph(name="cluster_torchlens_code_panel") as panel:
+        panel.attr(
+            label="",
+            style="filled,rounded",
+            fillcolor="#FAFAFA",
+            color="#A8A8A8",
+            margin="12",
+        )
+        panel.node(
+            "__tl_code_panel_node",
+            label=label,
+            shape="plaintext",
+            fontname="Courier",
+            margin="0",
+        )
+    if side == "right":
+        dot.edge("__tl_graph_panel_anchor", "__tl_code_panel_node", style="invis", weight="10")
+    else:
+        dot.edge("__tl_code_panel_node", "__tl_graph_panel_anchor", style="invis", weight="10")
+
+
+def _get_source_or_empty(obj: object) -> str:
+    """Return inspect source text for an object or an empty string.
+
+    Parameters
+    ----------
+    obj:
+        Object passed to ``inspect.getsource``.
+
+    Returns
+    -------
+    str
+        Dedented source text, or an empty string if introspection fails.
+    """
+
+    try:
+        return textwrap.dedent(inspect.getsource(cast(Any, obj))).rstrip()
+    except (OSError, TypeError):
+        return ""
+
+
+def _source_text_to_html_rows(source_text: str) -> list[str]:
+    """Convert source text into escaped Graphviz HTML table rows.
+
+    Parameters
+    ----------
+    source_text:
+        Source code to display.
+
+    Returns
+    -------
+    list[str]
+        HTML table-row strings suitable for an HTML-like Graphviz label.
+    """
+
+    source_lines = source_text.expandtabs(4).splitlines() or [""]
+    extra_line_count = max(0, len(source_lines) - MAX_CODE_PANEL_LINES)
+    displayed_lines = source_lines[:MAX_CODE_PANEL_LINES]
+    if extra_line_count:
+        displayed_lines.append(f"... {extra_line_count} more lines")
+    rows = []
+    for line in displayed_lines:
+        escaped_line = html.escape(line, quote=False) if line else "&#160;"
+        rows.append(f"<TR><TD ALIGN='LEFT'><FONT FACE='Courier'>{escaped_line}</FONT></TD></TR>")
+    missing_lines = max(0, MIN_CODE_PANEL_DISPLAY_LINES - len(displayed_lines))
+    if missing_lines:
+        spacer_height = missing_lines * 14
+        rows.append(
+            f"<TR><TD HEIGHT='{spacer_height}' ALIGN='LEFT'>"
+            "<FONT FACE='Courier' COLOR='#FAFAFA'>&#160;</FONT></TD></TR>"
+        )
+    return rows

--- a/torchlens/visualization/rendering.py
+++ b/torchlens/visualization/rendering.py
@@ -65,6 +65,7 @@ from ..data_classes.layer_pass_log import LayerPassLog
 from ..data_classes.layer_log import LayerLog
 from .modes import COLLAPSED_MODE_REGISTRY, MODE_REGISTRY
 from .node_spec import NodeSpec, render_lines_to_html
+from .code_panel import CodePanelOption, render_code_panel_subgraph, resolve_code_panel_source
 
 if TYPE_CHECKING:
     from ..data_classes.model_log import ModelLog
@@ -222,6 +223,7 @@ def render_graph(
     vis_node_placement: VisNodePlacementLiteral = "auto",
     vis_renderer: VisRendererLiteral = "graphviz",
     vis_theme: str = "torchlens",
+    code_panel: CodePanelOption = False,
 ) -> str:
     """Render the computational graph as a Graphviz Digraph.
 
@@ -262,6 +264,9 @@ def render_graph(
         vis_node_placement: Layout engine: ``'auto'`` (default), ``'dot'``, ``'elk'``,
             or ``'sfdp'``.  ``'auto'`` uses dot for small graphs and ELK (or sfdp
             fallback) for large ones.
+        code_panel: Optional source-code panel. ``True`` is equivalent to
+            ``"forward"``; callable values receive the live model object when
+            it is still available.
 
     Returns:
         The Graphviz DOT source string.
@@ -362,8 +367,18 @@ def render_graph(
         show_buffer_layers=show_buffer_layers,
         skip_fn=skip_fn,
     )
+    source_text = resolve_code_panel_source(
+        code_panel,
+        getattr(self, "_source_code_blob", {}),
+        getattr(self, "_source_model_ref", None),
+    )
     num_nodes = len(entries_to_plot) - len(skipped_labels)
     engine = get_node_placement_engine(vis_node_placement, num_nodes)
+    if source_text is not None and engine == "elk":
+        # The code panel is implemented in pure Graphviz so the graph and source
+        # remain in one output file. ELK's direct renderer bypasses Digraph
+        # construction, so panel renders stay on the Graphviz path.
+        engine = "dot"
     _vprint(self, f"Rendering {vis_mode} graph ({num_nodes} nodes, format={vis_fileformat})")
     _vprint(self, f"Layout engine: {engine}")
 
@@ -483,6 +498,8 @@ def render_graph(
 
     # Finally, set up the subgraphs.
     _setup_subgraphs(self, dot, vis_mode, module_cluster_dict, overrides)
+    if source_text is not None:
+        render_code_panel_subgraph(dot, source_text)
 
     if in_notebook() and not vis_save_only:
         from IPython.display import display  # #72: lazy import


### PR DESCRIPTION
## Summary

Adds a `code_panel` rendering option for TorchLens graph visualizations.

- Captures built-in model source snippets at `log_forward_pass()` time on `ModelLog._source_code_blob`.
- Adds `ModelLog.render_graph(code_panel=...)` and `show_model_graph(..., code_panel=...)` support for `True`, `"forward"`, `"class"`, `"init+forward"`, and callable panel text.
- Renders the panel as a pure Graphviz side cluster using an escaped monospace HTML table, line truncation, tab expansion, and a minimum display height for short snippets.
- Documents the visualization behavior in `torchlens/visualization/CLAUDE.md`.
- Adds focused code-panel DOT tests and an aesthetic visualization case that generates `shared_code_panel.pdf`.

## Test Plan

Passed:

```bash
ruff check . --fix
ruff format .
mypy torchlens/
pytest tests/ -m smoke -x --tb=short
pytest tests/test_code_panel.py tests/test_module_focus.py tests/test_node_modes.py tests/test_node_spec_api.py tests/test_collapse_fn.py tests/test_skip_fn.py -v
pytest tests/test_output_aesthetics.py -v
```

Visual check:

- Rendered and inspected `tests/test_outputs/visualizations/aesthetic_test_models/shared_code_panel.pdf`.
- The PDF shows the computational graph on the left and the source-code panel on the right. The source panel uses a fixed monospace table and reserves extra height for short snippets; Graphviz does not perfectly equalize the panel height to every graph, but the output is readable and stable.

Known unrelated failure:

```bash
pytest tests/ -m "not slow" -x --tb=short
```

This failed in `tests/test_real_world_models.py::test_timm_gluon_resnext101_32x4d` after 804 passes with:

```text
Saved activations for layer conv2d_104_405 do not match the values computed based on the parent layers ['relu_99_403'].
```

I reran the single failing test and reproduced the same failure. I also temporarily disabled the new source-capture assignment and reran the same test; it still failed, so this appears independent of the code-panel changes.
