### PR TITLE
fix(validation): tolerate small replay drift

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -23,6 +23,7 @@ from torchlens.validation.core import (
     _copy_validation_args,
     MAX_PERTURB_ATTEMPTS,
 )
+from torchlens.utils.tensor_utils import tensor_nanequal
 
 
 # =============================================================================
@@ -57,6 +58,17 @@ def test_model_log_check_metadata_method_bound():
     """ModelLog.check_metadata_invariants is callable."""
     assert hasattr(ModelLog, "check_metadata_invariants")
     assert callable(ModelLog.check_metadata_invariants)
+
+
+def test_tensor_nanequal_uses_relative_tolerance_for_replay() -> None:
+    """Validation replay should allow tiny relative floating-point drift."""
+    saved = torch.tensor([1.0, 100.0], dtype=torch.float32)
+    replayed = saved + torch.tensor([8e-6, 4e-3], dtype=torch.float32)
+    mismatched = saved + torch.tensor([1e-3, 1e-1], dtype=torch.float32)
+
+    assert not tensor_nanequal(saved, replayed, allow_tolerance=False)
+    assert tensor_nanequal(saved, replayed, allow_tolerance=True)
+    assert not tensor_nanequal(saved, mismatched, allow_tolerance=True)
 
 
 # =============================================================================

--- a/torchlens/utils/tensor_utils.py
+++ b/torchlens/utils/tensor_utils.py
@@ -20,11 +20,16 @@ from typing import Any, Optional
 import numpy as np
 import torch
 
-# Maximum tolerance for floating-point comparison in tensor_nanequal.
+# Maximum absolute tolerance for floating-point comparison in tensor_nanequal.
 # Used by validation replay to allow tiny numerical differences caused by
 # non-deterministic GPU reductions or float16 rounding.  Set conservatively
 # tight to catch genuine mismatches while tolerating hardware noise.
-MAX_FLOATING_POINT_TOLERANCE = 3e-6
+MAX_FLOATING_POINT_TOLERANCE = 1e-5
+
+# Maximum relative tolerance for floating-point comparison in tensor_nanequal.
+# Deep convolution replays can differ by a few ULPs above the absolute floor
+# while still matching the saved operation numerically.
+REL_FLOATING_POINT_TOLERANCE = 1e-4
 
 # Cached result of torch.cuda.is_available().  Evaluated once per process
 # because CUDA availability cannot change at runtime.  Avoids repeated
@@ -53,7 +58,9 @@ def tensor_all_nan(tensor: torch.Tensor) -> bool:
         return False
 
 
-def tensor_nanequal(tensor_a: torch.Tensor, tensor_b: torch.Tensor, allow_tolerance=False) -> bool:
+def tensor_nanequal(
+    tensor_a: torch.Tensor, tensor_b: torch.Tensor, allow_tolerance: bool = False
+) -> bool:
     """NaN-aware tensor equality check, used by validation replay.
 
     NaN positions are treated as equal (NaN == NaN is True here), which
@@ -109,12 +116,18 @@ def tensor_nanequal(tensor_a: torch.Tensor, tensor_b: torch.Tensor, allow_tolera
             return True
 
         # Tolerance path: allow small floating-point differences (e.g. from
-        # non-deterministic GPU reductions or mixed-precision rounding).
+        # convolution replay order, non-deterministic GPU reductions, or
+        # mixed-precision rounding).
         if (
             allow_tolerance
             and (tensor_a_nonan.dtype != torch.bool)
             and (tensor_b_nonan.dtype != torch.bool)
-            and ((tensor_a_nonan - tensor_b_nonan).abs().max() <= MAX_FLOATING_POINT_TOLERANCE)
+            and torch.allclose(
+                tensor_a_nonan,
+                tensor_b_nonan,
+                rtol=REL_FLOATING_POINT_TOLERANCE,
+                atol=MAX_FLOATING_POINT_TOLERANCE,
+            )
         ):
             return True
 


### PR DESCRIPTION
## Summary

- Allow validation replay float comparisons to use a small absolute floor plus relative tolerance.
- Add a regression unit test for tolerated replay drift.

## Root Cause

Deep timm convolution replays can differ from saved activations by a few float32 ULPs. The previous fixed absolute threshold was too tight for the deeper ResNeXt/ECA ResNet paths, even though captured Conv2d arguments matched the live modules.

## Fix

- Use torch.allclose for tolerated replay comparisons with atol=1e-5 and rtol=1e-4.
- Keep exact equality behavior when validation calls do not opt into tolerance.

## Test Plan

- [x] ruff check . --fix
- [x] ruff format .
- [x] mypy torchlens/
- [x] pytest tests/ -m smoke -x --tb=short
- [x] pytest tests/test_real_world_models.py::test_timm_gluon_resnext101_32x4d tests/test_real_world_models.py::test_timm_ecaresnet101d -v
- [x] pytest tests/ -m "not slow" -x --tb=short
