### PR TITLE
fix(perf): defer col_offset extraction until after frame filtering

### DIFF
--- a/scripts/bench_log_forward_pass.py
+++ b/scripts/bench_log_forward_pass.py
@@ -1,0 +1,108 @@
+"""Benchmark ``log_forward_pass`` on a 20-layer MLP."""
+
+import argparse
+import os
+import sys
+import statistics
+import time
+from typing import Sequence
+
+import torch
+from torch import nn
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from torchlens import log_forward_pass  # noqa: E402
+
+
+class TwentyLayerMLP(nn.Module):
+    """Simple 20-layer MLP for local logging benchmarks."""
+
+    def __init__(self, width: int = 128) -> None:
+        """Initialize the benchmark model.
+
+        Args:
+            width: Hidden dimension for every linear layer.
+        """
+        super().__init__()
+        layers = []
+        for _ in range(20):
+            layers.append(nn.Linear(width, width))
+            layers.append(nn.ReLU())
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the MLP forward pass.
+
+        Args:
+            x: Input tensor of shape ``(batch_size, width)``.
+
+        Returns:
+            Model output tensor.
+        """
+        return self.net(x)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Optional command-line argument sequence.
+
+    Returns:
+        Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=5, help="Timed benchmark runs.")
+    parser.add_argument("--warmup", type=int, default=1, help="Untimed warmup runs.")
+    parser.add_argument("--width", type=int, default=128, help="MLP hidden width.")
+    parser.add_argument("--batch-size", type=int, default=32, help="Input batch size.")
+    return parser.parse_args(argv)
+
+
+def run_once(model: nn.Module, x: torch.Tensor) -> float:
+    """Time one ``log_forward_pass`` call.
+
+    Args:
+        model: Model to log.
+        x: Input tensor for the model.
+
+    Returns:
+        Elapsed wall-clock seconds.
+    """
+    start = time.perf_counter()
+    log_forward_pass(model, x)
+    return time.perf_counter() - start
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the benchmark and print timing statistics.
+
+    Args:
+        argv: Optional command-line argument sequence.
+    """
+    args = parse_args(argv)
+    torch.manual_seed(0)
+    model = TwentyLayerMLP(width=args.width).eval()
+    x = torch.randn(args.batch_size, args.width)
+
+    with torch.no_grad():
+        for _ in range(args.warmup):
+            run_once(model, x)
+        times = [run_once(model, x) for _ in range(args.runs)]
+
+    print(f"runs: {args.runs}")
+    print(f"warmup: {args.warmup}")
+    print(f"width: {args.width}")
+    print(f"batch_size: {args.batch_size}")
+    print(f"mean_seconds: {statistics.mean(times):.6f}")
+    print(f"median_seconds: {statistics.median(times):.6f}")
+    print(f"min_seconds: {min(times):.6f}")
+    print(f"max_seconds: {max(times):.6f}")
+    print("all_seconds: " + ", ".join(f"{elapsed:.6f}" for elapsed in times))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -1,0 +1,166 @@
+"""Tests for TorchLens stack introspection helpers."""
+
+import os
+from types import FrameType
+from typing import List, Optional
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens
+from torchlens.data_classes import FuncCallLocation
+from torchlens.utils import introspection
+
+
+class RecursiveStackModel(nn.Module):
+    """Small module that creates a deep Python stack below ``forward``."""
+
+    def __init__(self, depth: int) -> None:
+        """Initialize the recursive model.
+
+        Args:
+            depth: Number of recursive calls to make below ``forward``.
+        """
+        super().__init__()
+        self.depth = depth
+
+    def forward(self, x: torch.Tensor) -> List[FuncCallLocation]:
+        """Return the filtered function call stack from a recursive call.
+
+        Args:
+            x: Input tensor, included to exercise normal ``nn.Module`` calling.
+
+        Returns:
+            Filtered TorchLens function call stack.
+        """
+        return self._recurse(x, self.depth)
+
+    def _recurse(self, x: torch.Tensor, depth: int) -> List[FuncCallLocation]:
+        """Recurse until the stack is deep enough, then capture it.
+
+        Args:
+            x: Input tensor carried through recursion.
+            depth: Remaining recursive depth.
+
+        Returns:
+            Filtered TorchLens function call stack.
+        """
+        if depth <= 0:
+            return introspection._get_func_call_stack()
+        return self._recurse(x, depth - 1)
+
+
+def test_stack_metadata_helpers_run_only_for_surviving_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify expensive stack metadata helpers run after frame filtering.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing helper functions.
+    """
+    col_offset_calls = []
+    code_qualname_calls = []
+
+    def fake_get_col_offset(frame: FrameType) -> Optional[int]:
+        """Record column-offset calls without walking bytecode.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Dummy column offset.
+        """
+        col_offset_calls.append((frame.f_code.co_filename, frame.f_code.co_name))
+        return 0
+
+    def fake_get_code_qualname(frame: FrameType) -> Optional[str]:
+        """Record qualname calls without inspecting code metadata.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Code object name for the frame.
+        """
+        code_qualname_calls.append((frame.f_code.co_filename, frame.f_code.co_name))
+        return frame.f_code.co_name
+
+    monkeypatch.setattr(introspection, "_get_col_offset", fake_get_col_offset)
+    monkeypatch.setattr(introspection, "_get_code_qualname", fake_get_code_qualname)
+
+    model = RecursiveStackModel(depth=12)
+    stack = model(torch.ones(1))
+
+    torchlens_pkg_dir = os.path.dirname(os.path.abspath(torchlens.__file__))
+    surviving_frames = [(loc.file, loc.func_name) for loc in stack]
+
+    assert len(stack) >= 13
+    assert col_offset_calls == surviving_frames
+    assert code_qualname_calls == surviving_frames
+    assert len(col_offset_calls) == len(stack)
+    assert len(code_qualname_calls) == len(stack)
+    assert all(not filename.startswith(torchlens_pkg_dir) for filename, _ in col_offset_calls)
+
+
+def test_disable_col_offset_skips_col_offset_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify ``disable_col_offset`` bypasses bytecode column-offset inspection.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing helper functions.
+    """
+    col_offset_calls = []
+    code_qualname_calls = []
+
+    def fake_get_col_offset(frame: FrameType) -> Optional[int]:
+        """Record unexpected column-offset calls.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Dummy column offset.
+        """
+        col_offset_calls.append(frame)
+        return 0
+
+    def fake_get_code_qualname(frame: FrameType) -> Optional[str]:
+        """Record qualname calls that should still occur.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Code object name for the frame.
+        """
+        code_qualname_calls.append(frame)
+        return frame.f_code.co_name
+
+    monkeypatch.setattr(introspection, "_get_col_offset", fake_get_col_offset)
+    monkeypatch.setattr(introspection, "_get_code_qualname", fake_get_code_qualname)
+
+    model = RecursiveStackModel(depth=12)
+
+    class DisableOffsetModel(RecursiveStackModel):
+        """Recursive model variant that disables column-offset extraction."""
+
+        def _recurse(self, x: torch.Tensor, depth: int) -> List[FuncCallLocation]:
+            """Recurse until the stack is deep enough, then capture it.
+
+            Args:
+                x: Input tensor carried through recursion.
+                depth: Remaining recursive depth.
+
+            Returns:
+                Filtered TorchLens function call stack.
+            """
+            if depth <= 0:
+                return introspection._get_func_call_stack(disable_col_offset=True)
+            return self._recurse(x, depth - 1)
+
+    stack = DisableOffsetModel(model.depth)(torch.ones(1))
+
+    assert len(stack) >= 13
+    assert col_offset_calls == []
+    assert len(code_qualname_calls) == len(stack)
+    assert all(loc.col_offset is None for loc in stack)

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -318,7 +318,9 @@ def _build_shared_fields_dict(
     fields_dict["func_applied"] = func
     fields_dict["func_name"] = func_name
     fields_dict["func_call_stack"] = _get_func_call_stack(
-        self.num_context_lines, source_loading_enabled=self.save_source_context
+        self.num_context_lines,
+        source_loading_enabled=self.save_source_context,
+        disable_col_offset=False,
     )
     fields_dict["func_time"] = exec_ctx.time_elapsed
     fields_dict["func_rng_states"] = exec_ctx.rng_states

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -167,7 +167,9 @@ def log_source_tensor_exhaustive(
         "func_applied": None,
         "func_name": "none",
         "func_call_stack": _get_func_call_stack(
-            self.num_context_lines, source_loading_enabled=self.save_source_context
+            self.num_context_lines,
+            source_loading_enabled=self.save_source_context,
+            disable_col_offset=False,
         ),
         "func_time": 0,
         "flops_forward": 0,

--- a/torchlens/postprocess/graph_traversal.py
+++ b/torchlens/postprocess/graph_traversal.py
@@ -65,7 +65,9 @@ def _add_output_layers(
         new_output_node.func_applied = identity
         new_output_node.func_name = "none"
         new_output_node.func_call_stack = _get_func_call_stack(
-            self.num_context_lines, source_loading_enabled=self.save_source_context
+            self.num_context_lines,
+            source_loading_enabled=self.save_source_context,
+            disable_col_offset=False,
         )
         new_output_node.func_time = 0
         new_output_node.func_rng_states = (

--- a/torchlens/utils/introspection.py
+++ b/torchlens/utils/introspection.py
@@ -24,6 +24,44 @@ from torch import nn
 _ATTR_SKIP_SET = frozenset({"T", "mT", "real", "imag", "H"})
 
 
+def _get_code_qualname(frame: FrameType) -> Optional[str]:
+    """Return ``co_qualname`` when available on this Python version.
+
+    Args:
+        frame: Stack frame whose code object should be inspected.
+
+    Returns:
+        Qualified code object name, or None when unavailable.
+    """
+    if sys.version_info < (3, 11):
+        return None
+    return getattr(frame.f_code, "co_qualname", None)
+
+
+def _get_col_offset(frame: FrameType) -> Optional[int]:
+    """Return the current instruction's column offset when available.
+
+    Args:
+        frame: Stack frame whose current bytecode instruction should be inspected.
+
+    Returns:
+        Column offset for the current instruction, or None when unavailable.
+    """
+    if sys.version_info < (3, 11):
+        return None
+    try:
+        for instruction in dis.get_instructions(frame.f_code):
+            if instruction.offset != frame.f_lasti:
+                continue
+            positions = instruction.positions
+            if positions is None:
+                return None
+            return positions.col_offset
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
 def get_vars_of_type_from_obj(
     obj: Any,
     which_type: Type,
@@ -373,7 +411,11 @@ def remove_attributes_with_prefix(obj: Any, prefix: str) -> None:
             delattr(obj, field)
 
 
-def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: bool = True) -> List:
+def _get_func_call_stack(
+    num_context_lines: int = 7,
+    source_loading_enabled: bool = True,
+    disable_col_offset: bool = False,
+) -> List:
     """Build a list of FuncCallLocation objects for the current call stack.
 
     Filters out torchlens internals and ``_call_impl`` frames, keeping only
@@ -390,6 +432,8 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
             ``2 * num_context_lines + 1``.
         source_loading_enabled: Whether each ``FuncCallLocation`` should
             lazily load source text and function metadata on demand.
+        disable_col_offset: If True, skip bytecode inspection for column
+            offsets and store None for ``col_offset``.
 
     Returns:
         List[FuncCallLocation] ordered shallow-to-deep.
@@ -405,30 +449,8 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
     def _is_torchlens_internal(filename: str) -> bool:
         return filename.startswith(_TORCHLENS_PKG_DIR)
 
-    def _get_code_qualname(frame: FrameType) -> Optional[str]:
-        """Return ``co_qualname`` when available on this Python version."""
-        if sys.version_info < (3, 11):
-            return None
-        return getattr(frame.f_code, "co_qualname", None)
-
-    def _get_col_offset(frame: FrameType) -> Optional[int]:
-        """Return the current instruction's column offset when available."""
-        if sys.version_info < (3, 11):
-            return None
-        try:
-            for instruction in dis.get_instructions(frame.f_code):
-                if instruction.offset != frame.f_lasti:
-                    continue
-                positions = instruction.positions
-                if positions is None:
-                    return None
-                return positions.col_offset
-        except (TypeError, ValueError):
-            return None
-        return None
-
     # Phase 1: Collect lightweight frame data — only co_filename, co_name, f_lineno.
-    # Do NOT do f_locals/f_globals dict lookups yet (expensive, ~50/call).
+    # Do NOT do f_locals/f_globals dict lookups or bytecode walks yet.
     raw_frames = []
     frame = sys._getframe(0)
     while frame is not None:
@@ -438,8 +460,6 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
                 frame.f_code.co_name,
                 frame.f_lineno,
                 frame.f_code.co_firstlineno,
-                _get_code_qualname(frame),
-                _get_col_offset(frame),
                 frame,  # keep reference for phase 2 func_obj lookup
             )
         )
@@ -454,7 +474,7 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
     filtered_indices = []
 
     for idx in range(len(raw_frames) - 1, -1, -1):
-        filename, func_name, lineno, _, _, _, frame_ref = raw_frames[idx]
+        filename, func_name, lineno, _, frame_ref = raw_frames[idx]
 
         # Skip torchlens internals and PyTorch _call_impl
         if _is_torchlens_internal(filename):
@@ -466,7 +486,7 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
             tracking = True
             # Look for the user-script frame that called log_forward_pass
             for j in range(idx + 1, len(raw_frames)):
-                j_filename, j_func_name, _, _, _, _, _ = raw_frames[j]
+                j_filename, j_func_name, _, _, _ = raw_frames[j]
                 if not _is_torchlens_internal(j_filename) and "_call_impl" not in j_func_name:
                     pre_forward_frame_idx = j
                     break
@@ -479,12 +499,10 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
         filtered_indices.append(pre_forward_frame_idx)
 
     # Phase 2: Build FuncCallLocation objects only for surviving frames (~5-10).
-    # Do the expensive f_locals/f_globals dict lookup only here.
+    # Do expensive f_locals/f_globals lookups and bytecode walks only here.
     result = []
     for idx in filtered_indices:
-        filename, func_name, lineno, code_firstlineno, code_qualname, col_offset, frame_ref = (
-            raw_frames[idx]
-        )
+        filename, func_name, lineno, code_firstlineno, frame_ref = raw_frames[idx]
         loc = FuncCallLocation(
             file=filename,
             line_number=lineno,
@@ -496,8 +514,8 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
                 else None
             ),
             code_firstlineno=code_firstlineno,
-            code_qualname=code_qualname,
-            col_offset=col_offset,
+            code_qualname=_get_code_qualname(frame_ref),
+            col_offset=None if disable_col_offset else _get_col_offset(frame_ref),
             source_loading_enabled=source_loading_enabled,
         )
         result.append(loc)


### PR DESCRIPTION
## Summary
- `_get_col_offset` and `_get_code_qualname` previously ran on every raw frame during stack capture, before filtering. The bytecode walks were responsible for ~94% of `log_forward_pass` wall-time on a 20-layer MLP.
- This patch moves both helpers to phase 2, after frame filtering. Adds a `disable_col_offset: bool = False` kwarg threaded through callers (current behavior unchanged; future fastlog path can opt fully out).

## Speedup
Local benchmark (20-layer MLP, 5 runs after warmup):

| | mean | median |
|---|---|---|
| pre-fix (main) | 0.460 s | 0.459 s |
| post-fix | 0.042 s | 0.043 s |
| **speedup** | **~10.9x** | |

## Test plan
- [x] `ruff format && ruff check . --fix`
- [x] `mypy torchlens/`
- [x] `pytest tests/ -m smoke -x --tb=short` (37 passed)
- [x] `pytest tests/test_introspection.py -v` (2 new tests, both passing)
- [x] New `scripts/bench_log_forward_pass.py` for local verification (not CI)