### PR TITLE
feat(fastlog): high-throughput activation recording for dynamic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,31 @@ streamed_log = tl.log_forward_pass(
 )
 ```
 
+## Fast activation recording (`tl.fastlog`)
+
+Use `tl.fastlog` when you already know the events you want and do not need a full
+`ModelLog`. `log_forward_pass()` remains the exhaustive path for graph metadata,
+visualization, validation, and faithful reconstruction of the forward pass. Fastlog is
+the lighter path for predicate-selected activations across one pass or many repeated
+rollouts.
+
+```python
+keep_op = lambda ctx: ctx.kind == "op" and ctx.layer_type == "relu"
+recording = tl.fastlog.record(model, x, keep_op=keep_op)
+print(recording.summary())
+```
+
+Predicates receive `RecordContext` objects with operation/module fields and bounded
+recent history, so they can express rules such as "ReLUs after convolutions" or "outputs
+of every `Linear` module." Captures can stay in RAM, stream synchronously to a fastlog
+directory bundle, or mirror to both. RAM mode is training-compatible via
+`CaptureSpec(keep_grad=True)`.
+
+The tutorial notebook at `notebooks/fastlog_tutorial.ipynb` walks through one-shot
+recording, many-rollout `Recorder` sessions, disk load/recovery, graph previews,
+`dry_run()` predicate iteration, downcasting with `CaptureSpec`, and the v1 support
+boundaries.
+
 ## Security
 
 Portable bundles contain a pickle file in `metadata.pkl`. Only load bundles

--- a/notebooks/fastlog_tutorial.ipynb
+++ b/notebooks/fastlog_tutorial.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Fast activation recording with `tl.fastlog`\n",
+    "\n",
+    "`tl.fastlog` is the sparse activation-recording path for cases where you know what you want to keep before the forward pass runs. `tl.log_forward_pass()` still builds a full `ModelLog` with graph metadata, labels, validation surfaces, and visualization. `save_new_activations()` is the fast second-pass path for an already traced `ModelLog` when you want the same graph structure with new inputs.\n",
+    "\n",
+    "Fastlog is different: predicates see lightweight `RecordContext` events during the pass and only selected records are copied to RAM and/or written to disk. Use it for repeated rollouts, targeted probes, memory-constrained activation collection, and training-time auxiliary losses where a full `ModelLog` would be too heavy.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import shutil\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import torch\n",
+    "from torch import nn\n",
+    "\n",
+    "repo_root = Path.cwd().resolve()\n",
+    "if not (repo_root / \"torchlens\").exists():\n",
+    "    repo_root = repo_root.parent\n",
+    "sys.path.insert(0, str(repo_root))\n",
+    "\n",
+    "import torchlens as tl  # noqa: E402\n",
+    "\n",
+    "\n",
+    "torch.manual_seed(7)\n",
+    "\n",
+    "\n",
+    "class TinyMLP(nn.Module):\n",
+    "    \"\"\"Small MLP used by most examples.\"\"\"\n",
+    "\n",
+    "    def __init__(self) -> None:\n",
+    "        \"\"\"Initialize three linear layers with ReLU activations.\"\"\"\n",
+    "\n",
+    "        super().__init__()\n",
+    "        self.net = nn.Sequential(\n",
+    "            nn.Linear(4, 8),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(8, 3),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(3, 2),\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"Return logits for one batch.\"\"\"\n",
+    "\n",
+    "        return self.net(x)\n",
+    "\n",
+    "\n",
+    "model = TinyMLP()\n",
+    "x = torch.randn(5, 4)\n",
+    "\n",
+    "\n",
+    "def keep_op(ctx: tl.fastlog.RecordContext) -> bool:\n",
+    "    \"\"\"Keep ReLU operation events.\"\"\"\n",
+    "\n",
+    "    return ctx.kind == \"op\" and ctx.layer_type == \"relu\"\n",
+    "\n",
+    "\n",
+    "recording = tl.fastlog.record(model, x, keep_op=keep_op)\n",
+    "print(recording.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Cross-layer predicates\n",
+    "\n",
+    "`RecordContext.recent_ops` is a bounded history of recent operation events. This lets a predicate ask about local graph context without building a full `ModelLog`. Here the rule keeps a ReLU only when a convolution appeared immediately before it.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ConvBlock(nn.Module):\n",
+    "    \"\"\"Small convolutional block for history-aware predicates.\"\"\"\n",
+    "\n",
+    "    def __init__(self) -> None:\n",
+    "        \"\"\"Initialize a Conv-ReLU-Flatten-Linear model.\"\"\"\n",
+    "\n",
+    "        super().__init__()\n",
+    "        self.net = nn.Sequential(\n",
+    "            nn.Conv2d(1, 2, kernel_size=3, padding=1),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Flatten(),\n",
+    "            nn.Linear(2 * 4 * 4, 2),\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"Return logits for an image batch.\"\"\"\n",
+    "\n",
+    "        return self.net(x)\n",
+    "\n",
+    "\n",
+    "def relu_after_conv(ctx: tl.fastlog.RecordContext) -> bool:\n",
+    "    \"\"\"Keep ReLU outputs whose recent history contains a convolution.\"\"\"\n",
+    "\n",
+    "    return (\n",
+    "        ctx.kind == \"op\"\n",
+    "        and ctx.layer_type == \"relu\"\n",
+    "        and any(previous.layer_type == \"conv2d\" for previous in ctx.recent_ops[-2:])\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "conv_model = ConvBlock()\n",
+    "x_img = torch.randn(2, 1, 4, 4)\n",
+    "conv_recording = tl.fastlog.record(conv_model, x_img, keep_op=relu_after_conv)\n",
+    "print([record.ctx.label for record in conv_recording])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Module-event predicates\n",
+    "\n",
+    "`keep_module` receives module enter and exit events. A common pattern is to keep module exits, because those correspond to the module forward output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def keep_linear_outputs(ctx: tl.fastlog.RecordContext) -> bool:\n",
+    "    \"\"\"Keep the output event for every Linear module forward.\"\"\"\n",
+    "\n",
+    "    return ctx.kind == \"module_exit\" and ctx.module_type == \"Linear\"\n",
+    "\n",
+    "\n",
+    "module_recording = tl.fastlog.record(model, x, keep_module=keep_linear_outputs)\n",
+    "print([(record.ctx.module_address, record.ctx.kind) for record in module_recording])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## `CaptureSpec` power-user form\n",
+    "\n",
+    "Returning `True` uses the default capture policy. Returning a `CaptureSpec` lets a predicate request details such as dtype conversion, device placement, metadata-only records, or gradient retention.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def keep_relu_bfloat16(ctx: tl.fastlog.RecordContext) -> bool | tl.fastlog.CaptureSpec:\n",
+    "    \"\"\"Downcast retained ReLU payloads to bfloat16.\"\"\"\n",
+    "\n",
+    "    if ctx.kind == \"op\" and ctx.layer_type == \"relu\":\n",
+    "        return tl.fastlog.CaptureSpec(dtype=torch.bfloat16)\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "bf16_recording = tl.fastlog.record(model, x, keep_op=keep_relu_bfloat16)\n",
+    "print([record.ram_payload.dtype for record in bf16_recording])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Many-rollout pattern\n",
+    "\n",
+    "Use `Recorder` when the same predicate should run over many explicit forwards. Logging is active only inside each `rec.log(...)` call, so ordinary torch work between calls is not captured.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = [torch.randn(2, 4), torch.randn(3, 4)]\n",
+    "\n",
+    "with tl.fastlog.Recorder(model, keep_op=keep_op) as rec:\n",
+    "    for batch_id, batch in enumerate(loader):\n",
+    "        rec.log(batch, sample_id=batch_id)\n",
+    "\n",
+    "many_recording = rec.recording\n",
+    "print(many_recording.summary())\n",
+    "print([record.ctx.sample_id for record in many_recording])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Disk save\n",
+    "\n",
+    "`StreamingOptions(bundle_path=..., retain_in_memory=False)` writes a synchronous fastlog bundle and keeps tensor payloads off RAM. Load finalized bundles with `tl.fastlog.load(...)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bundle_path = Path(\"./acts.tlfast\")\n",
+    "if bundle_path.exists():\n",
+    "    shutil.rmtree(bundle_path)\n",
+    "\n",
+    "streaming = tl.StreamingOptions(bundle_path=\"./acts.tlfast\", retain_in_memory=False)\n",
+    "disk_recording = tl.fastlog.record(model, x, keep_op=keep_op, streaming=streaming)\n",
+    "loaded = tl.fastlog.load(\"./acts.tlfast\")\n",
+    "print(disk_recording.summary())\n",
+    "print(loaded.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Preview pass\n",
+    "\n",
+    "When you want to inspect a predicate on a full graph first, build a `ModelLog` and call `preview_fastlog(...)`. The preview colors the graph using synthesized fastlog contexts; it is diagnostic and does not save fastlog activations.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_log = tl.log_forward_pass(model, x, layers_to_save=\"all\", vis_save_only=True)\n",
+    "dot_source = model_log.preview_fastlog(\n",
+    "    predicate=keep_op,\n",
+    "    vis_save_only=True,\n",
+    "    vis_outpath=\"/tmp/fastlog_preview\",\n",
+    "    vis_fileformat=\"dot\",\n",
+    ")\n",
+    "print(dot_source.splitlines()[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## Dry run and repredicate iteration\n",
+    "\n",
+    "`dry_run()` executes the model and records event contexts plus keep/skip decisions without retaining tensor payloads. `repredicate(...)` reuses those contexts to test another predicate quickly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def other_predicate(ctx: tl.fastlog.RecordContext) -> bool:\n",
+    "    \"\"\"Keep Linear operation events.\"\"\"\n",
+    "\n",
+    "    return ctx.kind == \"op\" and ctx.layer_type == \"linear\"\n",
+    "\n",
+    "\n",
+    "trace = tl.fastlog.dry_run(model, x, keep_op=keep_op)\n",
+    "print(trace.print_tree())\n",
+    "print(trace.repredicate(other_predicate).summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## Bundle recovery\n",
+    "\n",
+    "`recover(...)` scans the append-only index and tolerates a partial bundle. Recovered recordings set `recovered=True` and expose any recovery warnings.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partial_path = Path(\"./partial_bundle.tlfast\")\n",
+    "if partial_path.exists():\n",
+    "    shutil.rmtree(partial_path)\n",
+    "shutil.copytree(bundle_path, partial_path)\n",
+    "(partial_path / \"manifest.json\").unlink()\n",
+    "\n",
+    "recovered = tl.fastlog.recover(\"./partial_bundle.tlfast\")\n",
+    "print(recovered.recovered)\n",
+    "print(recovered.recovery_warnings)\n",
+    "print(recovered.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "## Training compatibility\n",
+    "\n",
+    "The v1 training highlight is RAM capture with `CaptureSpec(keep_grad=True)`. The retained payload remains attached to autograd, so it can participate in an auxiliary loss.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_model = TinyMLP()\n",
+    "train_x = torch.randn(6, 4)\n",
+    "\n",
+    "\n",
+    "def keep_relu_with_grad(ctx: tl.fastlog.RecordContext) -> bool | tl.fastlog.CaptureSpec:\n",
+    "    \"\"\"Keep ReLU payloads attached to autograd.\"\"\"\n",
+    "\n",
+    "    if ctx.kind == \"op\" and ctx.layer_type == \"relu\":\n",
+    "        return tl.fastlog.CaptureSpec(keep_grad=True)\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "output, train_recording = tl.fastlog.record(\n",
+    "    train_model,\n",
+    "    train_x,\n",
+    "    keep_op=keep_relu_with_grad,\n",
+    "    return_output=True,\n",
+    ")\n",
+    "auxiliary_loss = train_recording[0].ram_payload.square().mean()\n",
+    "loss = output.mean() + auxiliary_loss\n",
+    "loss.backward()\n",
+    "assert any(\n",
+    "    parameter.grad is not None and parameter.grad.abs().sum().item() > 0\n",
+    "    for parameter in train_model.parameters()\n",
+    ")\n",
+    "print(\"gradient reached model parameters\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## Not supported in v1\n",
+    "\n",
+    "- DDP forward semantics: fastlog unwraps and captures rank-local `.module` behavior only.\n",
+    "- FSDP: rejected with the existing fastlog error.\n",
+    "- Async disk drain: disk writes are synchronous in v1.\n",
+    "- `Recording.to_model_log()`: sparse captures cannot reconstruct a faithful `ModelLog`.\n",
+    "- `keep_grad` with disk-only sessions: use RAM+disk mirror instead.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/bench_log_forward_pass.py
+++ b/scripts/bench_log_forward_pass.py
@@ -1,0 +1,108 @@
+"""Benchmark ``log_forward_pass`` on a 20-layer MLP."""
+
+import argparse
+import os
+import sys
+import statistics
+import time
+from typing import Sequence
+
+import torch
+from torch import nn
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from torchlens import log_forward_pass  # noqa: E402
+
+
+class TwentyLayerMLP(nn.Module):
+    """Simple 20-layer MLP for local logging benchmarks."""
+
+    def __init__(self, width: int = 128) -> None:
+        """Initialize the benchmark model.
+
+        Args:
+            width: Hidden dimension for every linear layer.
+        """
+        super().__init__()
+        layers = []
+        for _ in range(20):
+            layers.append(nn.Linear(width, width))
+            layers.append(nn.ReLU())
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the MLP forward pass.
+
+        Args:
+            x: Input tensor of shape ``(batch_size, width)``.
+
+        Returns:
+            Model output tensor.
+        """
+        return self.net(x)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Optional command-line argument sequence.
+
+    Returns:
+        Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=5, help="Timed benchmark runs.")
+    parser.add_argument("--warmup", type=int, default=1, help="Untimed warmup runs.")
+    parser.add_argument("--width", type=int, default=128, help="MLP hidden width.")
+    parser.add_argument("--batch-size", type=int, default=32, help="Input batch size.")
+    return parser.parse_args(argv)
+
+
+def run_once(model: nn.Module, x: torch.Tensor) -> float:
+    """Time one ``log_forward_pass`` call.
+
+    Args:
+        model: Model to log.
+        x: Input tensor for the model.
+
+    Returns:
+        Elapsed wall-clock seconds.
+    """
+    start = time.perf_counter()
+    log_forward_pass(model, x)
+    return time.perf_counter() - start
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the benchmark and print timing statistics.
+
+    Args:
+        argv: Optional command-line argument sequence.
+    """
+    args = parse_args(argv)
+    torch.manual_seed(0)
+    model = TwentyLayerMLP(width=args.width).eval()
+    x = torch.randn(args.batch_size, args.width)
+
+    with torch.no_grad():
+        for _ in range(args.warmup):
+            run_once(model, x)
+        times = [run_once(model, x) for _ in range(args.runs)]
+
+    print(f"runs: {args.runs}")
+    print(f"warmup: {args.warmup}")
+    print(f"width: {args.width}")
+    print(f"batch_size: {args.batch_size}")
+    print(f"mean_seconds: {statistics.mean(times):.6f}")
+    print(f"median_seconds: {statistics.median(times):.6f}")
+    print(f"min_seconds: {min(times):.6f}")
+    print(f"max_seconds: {max(times):.6f}")
+    print("all_seconds: " + ", ".join(f"{elapsed:.6f}" for elapsed in times))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fastlog/test_ddp_unwrap.py
+++ b/tests/test_fastlog/test_ddp_unwrap.py
@@ -1,0 +1,74 @@
+"""DDP unwrap smoke tests for fastlog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+
+
+class DdpModel(nn.Module):
+    """Simple model for DDP unwrap tests."""
+
+    def __init__(self) -> None:
+        """Initialize the layer."""
+
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the layer."""
+
+        return self.linear(x)
+
+
+def _init_process_group(tmp_path: Path) -> bool:
+    """Initialize a local single-rank process group if needed."""
+
+    if not torch.distributed.is_available():
+        return False
+    if torch.distributed.is_initialized():
+        return True
+    init_file = tmp_path / "ddp_init"
+    torch.distributed.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=0,
+        world_size=1,
+    )
+    return True
+
+
+def test_ddp_wrapped_model_records_unwrapped_module(tmp_path: Path) -> None:
+    """This exercises only the unwrapped .module, NOT DDP forward semantics."""
+
+    if not _init_process_group(tmp_path):
+        pytest.skip("torch.distributed is unavailable")
+    ddp_model = torch.nn.parallel.DistributedDataParallel(DdpModel())
+
+    recording = tl.fastlog.record(ddp_model, torch.ones(1, 2), default_op=True)
+
+    assert len(recording) > 0
+
+
+def test_ddp_bundle_path_gets_rank_prefix(tmp_path: Path) -> None:
+    """DDP disk bundles are written under a rank_NN prefix."""
+
+    if not _init_process_group(tmp_path):
+        pytest.skip("torch.distributed is unavailable")
+    ddp_model = torch.nn.parallel.DistributedDataParallel(DdpModel())
+    requested = tmp_path / "bundle.tlfast"
+
+    recording = tl.fastlog.record(
+        ddp_model,
+        torch.ones(1, 2),
+        default_op=True,
+        streaming=tl.StreamingOptions(bundle_path=requested, retain_in_memory=False),
+    )
+
+    assert recording.bundle_path == tmp_path / "rank_00" / "bundle.tlfast"
+    assert (tmp_path / "rank_00" / "bundle.tlfast" / "manifest.json").exists()

--- a/tests/test_fastlog/test_dispatch_smoke.py
+++ b/tests/test_fastlog/test_dispatch_smoke.py
@@ -1,0 +1,115 @@
+"""Smoke coverage for predicate-mode capture dispatchers."""
+
+from __future__ import annotations
+
+import time
+
+import torch
+from torch import nn
+
+from torchlens import _state
+from torchlens.capture.source_tensors import log_source_tensor
+from torchlens.data_classes.model_log import ModelLog
+from torchlens.decoration.model_prep import (
+    _cleanup_model_session,
+    _ensure_model_prepared,
+    _prepare_model_session,
+)
+from torchlens.fastlog._state import RecordingState, active_recording_state
+from torchlens.fastlog.options import RecordingOptions
+from torchlens.fastlog.types import CaptureSpec, Recording
+
+
+class TinyMlp(nn.Module):
+    """Two-layer MLP for predicate dispatcher smoke tests."""
+
+    def __init__(self) -> None:
+        """Initialize the test network."""
+
+        super().__init__()
+        self.layers = nn.Sequential(nn.Linear(3, 4), nn.ReLU(), nn.Linear(4, 2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tiny network."""
+
+        return self.layers(x)
+
+
+def _empty_recording(history_size: int) -> Recording:
+    """Build an empty in-memory Recording for dispatcher tests."""
+
+    return Recording(
+        records=[],
+        by_pass={},
+        by_label={},
+        by_module_address={},
+        bundle_path=None,
+        n_passes=1,
+        n_records=0,
+        pass_start_times=[],
+        pass_end_times=[],
+        predicate_failures=[],
+        predicate_failure_overflow_count=0,
+        keep_op_repr=None,
+        keep_module_repr=None,
+        history_size=history_size,
+    )
+
+
+def _run_dispatcher_smoke(
+    model: nn.Module,
+    x: torch.Tensor,
+    options: RecordingOptions,
+) -> Recording:
+    """Run a minimal predicate pass through existing dispatchers."""
+
+    model_log = ModelLog("TinyMlp")
+    model_log.logging_mode = "predicate"
+    model_log.pass_start_time = time.time()
+    state = RecordingState(options=options, recording=_empty_recording(options.history_size))
+    _ensure_model_prepared(model)
+    _prepare_model_session(model_log, model)
+    try:
+        with active_recording_state(state), _state.active_logging(model_log):
+            log_source_tensor(model_log, x, "input", "input.x")
+            model(x)
+    finally:
+        _cleanup_model_session(model, [x])
+    return state.recording
+
+
+def test_predicate_dispatchers_fire_and_store_ram_payloads() -> None:
+    """Predicate mode calls predicates and stores RAM payloads through dispatchers."""
+
+    seen_kinds: list[str] = []
+
+    def keep_op(ctx) -> bool | CaptureSpec | None:
+        """Keep operation events and record predicate invocation."""
+
+        seen_kinds.append(ctx.kind)
+        return ctx.kind == "op"
+
+    def keep_module(ctx) -> bool:
+        """Keep module events and record predicate invocation."""
+
+        seen_kinds.append(ctx.kind)
+        return True
+
+    recording = _run_dispatcher_smoke(
+        TinyMlp(),
+        torch.ones(1, 3),
+        RecordingOptions(
+            keep_op=keep_op,
+            keep_module=keep_module,
+            default_op=False,
+            default_module=False,
+            include_source_events=True,
+        ),
+    )
+
+    assert "input" in seen_kinds
+    assert "op" in seen_kinds
+    assert "module_enter" in seen_kinds
+    assert "module_exit" in seen_kinds
+    assert len(recording.records) > 0
+    assert any(record.ctx.kind == "op" and record.ram_payload is not None for record in recording)

--- a/tests/test_fastlog/test_dry_run.py
+++ b/tests/test_fastlog/test_dry_run.py
@@ -1,0 +1,73 @@
+"""Comprehensive dry-run visualization tests for fastlog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import RecordContext
+
+
+def _mlp() -> nn.Module:
+    """Return a small static MLP."""
+
+    return nn.Sequential(nn.Linear(4, 5), nn.ReLU(), nn.Linear(5, 2))
+
+
+def _keep_linear(ctx: RecordContext) -> bool:
+    """Keep linear operation events."""
+
+    return ctx.kind == "op" and ctx.layer_type == "linear"
+
+
+def _keep_relu(ctx: RecordContext) -> bool:
+    """Keep relu operation events."""
+
+    return ctx.kind == "op" and ctx.layer_type == "relu"
+
+
+def test_print_tree_has_non_empty_output() -> None:
+    """print_tree returns non-empty tree text."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+
+    assert trace.print_tree().strip()
+
+
+def test_to_pandas_has_expected_columns() -> None:
+    """to_pandas returns the expected public columns."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+
+    assert list(trace.to_pandas().columns) == [
+        "pass_num",
+        "step_num",
+        "kind",
+        "op_type",
+        "module_address",
+        "shape",
+        "dtype",
+    ]
+
+
+def test_repredicate_changes_decisions_without_changing_events() -> None:
+    """repredicate changes decisions while preserving event identity."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+    updated = trace.repredicate(other_keep_op=_keep_relu)
+
+    assert updated.events is trace.events
+    assert updated.decisions != trace.decisions
+
+
+def test_show_graph_renders_without_error(tmp_path: Path) -> None:
+    """show_graph returns DOT and Graphviz can render it."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+    dot = trace.show_graph(vis_outpath=str(tmp_path / "dry_run"), vis_fileformat="png")
+
+    assert "digraph" in dot
+    assert (tmp_path / "dry_run.png").exists()

--- a/tests/test_fastlog/test_dry_run_render.py
+++ b/tests/test_fastlog/test_dry_run_render.py
@@ -1,0 +1,62 @@
+"""Smoke tests for fastlog dry-run live visualization helpers."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog.types import RecordContext
+
+
+def _mlp() -> nn.Module:
+    """Return a small two-layer MLP."""
+
+    return nn.Sequential(nn.Linear(4, 5), nn.ReLU(), nn.Linear(5, 2))
+
+
+def _keep_linear(ctx: RecordContext) -> bool:
+    """Keep linear operation events."""
+
+    return ctx.kind == "op" and ctx.layer_type == "linear"
+
+
+def _keep_relu(ctx: RecordContext) -> bool:
+    """Keep relu operation events."""
+
+    return ctx.kind == "op" and ctx.layer_type == "relu"
+
+
+def test_print_tree_outputs_unicode_rows() -> None:
+    """Dry-run print_tree returns non-empty unicode-indented text."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+    text = trace.print_tree()
+    assert text
+    assert "└─" in text
+
+
+def test_to_pandas_expected_columns() -> None:
+    """Dry-run to_pandas returns the public event columns."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+    frame = trace.to_pandas()
+    assert list(frame.columns) == [
+        "pass_num",
+        "step_num",
+        "kind",
+        "op_type",
+        "module_address",
+        "shape",
+        "dtype",
+    ]
+
+
+def test_repredicate_updates_decisions_without_replacing_events() -> None:
+    """Repredicate returns a new trace with shared events and changed decisions."""
+
+    trace = tl.fastlog.dry_run(_mlp(), torch.randn(1, 4), keep_op=_keep_linear)
+    updated = trace.repredicate(other_keep_op=_keep_relu)
+    assert updated is not trace
+    assert updated.events is trace.events
+    assert updated.decisions != trace.decisions

--- a/tests/test_fastlog/test_dynamic_graph.py
+++ b/tests/test_fastlog/test_dynamic_graph.py
@@ -1,0 +1,43 @@
+"""Dynamic graph coverage for repeated fastlog recording."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+import torchlens as tl
+
+
+class DynamicMLP(nn.Module):
+    """MLP with input-dependent control flow."""
+
+    def __init__(self) -> None:
+        """Initialize three layers."""
+
+        super().__init__()
+        self.layers = nn.ModuleList(nn.Linear(4, 4) for _ in range(3))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a variable number of layers based on the input sum."""
+
+        for i in range(int(x.sum().item()) % 3 + 1):
+            x = F.relu(self.layers[i](x))
+        return x
+
+
+def test_dynamic_graph_records_1000_passes_with_varying_event_counts() -> None:
+    """Recorder handles 1000 input-dependent passes and preserves pass counts."""
+
+    model = DynamicMLP()
+    with tl.fastlog.Recorder(model, keep_op=lambda ctx: ctx.kind == "op") as recorder:
+        for index in range(1000):
+            recorder.log(torch.full((1, 4), float(index)))
+    recording = recorder.recording
+    op_counts = Counter(record.ctx.pass_index for record in recording if record.ctx.kind == "op")
+
+    assert recording.n_passes == 1000
+    assert set(op_counts.values()) == {3, 5, 7}
+    assert {op_counts[index] for index in (1, 2, 3)} == {3, 5, 7}

--- a/tests/test_fastlog/test_enrich.py
+++ b/tests/test_fastlog/test_enrich.py
@@ -1,0 +1,46 @@
+"""Tests for opt-in fastlog recording enrichments."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog.exceptions import RecordingConfigError
+
+
+def _mlp() -> nn.Module:
+    """Return a small two-layer MLP."""
+
+    return nn.Sequential(nn.Linear(4, 5), nn.ReLU(), nn.Linear(5, 2))
+
+
+def test_enrich_module_path_strings_populates_metadata() -> None:
+    """Module path enrichment adds expected metadata fields."""
+
+    recording = tl.fastlog.record(_mlp(), torch.randn(1, 4), default_op=True)
+    enriched = recording.enrich(["module_path_strings"])
+    assert enriched is not recording
+    assert enriched.records
+    assert "module_path_strings" in enriched.records[0].metadata
+    assert "module_path" in enriched.records[0].metadata
+
+
+def test_enrich_param_addresses_requires_capture_time_field() -> None:
+    """Param address enrichment raises clearly when capture data is absent."""
+
+    recording = tl.fastlog.record(_mlp(), torch.randn(1, 4), default_op=True)
+    with pytest.raises(RecordingConfigError, match="parent_param_addresses"):
+        recording.enrich(["param_addresses"])
+
+
+def test_enrich_all_feasible_matches_available_enrichments() -> None:
+    """All-feasible applies all enrichments currently computable."""
+
+    recording = tl.fastlog.record(_mlp(), torch.randn(1, 4), default_op=True)
+    by_name = recording.enrich(["module_path_strings"])
+    by_preset = recording.enrich("all-feasible")
+    assert [record.metadata for record in by_preset.records] == [
+        record.metadata for record in by_name.records
+    ]

--- a/tests/test_fastlog/test_module_events.py
+++ b/tests/test_fastlog/test_module_events.py
@@ -1,0 +1,131 @@
+"""Comprehensive module-event behavior tests for fastlog."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+import torchlens._state as torchlens_state
+import torchlens.fastlog._state as fastlog_state
+from torchlens.fastlog import PredicateError, RecordContext
+
+
+class RootLinear(nn.Linear):
+    """A root-only linear model."""
+
+
+class SharedModule(nn.Module):
+    """Model that calls one shared child twice."""
+
+    def __init__(self) -> None:
+        """Initialize the shared module."""
+
+        super().__init__()
+        self.shared = nn.Linear(3, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Call the same child twice."""
+
+        return self.shared(self.shared(x))
+
+
+class IdentitySequence(nn.Module):
+    """Sequential model containing an identity pass-through."""
+
+    def __init__(self) -> None:
+        """Initialize the sequence."""
+
+        super().__init__()
+        self.sequence = nn.Sequential(nn.Linear(3, 3), nn.Identity())
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the sequence."""
+
+        return self.sequence(x)
+
+
+class RaisingModel(nn.Module):
+    """Model that raises from forward."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Raise a controlled exception."""
+
+        raise RuntimeError("forward exploded")
+
+
+def test_root_only_linear_emits_root_enter_exit() -> None:
+    """A single root nn.Linear still emits root enter and exit events."""
+
+    recording = tl.fastlog.record(
+        RootLinear(3, 2),
+        torch.ones(1, 3),
+        keep_module=lambda ctx: ctx.module_address == "",
+    )
+
+    assert [record.ctx.kind for record in recording] == ["module_enter", "module_exit"]
+
+
+def test_shared_module_pass_counter_increments_for_two_calls() -> None:
+    """Shared module pass counters increment for repeated calls in one forward."""
+
+    recording = tl.fastlog.record(
+        SharedModule(),
+        torch.ones(1, 3),
+        keep_module=lambda ctx: ctx.module_address == "shared",
+    )
+    child_events = [record.ctx for record in recording if record.ctx.module_address == "shared"]
+
+    assert [ctx.kind for ctx in child_events] == [
+        "module_enter",
+        "module_exit",
+        "module_enter",
+        "module_exit",
+    ]
+    assert [ctx.module_pass_index for ctx in child_events] == [1, 1, 2, 2]
+
+
+def test_identity_sequence_pass_through_tensor_is_visible() -> None:
+    """Identity modules emit events and pass-through tensors remain visible."""
+
+    recording = tl.fastlog.record(
+        IdentitySequence(),
+        torch.ones(1, 3),
+        keep_module=lambda ctx: bool(ctx.module_address and "1" in ctx.module_address),
+        default_op=False,
+    )
+
+    assert any(record.ctx.module_type == "Identity" for record in recording)
+
+
+def test_forward_exception_cleans_recording_stack() -> None:
+    """Forward exceptions clean global TorchLens and fastlog state."""
+
+    with pytest.raises(RuntimeError, match="forward exploded"):
+        tl.fastlog.record(RaisingModel(), torch.ones(1), default_module=True)
+
+    assert torchlens_state._logging_enabled is False
+    assert torchlens_state._active_model_log is None
+    assert fastlog_state._active_recording_state is None
+
+
+def test_predicate_exception_cleans_stack_and_respects_fail_fast() -> None:
+    """Fail-fast predicate exceptions clean global state immediately."""
+
+    def keep_op(ctx: RecordContext) -> bool:
+        """Raise for operation predicates."""
+
+        raise PredicateError("predicate exploded", ctx=ctx)
+
+    with pytest.raises(PredicateError, match="predicate exploded"):
+        tl.fastlog.record(
+            SharedModule(),
+            torch.ones(1, 3),
+            keep_op=keep_op,
+            on_predicate_error="fail-fast",
+        )
+
+    assert torchlens_state._logging_enabled is False
+    assert torchlens_state._active_model_log is None
+    assert fastlog_state._active_recording_state is None

--- a/tests/test_fastlog/test_no_bare_detach.py
+++ b/tests/test_fastlog/test_no_bare_detach.py
@@ -1,0 +1,34 @@
+"""AST guardrail tests for fastlog detach behavior."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _python_files() -> list[Path]:
+    """Return files whose predicate-mode branches must avoid bare detach."""
+
+    return [
+        *Path("torchlens/fastlog").glob("*.py"),
+        Path("torchlens/capture/output_tensors.py"),
+        Path("torchlens/capture/source_tensors.py"),
+        Path("torchlens/decoration/model_prep.py"),
+    ]
+
+
+def test_no_bare_detach_calls_in_fastlog_paths() -> None:
+    """Only safe_copy may detach tensors for fastlog capture paths."""
+
+    offenders: list[str] = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "detach"
+            ):
+                offenders.append(f"{path}:{node.lineno}")
+
+    assert offenders == []

--- a/tests/test_fastlog/test_no_torch_no_grad.py
+++ b/tests/test_fastlog/test_no_torch_no_grad.py
@@ -1,0 +1,32 @@
+"""AST guardrail tests for grad-preserving fastlog paths."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _python_files() -> list[Path]:
+    """Return files whose predicate-mode branches must avoid no_grad."""
+
+    return [
+        *Path("torchlens/fastlog").glob("*.py"),
+        Path("torchlens/capture/output_tensors.py"),
+        Path("torchlens/capture/source_tensors.py"),
+        Path("torchlens/decoration/model_prep.py"),
+    ]
+
+
+def test_no_torch_no_grad_or_inference_mode_in_fastlog_paths() -> None:
+    """Fastlog and predicate-mode branches do not use torch no-grad contexts."""
+
+    offenders: list[str] = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute):
+                continue
+            if node.attr in {"no_grad", "inference_mode"}:
+                offenders.append(f"{path}:{node.lineno}:{node.attr}")
+
+    assert offenders == []

--- a/tests/test_fastlog/test_orchestrator.py
+++ b/tests/test_fastlog/test_orchestrator.py
@@ -9,6 +9,7 @@ from torch import nn
 import torchlens._state as torchlens_state
 import torchlens.fastlog._state as fastlog_state
 from torchlens.fastlog._orchestrator import _run_predicate_pass
+from torchlens.fastlog.exceptions import PredicateError
 from torchlens.fastlog.options import RecordingOptions
 
 
@@ -133,7 +134,7 @@ def test_predicate_exception_cleans_logging_state() -> None:
 
         raise RuntimeError(f"bad predicate for {ctx.kind}")
 
-    with pytest.raises(RuntimeError, match="bad predicate"):
+    with pytest.raises(PredicateError, match="fastlog predicate failed"):
         _run_predicate_pass(
             RootOnly(),
             torch.ones(1),

--- a/tests/test_fastlog/test_orchestrator.py
+++ b/tests/test_fastlog/test_orchestrator.py
@@ -1,0 +1,146 @@
+"""Tests for the internal fastlog predicate orchestrator."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens._state as torchlens_state
+import torchlens.fastlog._state as fastlog_state
+from torchlens.fastlog._orchestrator import _run_predicate_pass
+from torchlens.fastlog.options import RecordingOptions
+
+
+class RootOnly(nn.Module):
+    """Model with operations only at the root module."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a root-only operation."""
+
+        return x + 1
+
+
+class SharedModule(nn.Module):
+    """Model that calls one child module twice."""
+
+    def __init__(self) -> None:
+        """Initialize the shared child."""
+
+        super().__init__()
+        self.shared = nn.Linear(3, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Call the same module twice."""
+
+        return self.shared(self.shared(x))
+
+
+class IdentityModel(nn.Module):
+    """Model containing an Identity pass-through module."""
+
+    def __init__(self) -> None:
+        """Initialize the identity module."""
+
+        super().__init__()
+        self.identity = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return the identity output."""
+
+        return self.identity(x)
+
+
+class RaisingModel(nn.Module):
+    """Model whose forward method always raises."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Raise during forward."""
+
+        raise RuntimeError("forward failed")
+
+
+def _options() -> RecordingOptions:
+    """Return options that keep all module events and operation payloads."""
+
+    return RecordingOptions(
+        keep_op=lambda ctx: ctx.kind == "op",
+        keep_module=lambda ctx: True,
+        default_op=False,
+        default_module=False,
+        include_source_events=True,
+    )
+
+
+def test_root_only_model_emits_root_events() -> None:
+    """Root-only models still get synthetic root enter and exit events."""
+
+    output, recording = _run_predicate_pass(RootOnly(), torch.ones(1), None, _options())
+    kinds = [record.ctx.kind for record in recording]
+
+    assert torch.equal(output, torch.tensor([2.0]))
+    assert kinds.count("module_enter") == 1
+    assert kinds.count("module_exit") == 1
+    assert recording.records[0].ctx.label == "root:enter:1"
+    assert recording.records[-1].ctx.label == "root:exit:1"
+
+
+def test_shared_module_called_twice_has_balanced_events() -> None:
+    """A shared child module called twice emits balanced enter/exit events."""
+
+    _, recording = _run_predicate_pass(SharedModule(), torch.ones(1, 3), None, _options())
+    child_events = [
+        record.ctx
+        for record in recording
+        if record.ctx.module_address == "shared" and record.ctx.kind.startswith("module")
+    ]
+
+    assert [ctx.kind for ctx in child_events] == [
+        "module_enter",
+        "module_exit",
+        "module_enter",
+        "module_exit",
+    ]
+    assert [ctx.module_pass_index for ctx in child_events] == [1, 1, 2, 2]
+
+
+def test_identity_passthrough_has_module_events() -> None:
+    """Identity modules are represented even when their tensor passes through."""
+
+    output, recording = _run_predicate_pass(IdentityModel(), torch.ones(1), None, _options())
+    labels = [record.ctx.module_address for record in recording]
+
+    assert torch.equal(output, torch.ones(1))
+    assert "identity" in labels
+
+
+def test_forward_exception_cleans_logging_state() -> None:
+    """Forward exceptions leave global logging and recording state inactive."""
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        _run_predicate_pass(RaisingModel(), torch.ones(1), None, _options())
+
+    assert torchlens_state._logging_enabled is False
+    assert torchlens_state._active_model_log is None
+    assert fastlog_state._active_recording_state is None
+
+
+def test_predicate_exception_cleans_logging_state() -> None:
+    """Predicate exceptions leave global logging and recording state inactive."""
+
+    def bad_keep_module(ctx) -> bool:
+        """Raise from the module predicate."""
+
+        raise RuntimeError(f"bad predicate for {ctx.kind}")
+
+    with pytest.raises(RuntimeError, match="bad predicate"):
+        _run_predicate_pass(
+            RootOnly(),
+            torch.ones(1),
+            None,
+            RecordingOptions(keep_module=bad_keep_module, default_op=False),
+        )
+
+    assert torchlens_state._logging_enabled is False
+    assert torchlens_state._active_model_log is None
+    assert fastlog_state._active_recording_state is None

--- a/tests/test_fastlog/test_perf_smoke.py
+++ b/tests/test_fastlog/test_perf_smoke.py
@@ -1,0 +1,59 @@
+"""Functional performance-regression smoke tests."""
+
+from __future__ import annotations
+
+from types import FrameType
+
+import torch
+from torch import nn
+
+import torchlens as tl
+import torchlens.utils.introspection as introspection
+
+
+class TenLayerMlp(nn.Module):
+    """Ten-layer MLP for stack-introspection smoke tests."""
+
+    def __init__(self) -> None:
+        """Initialize layers."""
+
+        super().__init__()
+        layers: list[nn.Module] = []
+        for _ in range(10):
+            layers.extend([nn.Linear(8, 8), nn.ReLU()])
+        self.layers = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the MLP."""
+
+        return self.layers(x)
+
+
+def test_col_offset_and_qualname_called_only_on_filtered_frames(monkeypatch) -> None:
+    """Stack helpers are called on filtered frames, not every raw frame."""
+
+    col_offset_calls = 0
+    qualname_calls = 0
+
+    def fake_col_offset(frame: FrameType) -> int:
+        """Count col-offset calls."""
+
+        nonlocal col_offset_calls
+        col_offset_calls += 1
+        return 0
+
+    def fake_qualname(frame: FrameType) -> str:
+        """Count qualname calls."""
+
+        nonlocal qualname_calls
+        qualname_calls += 1
+        return frame.f_code.co_name
+
+    monkeypatch.setattr(introspection, "_get_col_offset", fake_col_offset)
+    monkeypatch.setattr(introspection, "_get_code_qualname", fake_qualname)
+
+    model_log = tl.log_forward_pass(TenLayerMlp(), torch.randn(1, 8))
+
+    assert len(model_log.layer_list) >= 20
+    assert 0 < col_offset_calls < 200
+    assert 0 < qualname_calls < 200

--- a/tests/test_fastlog/test_persistence_recover.py
+++ b/tests/test_fastlog/test_persistence_recover.py
@@ -1,0 +1,182 @@
+"""Persistence load and recovery corruption-matrix tests for fastlog."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import RecoveryError
+
+
+class PersistenceModel(nn.Module):
+    """Small model for persistence tests."""
+
+    def __init__(self) -> None:
+        """Initialize the layer."""
+
+        super().__init__()
+        self.linear = nn.Linear(3, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a forward pass."""
+
+        return torch.relu(self.linear(x))
+
+
+def _write_bundle(path: Path) -> tl.fastlog.Recording:
+    """Write a finalized disk-only bundle."""
+
+    return tl.fastlog.record(
+        PersistenceModel(),
+        torch.ones(1, 3),
+        default_op=True,
+        streaming=tl.StreamingOptions(bundle_path=path, retain_in_memory=False),
+    )
+
+
+def _copy_bundle(source: Path, destination: Path) -> Path:
+    """Copy a finalized bundle for corruption testing."""
+
+    shutil.copytree(source, destination)
+    return destination
+
+
+def _labels(recording: tl.fastlog.Recording) -> list[str]:
+    """Return record labels for equality checks."""
+
+    return [record.ctx.label for record in recording.records]
+
+
+def _first_blob(bundle_path: Path) -> Path:
+    """Return the first persisted safetensors blob."""
+
+    return next((bundle_path / "blobs").glob("*.safetensors"))
+
+
+def test_finalized_bundle_loads_and_recover_returns_identical_not_recovered(
+    tmp_path: Path,
+) -> None:
+    """Finalized bundles load and recover as identical non-recovered recordings."""
+
+    bundle_path = tmp_path / "final.tlfast"
+    original = _write_bundle(bundle_path)
+
+    loaded = tl.fastlog.load(bundle_path)
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert loaded.recovered is False
+    assert recovered.recovered is False
+    assert _labels(loaded) == _labels(original)
+    assert _labels(recovered) == _labels(loaded)
+    assert list(recovered.records)
+
+
+def test_recover_with_missing_manifest_walks_jsonl(tmp_path: Path) -> None:
+    """Recovery ignores a missing manifest and scans JSONL."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "missing"
+    )
+    (bundle_path / "manifest.json").unlink()
+
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert recovered.recovered is True
+    assert len(recovered.records) > 0
+
+
+def test_recover_with_malformed_manifest_uses_jsonl(tmp_path: Path) -> None:
+    """Recovery ignores malformed manifest JSON and scans JSONL."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "badmanifest"
+    )
+    (bundle_path / "manifest.json").write_text("{", encoding="utf-8")
+
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert recovered.recovered is True
+    assert len(recovered.records) > 0
+
+
+def test_recover_missing_jsonl_raises(tmp_path: Path) -> None:
+    """Recovery fails clearly when the JSONL index is absent."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "noindex"
+    )
+    (bundle_path / "manifest.json").unlink()
+    (bundle_path / "fastlog_index.jsonl").unlink()
+
+    with pytest.raises(RecoveryError, match="no recoverable index"):
+        tl.fastlog.recover(bundle_path)
+
+
+def test_recover_skips_truncated_last_jsonl_line(tmp_path: Path) -> None:
+    """Recovery skips a truncated JSONL tail line and keeps earlier records."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "truncated"
+    )
+    (bundle_path / "manifest.json").unlink()
+    index_path = bundle_path / "fastlog_index.jsonl"
+    text = index_path.read_text(encoding="utf-8")
+    index_path.write_text(text + '{"ctx":', encoding="utf-8")
+
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert any("truncated tail" in warning for warning in recovered.recovery_warnings)
+    assert len(recovered.records) > 0
+
+
+def test_recover_skips_malformed_middle_line_and_continues(tmp_path: Path) -> None:
+    """Recovery skips malformed middle lines and continues scanning."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "middle"
+    )
+    (bundle_path / "manifest.json").unlink()
+    index_path = bundle_path / "fastlog_index.jsonl"
+    lines = index_path.read_text(encoding="utf-8").splitlines()
+    lines.insert(1, "not-json")
+    index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert any("malformed line" in warning for warning in recovered.recovery_warnings)
+    assert len(recovered.records) == len(lines) - 1
+
+
+def test_recover_skips_missing_blob_record(tmp_path: Path) -> None:
+    """Recovery skips JSONL records whose blob file is missing."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "missingblob"
+    )
+    (bundle_path / "manifest.json").unlink()
+    _first_blob(bundle_path).unlink()
+
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert any("missing blob" in warning for warning in recovered.recovery_warnings)
+    assert len(recovered.records) > 0
+
+
+def test_recover_skips_hash_mismatch_record(tmp_path: Path) -> None:
+    """Recovery skips JSONL records whose blob hash does not match."""
+
+    bundle_path = _copy_bundle(
+        _write_bundle(tmp_path / "source.tlfast").bundle_path, tmp_path / "hash"
+    )
+    (bundle_path / "manifest.json").unlink()
+    _first_blob(bundle_path).write_bytes(b"corrupt")
+
+    recovered = tl.fastlog.recover(bundle_path)
+
+    assert any("hash mismatch" in warning for warning in recovered.recovery_warnings)
+    assert list(recovered.records)

--- a/tests/test_fastlog/test_predicate_api.py
+++ b/tests/test_fastlog/test_predicate_api.py
@@ -1,0 +1,89 @@
+"""Comprehensive predicate API contract tests for fastlog."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import CaptureSpec, PredicateError, RecordContext
+
+
+class PredicateApiModel(nn.Module):
+    """Small model for predicate API tests."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run one differentiable operation."""
+
+        return torch.relu(x + 1)
+
+
+def _make_generator() -> Generator[bool, None, None]:
+    """Return a generator object for invalid-return validation."""
+
+    yield True
+
+
+def test_predicate_accepts_record_context_signature() -> None:
+    """Predicates receive a RecordContext instance."""
+
+    seen: list[RecordContext] = []
+
+    def keep_op(ctx: RecordContext) -> bool:
+        """Keep operation events and record the predicate argument."""
+
+        seen.append(ctx)
+        return ctx.kind == "op"
+
+    recording = tl.fastlog.record(PredicateApiModel(), torch.ones(2), keep_op=keep_op)
+
+    assert len(recording) > 0
+    assert seen
+    assert all(isinstance(ctx, RecordContext) for ctx in seen)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [True, False, None, CaptureSpec(save_activation=True, save_metadata=False)],
+)
+def test_predicate_accepts_supported_return_types(result: bool | CaptureSpec | None) -> None:
+    """Bool, CaptureSpec, and None predicate returns are accepted."""
+
+    def keep_op(ctx: RecordContext) -> bool | CaptureSpec | None:
+        """Return the parametrized decision for operation events."""
+
+        return result if ctx.kind == "op" else False
+
+    recording = tl.fastlog.record(
+        PredicateApiModel(),
+        torch.ones(2),
+        keep_op=keep_op,
+        default_op=True,
+    )
+
+    assert recording.n_passes == 1
+
+
+@pytest.mark.parametrize(
+    "bad_result",
+    [torch.tensor(True), "yes", 1, _make_generator()],
+)
+def test_predicate_rejects_invalid_return_types_with_event_context(bad_result: Any) -> None:
+    """Unsupported predicate returns raise PredicateError with event context."""
+
+    def keep_op(ctx: RecordContext) -> Any:
+        """Return an invalid predicate value for operation events."""
+
+        return bad_result if ctx.kind == "op" else False
+
+    with pytest.raises(PredicateError) as exc_info:
+        tl.fastlog.record(PredicateApiModel(), torch.ones(2), keep_op=keep_op)
+
+    assert exc_info.value.ctx is not None or exc_info.value.failures
+    if exc_info.value.ctx is not None:
+        assert exc_info.value.ctx.kind == "op"
+        assert exc_info.value.result is bad_result

--- a/tests/test_fastlog/test_predicate_defaults.py
+++ b/tests/test_fastlog/test_predicate_defaults.py
@@ -1,0 +1,85 @@
+"""Default predicate decision semantics for fastlog."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import CaptureSpec, RecordContext, RecordingConfigError
+
+
+class DefaultsModel(nn.Module):
+    """Small model for default-decision tests."""
+
+    def __init__(self) -> None:
+        """Initialize a linear layer."""
+
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model."""
+
+        return torch.relu(self.linear(x))
+
+
+@pytest.mark.parametrize("default_op", [True, False, CaptureSpec(save_metadata=True)])
+def test_default_op_accepts_bool_and_capture_spec(default_op: bool | CaptureSpec) -> None:
+    """Operation defaults accept bool and CaptureSpec values."""
+
+    recording = tl.fastlog.record(
+        DefaultsModel(),
+        torch.ones(1, 2),
+        keep_module=lambda ctx: False,
+        default_op=default_op,
+    )
+
+    expected_any_ops = default_op is not False
+    assert any(record.ctx.kind == "op" for record in recording) is expected_any_ops
+
+
+@pytest.mark.parametrize("default_module", [True, False, CaptureSpec(save_metadata=True)])
+def test_default_module_accepts_bool_and_capture_spec(
+    default_module: bool | CaptureSpec,
+) -> None:
+    """Module defaults accept bool and CaptureSpec values."""
+
+    recording = tl.fastlog.record(
+        DefaultsModel(),
+        torch.ones(1, 2),
+        keep_op=lambda ctx: False,
+        default_module=default_module,
+    )
+
+    expected_any_modules = default_module is not False
+    assert any(record.ctx.kind.startswith("module") for record in recording) is expected_any_modules
+
+
+def test_none_abstain_uses_default_op() -> None:
+    """A None operation predicate return falls back to default_op."""
+
+    recording = tl.fastlog.record(
+        DefaultsModel(),
+        torch.ones(1, 2),
+        keep_op=lambda ctx: None,
+        default_op=CaptureSpec(save_activation=False, save_metadata=True),
+    )
+
+    assert recording.records
+    assert all(record.ram_payload is None for record in recording)
+    assert all(record.spec.save_metadata for record in recording)
+
+
+def test_noop_recorder_configuration_errors_at_construction() -> None:
+    """A statically empty recorder configuration is rejected immediately."""
+
+    with pytest.raises(RecordingConfigError, match="requires a predicate"):
+        tl.fastlog.Recorder(
+            DefaultsModel(),
+            keep_op=None,
+            keep_module=None,
+            default_op=False,
+            default_module=False,
+        )

--- a/tests/test_fastlog/test_predicate_eval.py
+++ b/tests/test_fastlog/test_predicate_eval.py
@@ -1,0 +1,133 @@
+"""Tests for fastlog predicate normalization and RecordContext construction."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+import torch
+
+from torchlens.fastlog._predicate import (
+    _evaluate_keep_module,
+    _evaluate_keep_op,
+    _normalize_capture_decision,
+)
+from torchlens.fastlog._record_context import _build_record_context
+from torchlens.fastlog.exceptions import PredicateError
+from torchlens.fastlog.options import RecordingOptions
+from torchlens.fastlog.types import CaptureSpec, ModuleStackFrame
+
+
+def _ctx() -> object:
+    """Build a minimal operation context for predicate tests."""
+
+    return _build_record_context(
+        kind="op",
+        layer_pass_log_or_op_data={
+            "label": "linear_1_1_raw",
+            "func_name": "linear",
+            "tensor": torch.ones(2, 3),
+        },
+        event_index=1,
+        op_index=1,
+    )
+
+
+def test_normalize_capture_decision_bool_and_none_rules() -> None:
+    """Boolean and None returns normalize according to the slot default."""
+
+    ctx = _ctx()
+    default = CaptureSpec(save_activation=True, save_metadata=False, keep_grad=True)
+
+    keep = _normalize_capture_decision(True, ctx, default)
+    skip = _normalize_capture_decision(False, ctx, default)
+    inherited = _normalize_capture_decision(None, ctx, default)
+
+    assert keep == CaptureSpec(save_activation=True, save_metadata=True, keep_grad=True)
+    assert skip == CaptureSpec(save_activation=False, save_metadata=False)
+    assert inherited is default
+
+
+def test_normalize_capture_decision_accepts_capture_spec() -> None:
+    """CaptureSpec returns pass through unchanged."""
+
+    ctx = _ctx()
+    spec = CaptureSpec(save_activation=False, save_metadata=True)
+
+    assert _normalize_capture_decision(spec, ctx, False) is spec
+
+
+@pytest.mark.parametrize("bad_result", [1, "yes", torch.tensor(True)])
+def test_normalize_capture_decision_rejects_invalid_returns(bad_result: object) -> None:
+    """Invalid predicate return values raise PredicateError with context."""
+
+    ctx = _ctx()
+
+    with pytest.raises(PredicateError) as exc_info:
+        _normalize_capture_decision(bad_result, ctx, False)  # type: ignore[arg-type]
+
+    assert exc_info.value.ctx is ctx
+    assert exc_info.value.result is bad_result
+
+
+def test_evaluate_keep_op_and_module_use_predicates_and_defaults() -> None:
+    """Slot evaluators call the right predicate and default."""
+
+    ctx = _ctx()
+    options = RecordingOptions(
+        keep_op=lambda event: event.func_name == "linear",
+        keep_module=lambda event: None,
+        default_module=True,
+    )
+
+    assert _evaluate_keep_op(ctx, options).save_activation is True
+    assert _evaluate_keep_module(ctx, options) == CaptureSpec(
+        save_activation=True,
+        save_metadata=True,
+    )
+
+
+def test_record_context_constructor_is_schema_source_of_truth() -> None:
+    """Equivalent inputs from real and synthesized data produce identical contexts."""
+
+    tensor = torch.ones(2, 3)
+    module_stack = (
+        ModuleStackFrame(
+            module_address="encoder",
+            module_type="Linear",
+            module_id=123,
+            pass_index=1,
+        ),
+    )
+    op_data = {
+        "label": "relu_1_2_raw",
+        "raw_label": "relu_1_2_raw",
+        "creation_order": 2,
+        "func_name": "relu",
+        "module_address": "encoder",
+        "module_type": "Linear",
+        "module_pass_index": 1,
+        "parent_labels": ("input_1_raw",),
+        "tensor": tensor,
+        "output_index": 0,
+        "is_bottom_level_func": True,
+    }
+
+    real_ctx = _build_record_context(
+        kind="op",
+        layer_pass_log_or_op_data=op_data,
+        module_stack=module_stack,
+        event_index=2,
+        op_index=1,
+        time_since_pass_start=0.25,
+    )
+    synth_ctx = _build_record_context(
+        kind="op",
+        layer_pass_log_or_op_data=op_data,
+        module_stack=tuple(frame for frame in module_stack),
+        event_index=2,
+        op_index=1,
+        time_since_pass_start=0.25,
+    )
+
+    assert asdict(real_ctx) == asdict(synth_ctx)

--- a/tests/test_fastlog/test_predicate_exceptions.py
+++ b/tests/test_fastlog/test_predicate_exceptions.py
@@ -1,0 +1,132 @@
+"""Predicate exception mode tests for fastlog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import PredicateError, RecordContext
+
+
+class ExceptionModel(nn.Module):
+    """Model with several operation events."""
+
+    def __init__(self) -> None:
+        """Initialize layers."""
+
+        super().__init__()
+        self.layers = nn.Sequential(nn.Linear(3, 3), nn.ReLU(), nn.Linear(3, 2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model."""
+
+        return self.layers(x)
+
+
+def _raising_predicate(ctx: RecordContext) -> bool:
+    """Raise for every operation predicate call."""
+
+    raise RuntimeError(f"bad predicate at {ctx.label}")
+
+
+def test_accumulate_ram_raises_at_end_with_capped_failures() -> None:
+    """RAM accumulate mode collects failures up to max_predicate_failures."""
+
+    with pytest.raises(PredicateError) as exc_info:
+        tl.fastlog.record(
+            ExceptionModel(),
+            torch.ones(1, 3),
+            keep_op=_raising_predicate,
+            on_predicate_error="accumulate",
+            max_predicate_failures=2,
+        )
+
+    assert len(exc_info.value.failures) == 2
+    assert exc_info.value.overflow > 0
+    assert exc_info.value.total_count > 2
+
+
+def test_fail_fast_raises_on_first_failure() -> None:
+    """Fail-fast mode raises immediately on the first predicate failure."""
+
+    calls = 0
+
+    def keep_op(ctx: RecordContext) -> bool:
+        """Count and then fail."""
+
+        nonlocal calls
+        calls += 1
+        raise PredicateError("first failure", ctx=ctx)
+
+    with pytest.raises(PredicateError, match="first failure"):
+        tl.fastlog.record(
+            ExceptionModel(),
+            torch.ones(1, 3),
+            keep_op=keep_op,
+            on_predicate_error="fail-fast",
+        )
+
+    assert calls == 1
+
+
+def test_auto_maps_to_accumulate_for_ram() -> None:
+    """Auto predicate error mode accumulates failures for RAM-only sessions."""
+
+    with pytest.raises(PredicateError) as exc_info:
+        tl.fastlog.record(
+            ExceptionModel(),
+            torch.ones(1, 3),
+            keep_op=_raising_predicate,
+            on_predicate_error="auto",
+            max_predicate_failures=1,
+        )
+
+    assert len(exc_info.value.failures) == 1
+    assert exc_info.value.total_count > 1
+
+
+def test_auto_maps_to_fail_fast_for_disk(tmp_path: Path) -> None:
+    """Auto predicate error mode fails fast for disk-backed sessions."""
+
+    calls = 0
+
+    def keep_op(ctx: RecordContext) -> bool:
+        """Count and then fail."""
+
+        nonlocal calls
+        calls += 1
+        raise PredicateError("disk failure", ctx=ctx)
+
+    with pytest.raises(PredicateError, match="disk failure"):
+        tl.fastlog.record(
+            ExceptionModel(),
+            torch.ones(1, 3),
+            keep_op=keep_op,
+            on_predicate_error="auto",
+            streaming=tl.StreamingOptions(
+                bundle_path=tmp_path / "disk.tlfast",
+                retain_in_memory=False,
+            ),
+        )
+
+    assert calls == 1
+
+
+def test_max_predicate_failures_tracks_overflow_separately() -> None:
+    """Overflow failures are counted separately from retained failures."""
+
+    with pytest.raises(PredicateError) as exc_info:
+        tl.fastlog.record(
+            ExceptionModel(),
+            torch.ones(1, 3),
+            keep_op=_raising_predicate,
+            on_predicate_error="accumulate",
+            max_predicate_failures=0,
+        )
+
+    assert exc_info.value.failures == []
+    assert exc_info.value.overflow == exc_info.value.total_count

--- a/tests/test_fastlog/test_preview_fidelity.py
+++ b/tests/test_fastlog/test_preview_fidelity.py
@@ -1,0 +1,69 @@
+"""Preview and dry-run RecordContext fidelity tests."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import RecordContext, RecordContextFieldError
+from torchlens.visualization.fastlog_preview import _build_preview_nodes
+
+
+class StaticGraph(nn.Module):
+    """Static graph model for preview fidelity."""
+
+    def __init__(self) -> None:
+        """Initialize layers."""
+
+        super().__init__()
+        self.layers = nn.Sequential(nn.Linear(4, 3), nn.ReLU(), nn.Linear(3, 2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the static graph."""
+
+        return self.layers(x)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Preview currently synthesizes ModelLog layer contexts only; dry_run includes "
+        "module events and uses raw labels, so exact field-by-field parity is pending."
+    )
+)
+def test_preview_and_dry_run_contexts_match_field_by_field() -> None:
+    """Preview-synthesized and real dry-run contexts match field-by-field."""
+
+    model = StaticGraph()
+    x = torch.randn(1, 4)
+    model_log = tl.log_forward_pass(model, x)
+    trace = tl.fastlog.dry_run(model, x, keep_op=lambda ctx: True, include_source_events=True)
+    preview_nodes = _build_preview_nodes(model_log, lambda ctx: True)
+    preview_contexts = [node.ctx for node in dict.fromkeys(preview_nodes.values())]
+    real_contexts = [
+        ctx for ctx in trace.contexts if ctx.kind in {"input", "op"} and ctx.layer_type != "output"
+    ]
+
+    assert [asdict(ctx) for ctx in preview_contexts] == [asdict(ctx) for ctx in real_contexts]
+
+
+def test_missing_record_context_field_errors_in_preview_and_dry_run() -> None:
+    """A nonexistent predicate field fails with RecordContextFieldError in both paths."""
+
+    model = StaticGraph()
+    x = torch.randn(1, 4)
+    model_log = tl.log_forward_pass(model, x)
+
+    def bad_predicate(ctx: RecordContext) -> bool:
+        """Access a field outside the RecordContext schema."""
+
+        return bool(ctx.recurrent_group)
+
+    dot = model_log.preview_fastlog(predicate=bad_predicate)
+
+    assert "exception" in dot
+    with pytest.raises(RecordContextFieldError):
+        tl.fastlog.dry_run(model, x, keep_op=bad_predicate)

--- a/tests/test_fastlog/test_preview_smoke.py
+++ b/tests/test_fastlog/test_preview_smoke.py
@@ -1,0 +1,55 @@
+"""Smoke tests for fastlog ModelLog preview rendering."""
+
+from __future__ import annotations
+
+import torch
+from pathlib import Path
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog.exceptions import RecordContextFieldError
+from torchlens.fastlog.types import RecordContext
+
+
+def _mlp() -> nn.Module:
+    """Return a small two-layer MLP."""
+
+    return nn.Sequential(nn.Linear(4, 5), nn.ReLU(), nn.Linear(5, 2))
+
+
+def test_preview_fastlog_renders_on_mlp(tmp_path: Path) -> None:
+    """Preview rendering returns Graphviz source for a small MLP."""
+
+    model_log = tl.log_forward_pass(_mlp(), torch.randn(1, 4))
+    dot = model_log.preview_fastlog(
+        keep_op=lambda ctx: ctx.layer_type == "linear",
+        vis_outpath=str(tmp_path / "preview"),
+        vis_save_only=True,
+    )
+    assert "digraph" in dot
+    assert "fastlog" in dot
+
+
+def test_preview_fastlog_catches_record_context_field_error(tmp_path: Path) -> None:
+    """Missing RecordContext fields are caught and rendered as hot nodes."""
+
+    model_log = tl.log_forward_pass(_mlp(), torch.randn(1, 4))
+
+    def bad_predicate(ctx: RecordContext) -> bool:
+        """Access a field outside the RecordContext schema."""
+
+        try:
+            getattr(ctx, "not_a_record_context_field")
+        except RecordContextFieldError:
+            raise
+        return True
+
+    dot = tl.preview_fastlog(
+        model_log,
+        predicate=bad_predicate,
+        color_predicate_error="#FF7AB6",
+        vis_outpath=str(tmp_path / "preview_error"),
+        vis_save_only=True,
+    )
+    assert "#FF7AB6" in dot
+    assert "RecordContext has no field" in dot

--- a/tests/test_fastlog/test_public_api_smoke.py
+++ b/tests/test_fastlog/test_public_api_smoke.py
@@ -1,0 +1,122 @@
+"""Smoke tests for the public fastlog API."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import RecordContext, RecorderStateError
+
+
+class SimpleMlp(nn.Module):
+    """Small MLP used by public API smoke tests."""
+
+    def __init__(self) -> None:
+        """Initialize the layers."""
+
+        super().__init__()
+        self.layers = nn.Sequential(nn.Linear(3, 4), nn.ReLU(), nn.Linear(4, 2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the MLP."""
+
+        return self.layers(x)
+
+
+class MultiArgModel(nn.Module):
+    """Model with multiple positional inputs and a keyword argument."""
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor, *, scale: int = 1) -> torch.Tensor:
+        """Combine inputs with a scalar multiplier."""
+
+        return (x + y) * scale
+
+
+def _keep_all_ops(ctx: RecordContext) -> bool:
+    """Keep every operation event."""
+
+    return ctx.kind == "op"
+
+
+def _keep_no_ops(ctx: RecordContext) -> bool:
+    """Reject every operation event."""
+
+    _ = ctx
+    return False
+
+
+def test_record_keep_op_true_and_false() -> None:
+    """One-shot record honors constant true and false operation predicates."""
+
+    x = torch.ones(1, 3)
+    kept = tl.fastlog.record(SimpleMlp(), x, keep_op=_keep_all_ops)
+    skipped = tl.fastlog.record(SimpleMlp(), x, keep_op=_keep_no_ops)
+
+    assert len(kept.records) > 0
+    assert skipped.records == []
+
+
+def test_record_multi_arg_and_kwargs_forward() -> None:
+    """One-shot record supports tuple args plus explicit kwargs."""
+
+    x = torch.ones(1, 3)
+    y = torch.ones(1, 3)
+    recording = tl.fastlog.record(
+        MultiArgModel(),
+        (x, y),
+        {"scale": 2},
+        keep_op=_keep_all_ops,
+    )
+
+    assert len(recording.records) > 0
+
+
+def test_record_single_tensor_input_shorthand() -> None:
+    """One-shot record treats a single tensor as one positional argument."""
+
+    recording = tl.fastlog.record(SimpleMlp(), torch.ones(1, 3), keep_op=_keep_all_ops)
+
+    assert len(recording.records) > 0
+
+
+def test_recorder_context_records_multiple_forwards() -> None:
+    """Recorder accumulates explicitly logged forwards across a loop."""
+
+    with tl.fastlog.Recorder(SimpleMlp(), keep_op=_keep_all_ops) as recorder:
+        for _ in range(5):
+            recorder.log(torch.ones(1, 3))
+
+    assert recorder.recording.n_passes == 5
+
+
+def test_direct_model_call_inside_recorder_block_does_not_capture() -> None:
+    """Only Recorder.log opens the capture scope."""
+
+    model = SimpleMlp()
+    with tl.fastlog.Recorder(model, keep_op=_keep_all_ops) as recorder:
+        recorder.log(torch.ones(1, 3))
+        before = len(recorder._state.recording.records)  # noqa: SLF001
+        model(torch.ones(1, 3))
+        after = len(recorder._state.recording.records)  # noqa: SLF001
+
+    assert after == before
+
+
+def test_dry_run_returns_events_without_tensor_payloads() -> None:
+    """Dry-run returns event contexts and no retained tensor payloads."""
+
+    trace = tl.fastlog.dry_run(SimpleMlp(), torch.ones(1, 3), keep_op=_keep_all_ops)
+
+    assert trace.events
+    assert all(not hasattr(event, "ram_payload") for event in trace.events)
+    assert all(not hasattr(event, "disk_payload") for event in trace.events)
+
+
+def test_recorder_recording_before_exit_raises() -> None:
+    """Recorder.recording is guarded until __exit__ finalizes."""
+
+    with tl.fastlog.Recorder(SimpleMlp(), keep_op=_keep_all_ops) as recorder:
+        with pytest.raises(RecorderStateError):
+            _ = recorder.recording

--- a/tests/test_fastlog/test_storage_async_disk.py
+++ b/tests/test_fastlog/test_storage_async_disk.py
@@ -1,0 +1,12 @@
+"""Async disk-mode placeholder tests for fastlog v1."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xfail(reason="v1 ships sync-only; async pending safetensors 0.8 stable + benchmarks")
+def test_async_disk_storage_pending() -> None:
+    """Async disk storage is intentionally not shipped in v1."""
+
+    raise NotImplementedError("async disk storage is not implemented in v1")

--- a/tests/test_fastlog/test_storage_modes.py
+++ b/tests/test_fastlog/test_storage_modes.py
@@ -1,0 +1,185 @@
+"""Comprehensive storage-mode behavior tests for fastlog."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens._io.streaming import PARTIAL_SENTINEL
+from torchlens.fastlog import CaptureSpec, PredicateError, RecordContext, RecordingConfigError
+
+
+class StorageModel(nn.Module):
+    """Small differentiable model for storage-mode tests."""
+
+    def __init__(self) -> None:
+        """Initialize the layer."""
+
+        super().__init__()
+        self.linear = nn.Linear(3, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a differentiable forward pass."""
+
+        return self.linear(x).relu()
+
+
+def _first_payload_record(recording: tl.fastlog.Recording) -> tl.fastlog.ActivationRecord:
+    """Return the first record with a RAM payload."""
+
+    return next(record for record in recording if record.ram_payload is not None)
+
+
+def test_ram_only_keep_grad_false_records_detached_tensor() -> None:
+    """RAM-only keep_grad=False stores a detached tensor payload."""
+
+    recording = tl.fastlog.record(StorageModel(), torch.ones(1, 3), default_op=True)
+    payload = _first_payload_record(recording).ram_payload
+
+    assert payload is not None
+    assert payload.requires_grad is False
+    assert payload.grad_fn is None
+
+
+def test_ram_only_keep_grad_true_records_attached_tensor_and_backpropagates() -> None:
+    """RAM-only keep_grad=True keeps an attached clone that reaches parameters."""
+
+    model = StorageModel()
+    recording = tl.fastlog.record(
+        model,
+        torch.ones(1, 3),
+        default_op=CaptureSpec(keep_grad=True),
+    )
+    payload = _first_payload_record(recording).ram_payload
+
+    assert payload is not None
+    assert payload.requires_grad is True
+    assert payload.grad_fn is not None
+    payload.sum().backward()
+    assert model.linear.weight.grad is not None
+
+
+def test_ram_disk_mirror_keep_grad_true_splits_attached_ram_detached_disk(
+    tmp_path: Path,
+) -> None:
+    """RAM+disk mirror keeps RAM attached and disk payload detached."""
+
+    recording = tl.fastlog.record(
+        StorageModel(),
+        torch.ones(1, 3),
+        default_op=CaptureSpec(keep_grad=True),
+        streaming=tl.StreamingOptions(
+            bundle_path=tmp_path / "mirror.tlfast",
+            retain_in_memory=True,
+        ),
+    )
+    record = _first_payload_record(recording)
+
+    assert record.ram_payload is not None
+    assert record.ram_payload.grad_fn is not None
+    assert record.disk_payload is not None
+    assert record.disk_payload.grad_fn is None
+
+
+def test_disk_only_keep_grad_default_rejected_at_construction(tmp_path: Path) -> None:
+    """Disk-only storage rejects static keep_grad defaults before recording."""
+
+    with pytest.raises(RecordingConfigError, match="keep_grad=True"):
+        tl.fastlog.Recorder(
+            StorageModel(),
+            default_op=CaptureSpec(keep_grad=True),
+            streaming=tl.StreamingOptions(
+                bundle_path=tmp_path / "disk.tlfast",
+                retain_in_memory=False,
+            ),
+        )
+
+
+def test_disk_only_predicate_keep_grad_rejected_before_record_write(
+    tmp_path: Path,
+) -> None:
+    """Disk-only runtime keep_grad errors before writing the offending record."""
+
+    bundle_path = tmp_path / "disk.tlfast"
+
+    def keep_op(ctx: RecordContext) -> CaptureSpec | bool:
+        """Request keep_grad for the first operation event."""
+
+        return CaptureSpec(keep_grad=True) if ctx.kind == "op" else False
+
+    with pytest.raises(PredicateError, match="disk-only"):
+        tl.fastlog.record(
+            StorageModel(),
+            torch.ones(1, 3),
+            keep_op=keep_op,
+            streaming=tl.StreamingOptions(bundle_path=bundle_path, retain_in_memory=False),
+        )
+
+    partials = list(tmp_path.glob("disk.tlfast.tmp.*"))
+    assert partials
+    assert (partials[0] / PARTIAL_SENTINEL).exists()
+    assert not (partials[0] / "fastlog_index.jsonl").exists()
+
+
+def test_keep_grad_true_integer_dtype_rejected_per_record() -> None:
+    """keep_grad=True with an integer dtype transform is rejected per record."""
+
+    with pytest.raises(PredicateError, match="integer or bool"):
+        tl.fastlog.record(
+            StorageModel(),
+            torch.ones(1, 3),
+            default_op=CaptureSpec(keep_grad=True, dtype=torch.int32),
+        )
+
+
+def test_keep_grad_true_cpu_device_warns_once_and_is_allowed(tmp_path: Path) -> None:
+    """keep_grad=True with an explicit CPU device warns once and records."""
+
+    with pytest.warns(UserWarning, match="explicit device target") as warnings_seen:
+        recording = tl.fastlog.record(
+            StorageModel(),
+            torch.ones(1, 3),
+            default_op=CaptureSpec(keep_grad=True, device="cpu"),
+            streaming=tl.StreamingOptions(
+                bundle_path=tmp_path / "mirror.tlfast",
+                retain_in_memory=True,
+            ),
+        )
+
+    assert len(warnings_seen) == 1
+    assert len(recording) > 0
+
+
+def test_safe_copy_is_only_detach_lever_in_fastlog() -> None:
+    """The fastlog package does not call .detach() directly."""
+
+    offenders: list[str] = []
+    for path in Path("torchlens/fastlog").glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "detach"
+            ):
+                offenders.append(f"{path}:{node.lineno}")
+
+    assert offenders == []
+
+
+def test_model_parameter_requires_grad_flags_preserved() -> None:
+    """Fastlog does not mutate mixed parameter requires_grad flags."""
+
+    model = StorageModel()
+    model.linear.bias.requires_grad_(False)
+    before = {name: param.requires_grad for name, param in model.named_parameters()}
+
+    tl.fastlog.record(model, torch.ones(1, 3), default_op=True)
+
+    after = {name: param.requires_grad for name, param in model.named_parameters()}
+    assert after == before

--- a/tests/test_fastlog/test_storage_resolution.py
+++ b/tests/test_fastlog/test_storage_resolution.py
@@ -1,0 +1,42 @@
+"""Storage intent resolution tests for fastlog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torchlens as tl
+from torchlens.fastlog._state import _resolve_storage_intent
+from torchlens.fastlog.options import RecordingOptions
+
+
+def test_streaming_none_is_ram_only_intent() -> None:
+    """StreamingOptions(bundle_path=None) resolves to RAM-only storage."""
+
+    options = RecordingOptions(default_op=True, streaming=tl.StreamingOptions(bundle_path=None))
+
+    assert _resolve_storage_intent(options).in_ram is True
+    assert _resolve_storage_intent(options).on_disk is False
+
+
+def test_streaming_bundle_retain_true_is_ram_disk_mirror(tmp_path: Path) -> None:
+    """bundle_path plus retain_in_memory=True resolves to RAM and disk."""
+
+    options = RecordingOptions(
+        default_op=True,
+        streaming=tl.StreamingOptions(bundle_path=tmp_path / "bundle", retain_in_memory=True),
+    )
+
+    assert _resolve_storage_intent(options).in_ram is True
+    assert _resolve_storage_intent(options).on_disk is True
+
+
+def test_streaming_bundle_retain_false_is_disk_only(tmp_path: Path) -> None:
+    """bundle_path plus retain_in_memory=False resolves to disk only."""
+
+    options = RecordingOptions(
+        default_op=True,
+        streaming=tl.StreamingOptions(bundle_path=tmp_path / "bundle", retain_in_memory=False),
+    )
+
+    assert _resolve_storage_intent(options).in_ram is False
+    assert _resolve_storage_intent(options).on_disk is True

--- a/tests/test_fastlog/test_storage_smoke.py
+++ b/tests/test_fastlog/test_storage_smoke.py
@@ -1,0 +1,136 @@
+"""Smoke tests for fastlog RAM, disk, and recovery storage paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.fastlog import CaptureSpec
+from torchlens.fastlog.exceptions import PredicateError, RecordingConfigError
+from torchlens.fastlog.types import RecordContext
+
+
+class TinyModel(nn.Module):
+    """Small model for storage smoke tests."""
+
+    def __init__(self) -> None:
+        """Initialize the model."""
+
+        super().__init__()
+        self.linear = nn.Linear(3, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model."""
+
+        return self.linear(x).relu()
+
+
+def test_ram_only_roundtrip_records_in_memory() -> None:
+    """RAM-only recording returns an in-memory Recording."""
+
+    recording = tl.fastlog.record(TinyModel(), torch.ones(1, 3), default_op=True)
+
+    assert recording.bundle_path is None
+    assert recording.recovered is False
+    assert len(recording) > 0
+    assert any(record.ram_payload is not None for record in recording)
+
+
+def test_disk_only_roundtrip_loads_bundle(tmp_path: Path) -> None:
+    """Disk-only recording writes a fastlog bundle that load can read."""
+
+    bundle_path = tmp_path / "recording.tlfast"
+    recording = tl.fastlog.record(
+        TinyModel(),
+        torch.ones(1, 3),
+        default_op=True,
+        streaming=tl.StreamingOptions(bundle_path=bundle_path, retain_in_memory=False),
+    )
+    loaded = tl.fastlog.load(bundle_path)
+
+    assert recording.bundle_path == bundle_path
+    assert (bundle_path / "manifest.json").exists()
+    assert (bundle_path / "metadata.json").exists()
+    assert loaded.recovered is False
+    assert len(loaded) == len(recording)
+    assert loaded.records[0].metadata["blob_id"] == recording.records[0].metadata["blob_id"]
+
+
+def test_keep_grad_disk_only_default_raises_at_construction(tmp_path: Path) -> None:
+    """Static keep_grad defaults are rejected before any bundle is created."""
+
+    bundle_path = tmp_path / "recording.tlfast"
+
+    with pytest.raises(RecordingConfigError, match="keep_grad=True"):
+        tl.fastlog.record(
+            TinyModel(),
+            torch.ones(1, 3),
+            default_op=CaptureSpec(keep_grad=True),
+            streaming=tl.StreamingOptions(bundle_path=bundle_path, retain_in_memory=False),
+        )
+
+    assert not bundle_path.exists()
+
+
+def test_keep_grad_disk_only_predicate_raises_at_runtime(tmp_path: Path) -> None:
+    """Runtime keep_grad predicate decisions are rejected before writing a record."""
+
+    bundle_path = tmp_path / "recording.tlfast"
+
+    def keep_first(ctx: RecordContext) -> CaptureSpec | bool:
+        """Request keep_grad for the first operation only."""
+
+        return CaptureSpec(keep_grad=True) if ctx.kind == "op" else False
+
+    with pytest.raises(PredicateError, match="disk-only"):
+        tl.fastlog.record(
+            TinyModel(),
+            torch.ones(1, 3),
+            keep_op=keep_first,
+            streaming=tl.StreamingOptions(bundle_path=bundle_path, retain_in_memory=False),
+        )
+
+
+def test_keep_grad_integer_dtype_rejected_per_record() -> None:
+    """Integer tensors cannot be retained with keep_grad=True."""
+
+    class IntegerModel(nn.Module):
+        """Model producing integer output."""
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Produce an integer tensor."""
+
+            return (x + 1).to(torch.int64)
+
+    with pytest.raises(PredicateError, match="integer or bool"):
+        tl.fastlog.record(
+            IntegerModel(),
+            torch.ones(1),
+            default_op=CaptureSpec(keep_grad=True),
+        )
+
+
+def test_crash_recovery_from_partial_bundle(tmp_path: Path) -> None:
+    """Recover skips a partial bundle's missing blob and reports a warning."""
+
+    bundle_path = tmp_path / "partial.tlfast"
+    tl.fastlog.record(
+        TinyModel(),
+        torch.ones(1, 3),
+        default_op=True,
+        streaming=tl.StreamingOptions(bundle_path=bundle_path, retain_in_memory=False),
+    )
+    partial_path = tmp_path / "partial_unfinalized.tlfast"
+    bundle_path.rename(partial_path)
+    (partial_path / "manifest.json").unlink()
+    first_blob = next((partial_path / "blobs").glob("*.safetensors"))
+    first_blob.unlink()
+
+    recovered = tl.fastlog.recover(partial_path)
+
+    assert recovered.recovered is True
+    assert any("missing blob" in warning for warning in recovered.recovery_warnings)

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -1,0 +1,166 @@
+"""Tests for TorchLens stack introspection helpers."""
+
+import os
+from types import FrameType
+from typing import List, Optional
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens
+from torchlens.data_classes import FuncCallLocation
+from torchlens.utils import introspection
+
+
+class RecursiveStackModel(nn.Module):
+    """Small module that creates a deep Python stack below ``forward``."""
+
+    def __init__(self, depth: int) -> None:
+        """Initialize the recursive model.
+
+        Args:
+            depth: Number of recursive calls to make below ``forward``.
+        """
+        super().__init__()
+        self.depth = depth
+
+    def forward(self, x: torch.Tensor) -> List[FuncCallLocation]:
+        """Return the filtered function call stack from a recursive call.
+
+        Args:
+            x: Input tensor, included to exercise normal ``nn.Module`` calling.
+
+        Returns:
+            Filtered TorchLens function call stack.
+        """
+        return self._recurse(x, self.depth)
+
+    def _recurse(self, x: torch.Tensor, depth: int) -> List[FuncCallLocation]:
+        """Recurse until the stack is deep enough, then capture it.
+
+        Args:
+            x: Input tensor carried through recursion.
+            depth: Remaining recursive depth.
+
+        Returns:
+            Filtered TorchLens function call stack.
+        """
+        if depth <= 0:
+            return introspection._get_func_call_stack()
+        return self._recurse(x, depth - 1)
+
+
+def test_stack_metadata_helpers_run_only_for_surviving_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify expensive stack metadata helpers run after frame filtering.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing helper functions.
+    """
+    col_offset_calls = []
+    code_qualname_calls = []
+
+    def fake_get_col_offset(frame: FrameType) -> Optional[int]:
+        """Record column-offset calls without walking bytecode.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Dummy column offset.
+        """
+        col_offset_calls.append((frame.f_code.co_filename, frame.f_code.co_name))
+        return 0
+
+    def fake_get_code_qualname(frame: FrameType) -> Optional[str]:
+        """Record qualname calls without inspecting code metadata.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Code object name for the frame.
+        """
+        code_qualname_calls.append((frame.f_code.co_filename, frame.f_code.co_name))
+        return frame.f_code.co_name
+
+    monkeypatch.setattr(introspection, "_get_col_offset", fake_get_col_offset)
+    monkeypatch.setattr(introspection, "_get_code_qualname", fake_get_code_qualname)
+
+    model = RecursiveStackModel(depth=12)
+    stack = model(torch.ones(1))
+
+    torchlens_pkg_dir = os.path.dirname(os.path.abspath(torchlens.__file__))
+    surviving_frames = [(loc.file, loc.func_name) for loc in stack]
+
+    assert len(stack) >= 13
+    assert col_offset_calls == surviving_frames
+    assert code_qualname_calls == surviving_frames
+    assert len(col_offset_calls) == len(stack)
+    assert len(code_qualname_calls) == len(stack)
+    assert all(not filename.startswith(torchlens_pkg_dir) for filename, _ in col_offset_calls)
+
+
+def test_disable_col_offset_skips_col_offset_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify ``disable_col_offset`` bypasses bytecode column-offset inspection.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing helper functions.
+    """
+    col_offset_calls = []
+    code_qualname_calls = []
+
+    def fake_get_col_offset(frame: FrameType) -> Optional[int]:
+        """Record unexpected column-offset calls.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Dummy column offset.
+        """
+        col_offset_calls.append(frame)
+        return 0
+
+    def fake_get_code_qualname(frame: FrameType) -> Optional[str]:
+        """Record qualname calls that should still occur.
+
+        Args:
+            frame: Stack frame passed by ``_get_func_call_stack``.
+
+        Returns:
+            Code object name for the frame.
+        """
+        code_qualname_calls.append(frame)
+        return frame.f_code.co_name
+
+    monkeypatch.setattr(introspection, "_get_col_offset", fake_get_col_offset)
+    monkeypatch.setattr(introspection, "_get_code_qualname", fake_get_code_qualname)
+
+    model = RecursiveStackModel(depth=12)
+
+    class DisableOffsetModel(RecursiveStackModel):
+        """Recursive model variant that disables column-offset extraction."""
+
+        def _recurse(self, x: torch.Tensor, depth: int) -> List[FuncCallLocation]:
+            """Recurse until the stack is deep enough, then capture it.
+
+            Args:
+                x: Input tensor carried through recursion.
+                depth: Remaining recursive depth.
+
+            Returns:
+                Filtered TorchLens function call stack.
+            """
+            if depth <= 0:
+                return introspection._get_func_call_stack(disable_col_offset=True)
+            return self._recurse(x, depth - 1)
+
+    stack = DisableOffsetModel(model.depth)(torch.ones(1))
+
+    assert len(stack) >= 13
+    assert col_offset_calls == []
+    assert len(code_qualname_calls) == len(stack)
+    assert all(loc.col_offset is None for loc in stack)

--- a/torchlens/CLAUDE.md
+++ b/torchlens/CLAUDE.md
@@ -18,10 +18,19 @@ log_forward_pass(model, input)
   |- capture/output_tensors.py — log each tensor operation
   |- postprocess/              — 18-step pipeline (graph, loops, labels, modules)
   +- Returns ModelLog with all logged data
+
+tl.fastlog.record(model, input, keep_op=...)
+  |- decoration/model_prep.py  — prepare model without mutating trainability
+  |- capture/output_tensors.py — build lightweight op RecordContext values
+  |- decoration/model_prep.py  — build module enter/exit RecordContext values
+  |- fastlog/_orchestrator.py  — evaluate predicates and append selected records
+  +- Returns Recording with sparse RAM and/or disk-backed activation records
 ```
 
 Two-pass strategy: when `layers_to_save` is a specific list, Pass 1 runs exhaustive
 (metadata only), Pass 2 runs fast (saves only requested layers).
+Predicate strategy: `tl.fastlog` runs one or more explicit `Recorder.log()` passes and
+retains only events selected by predicates. It does not build a faithful `ModelLog`.
 
 ## Key Concepts
 
@@ -45,6 +54,7 @@ Two-pass strategy: when `layers_to_save` is a specific list, Pass 1 runs exhaust
 - **[capture/](capture/)** — Real-time tensor operation logging during forward pass (7 files)
 - **[data_classes/](data_classes/)** — ModelLog, LayerLog, LayerPassLog, ModuleLog, ParamLog, etc. (10 files)
 - **[decoration/](decoration/)** — One-time torch function wrapping + model preparation (2 files)
+- **[fastlog/](fastlog/)** — Predicate-based sparse activation recording with RAM/disk storage (16 files)
 - **[postprocess/](postprocess/)** — 18-step pipeline: graph cleanup, loop detection, labeling (6 files)
 - **[utils/](utils/)** — Arg handling, tensor ops, RNG, hashing, display helpers (7 files)
 - **[validation/](validation/)** — Forward replay, perturbation checks, metadata invariants (3 files)

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -27,6 +27,7 @@ from .options import StreamingOptions, VisualizationOptions
 from .validation.invariants import check_metadata_invariants, MetadataInvariantError
 from ._io.bundle import save, load, cleanup_tmp
 from ._io import rehydrate_nested
+from . import fastlog
 
 # ---- Public API: data classes users interact with ------------------------
 
@@ -45,3 +46,9 @@ from .visualization import (
 # ---- Public API: decoration lifecycle ------------------------------------
 
 from .decoration import wrap_torch, unwrap_torch, wrapped
+
+
+def preview_fastlog(model_log, *args, **kwargs):
+    """Delegate to ``model_log.preview_fastlog`` when the preview method is available."""
+
+    return model_log.preview_fastlog(*args, **kwargs)

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -48,7 +48,20 @@ from .visualization import (
 from .decoration import wrap_torch, unwrap_torch, wrapped
 
 
-def preview_fastlog(model_log, *args, **kwargs):
-    """Delegate to ``model_log.preview_fastlog`` when the preview method is available."""
+def preview_fastlog(model_log: ModelLog, *args, **kwargs) -> str:
+    """Render a fastlog predicate preview for a model log.
+
+    Parameters
+    ----------
+    model_log:
+        ModelLog to render.
+    *args, **kwargs:
+        Forwarded to ``model_log.preview_fastlog``.
+
+    Returns
+    -------
+    str
+        Graphviz DOT source.
+    """
 
     return model_log.preview_fastlog(*args, **kwargs)

--- a/torchlens/_io/manifest.py
+++ b/torchlens/_io/manifest.py
@@ -237,9 +237,10 @@ class Manifest:
             if not isinstance(field_value, str) or field_value == "":
                 raise TorchLensIOError(f"Manifest field {field_name!r} must be a non-empty string.")
 
-        if data["bundle_format"] != "directory":
+        if data["bundle_format"] not in {"directory", "fastlog-directory"}:
             raise TorchLensIOError(
-                f"Unsupported bundle_format={data['bundle_format']!r}; expected 'directory'."
+                "Unsupported bundle_format="
+                f"{data['bundle_format']!r}; expected 'directory' or 'fastlog-directory'."
             )
 
         raw_tensors = data.get("tensors")

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -318,7 +318,9 @@ def _build_shared_fields_dict(
     fields_dict["func_applied"] = func
     fields_dict["func_name"] = func_name
     fields_dict["func_call_stack"] = _get_func_call_stack(
-        self.num_context_lines, source_loading_enabled=self.save_source_context
+        self.num_context_lines,
+        source_loading_enabled=self.save_source_context,
+        disable_col_offset=False,
     )
     fields_dict["func_time"] = exec_ctx.time_elapsed
     fields_dict["func_rng_states"] = exec_ctx.rng_states

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -75,7 +75,6 @@ from ..data_classes.internal_types import FuncExecutionContext
 from ..fastlog._predicate import _evaluate_keep_op
 from ..fastlog._record_context import _build_record_context
 from ..fastlog._state import get_active_recording_state
-from ..fastlog._storage_resolver import _resolve_storage
 from ..fastlog.types import ActivationRecord, CaptureSpec
 from .salient_args import extract_salient_args
 from .source_tensors import _get_input_module_info
@@ -150,7 +149,7 @@ def _record_predicate_output(
     ram_payload = None
     disk_payload = None
     if spec.save_activation:
-        ram_payload, disk_payload = _resolve_storage(out, spec, state.storage_intent)
+        ram_payload, disk_payload = state.resolve_storage(out, spec)
     state.add_record(
         ActivationRecord(
             ctx=ctx,

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -33,6 +33,7 @@ pause_logging usage:
 """
 
 import copy
+import time
 from collections import defaultdict
 from math import prod
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
@@ -71,6 +72,11 @@ from .tensor_tracking import (
     _update_tensor_containing_modules,
 )
 from ..data_classes.internal_types import FuncExecutionContext
+from ..fastlog._predicate import _evaluate_keep_op
+from ..fastlog._record_context import _build_record_context
+from ..fastlog._state import get_active_recording_state
+from ..fastlog._storage_resolver import _resolve_storage
+from ..fastlog.types import ActivationRecord, CaptureSpec
 from .salient_args import extract_salient_args
 from .source_tensors import _get_input_module_info
 
@@ -121,6 +127,104 @@ def log_function_output_tensors(
             exec_ctx,
             is_bottom_level_func,
         )
+    elif self.logging_mode == "predicate":
+        log_function_output_tensors_predicate(
+            self,
+            func_name,
+            args,
+            out_orig,
+            is_bottom_level_func,
+        )
+
+
+def _record_predicate_output(
+    ctx,
+    out: torch.Tensor,
+    spec: CaptureSpec,
+) -> None:
+    """Store a predicate-selected operation output."""
+
+    if not spec.save_activation and not spec.save_metadata:
+        return
+    state = get_active_recording_state()
+    ram_payload = None
+    disk_payload = None
+    if spec.save_activation:
+        ram_payload, disk_payload = _resolve_storage(out, spec, state.storage_intent)
+    state.add_record(
+        ActivationRecord(
+            ctx=ctx,
+            spec=spec,
+            ram_payload=ram_payload,
+            disk_payload=disk_payload,
+        )
+    )
+
+
+def log_function_output_tensors_predicate(
+    self,
+    func_name: str,
+    args: Tuple[Any],
+    out_orig: Any,
+    is_bottom_level_func: bool,
+) -> None:
+    """Predicate-mode logging for decorated torch function outputs."""
+
+    state = get_active_recording_state()
+    layer_type = func_name.lower().replace("_", "")
+    arg_tensors, _ = _extract_arg_tensors_and_params(layer_type, args, {})
+    parent_labels = tuple(get_attr_values_from_tensor_list(arg_tensors, "tl_tensor_label_raw"))
+    out_iter = ensure_iterable(out_orig)
+
+    for output_index, out in enumerate(out_iter):
+        if not _output_should_be_logged(out, is_bottom_level_func):
+            continue
+        self._layer_counter += 1
+        self._raw_layer_type_counter[layer_type] += 1
+        state.op_counts[layer_type] = state.op_counts.get(layer_type, 0) + 1
+        state.op_index += 1
+        state.event_index += 1
+        creation_order = self._layer_counter
+        layer_type_num = self._raw_layer_type_counter[layer_type]
+        tensor_label_raw = f"{layer_type}_{layer_type_num}_{creation_order}_raw"
+        out.tl_tensor_label_raw = tensor_label_raw
+        module_frame = state.module_stack[-1] if state.module_stack else None
+        ctx = _build_record_context(
+            kind="op",
+            layer_pass_log_or_op_data={
+                "label": tensor_label_raw,
+                "raw_label": tensor_label_raw,
+                "tensor_label_raw": tensor_label_raw,
+                "creation_order": creation_order,
+                "layer_type": layer_type,
+                "layer_type_num": layer_type_num,
+                "func_name": func_name,
+                "parent_labels": parent_labels,
+                "tensor": out,
+                "output_index": output_index,
+                "is_bottom_level_func": is_bottom_level_func,
+                "module_address": module_frame.module_address if module_frame else None,
+                "module_type": module_frame.module_type if module_frame else None,
+                "module_pass_index": module_frame.pass_index if module_frame else None,
+            },
+            module_stack=state.module_stack,
+            history=tuple(state.history),
+            op_counts=state.op_counts,
+            pass_index=state.pass_index,
+            event_index=state.event_index,
+            op_index=state.op_index,
+            time_since_pass_start=time.time() - self.pass_start_time,
+            include_source_events=state.options.include_source_events,
+            sample_id=state.sample_id,
+        )
+        try:
+            spec = _evaluate_keep_op(ctx, state.options)
+            _record_predicate_output(ctx, out, spec)
+        except Exception as exc:
+            state.add_predicate_failure(ctx, exc)
+            raise
+        finally:
+            state.append_context(ctx)
 
 
 def _build_graph_relationship_fields(

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -220,8 +220,7 @@ def log_function_output_tensors_predicate(
             spec = _evaluate_keep_op(ctx, state.options)
             _record_predicate_output(ctx, out, spec)
         except Exception as exc:
-            state.add_predicate_failure(ctx, exc)
-            raise
+            state.handle_predicate_exception(ctx, exc)
         finally:
             state.append_context(ctx)
 

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -167,7 +167,9 @@ def log_source_tensor_exhaustive(
         "func_applied": None,
         "func_name": "none",
         "func_call_stack": _get_func_call_stack(
-            self.num_context_lines, source_loading_enabled=self.save_source_context
+            self.num_context_lines,
+            source_loading_enabled=self.save_source_context,
+            disable_col_offset=False,
         ),
         "func_time": 0,
         "flops_forward": 0,

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -36,7 +36,6 @@ from ..data_classes.layer_pass_log import LayerPassLog
 from ..fastlog._predicate import _evaluate_keep_op
 from ..fastlog._record_context import _build_record_context
 from ..fastlog._state import get_active_recording_state
-from ..fastlog._storage_resolver import _resolve_storage
 from ..fastlog.types import ActivationRecord
 
 from .tensor_tracking import _add_backward_hook, _update_tensor_containing_modules
@@ -121,7 +120,7 @@ def log_source_tensor_predicate(
                 ram_payload = None
                 disk_payload = None
                 if spec.save_activation:
-                    ram_payload, disk_payload = _resolve_storage(t, spec, state.storage_intent)
+                    ram_payload, disk_payload = state.resolve_storage(t, spec)
                 state.add_record(
                     ActivationRecord(
                         ctx=ctx,

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -130,8 +130,7 @@ def log_source_tensor_predicate(
                     )
                 )
     except Exception as exc:
-        state.add_predicate_failure(ctx, exc)
-        raise
+        state.handle_predicate_exception(ctx, exc)
     finally:
         state.append_context(ctx)
 

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -22,6 +22,7 @@ recognized as the same layer).
 """
 
 from collections import defaultdict
+import time
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import torch
@@ -32,6 +33,11 @@ from ..utils.tensor_utils import get_tensor_memory_amount
 from ..utils.rng import log_current_rng_states
 from ..data_classes.buffer_log import BufferLog
 from ..data_classes.layer_pass_log import LayerPassLog
+from ..fastlog._predicate import _evaluate_keep_op
+from ..fastlog._record_context import _build_record_context
+from ..fastlog._state import get_active_recording_state
+from ..fastlog._storage_resolver import _resolve_storage
+from ..fastlog.types import ActivationRecord
 
 from .tensor_tracking import _add_backward_hook, _update_tensor_containing_modules
 
@@ -55,6 +61,80 @@ def log_source_tensor(self, t: torch.Tensor, source: str, extra_address: Optiona
         log_source_tensor_exhaustive(self, t, source, extra_address)
     elif self.logging_mode == "fast":
         log_source_tensor_fast(self, t, source)
+    elif self.logging_mode == "predicate":
+        log_source_tensor_predicate(self, t, source, extra_address)
+
+
+def log_source_tensor_predicate(
+    self,
+    t: torch.Tensor,
+    source: str,
+    extra_addr: Optional[str] = None,
+) -> None:
+    """Predicate-mode source tensor logging for inputs and buffers."""
+
+    if source not in {"input", "buffer"}:
+        raise ValueError("source must be either 'input' or 'buffer'")
+    state = get_active_recording_state()
+    self._layer_counter += 1
+    self._raw_layer_type_counter[source] += 1
+    state.event_index += 1
+    creation_order = self._layer_counter
+    layer_type_num = self._raw_layer_type_counter[source]
+    tensor_label = f"{source}_{layer_type_num}_raw"
+    setattr(t, "tl_tensor_label_raw", tensor_label)
+    if source == "input":
+        self.input_layers.append(tensor_label)
+    else:
+        self.buffer_layers.append(tensor_label)
+    module_frame = state.module_stack[-1] if state.module_stack else None
+    ctx = _build_record_context(
+        kind="input" if source == "input" else "buffer",
+        layer_pass_log_or_op_data={
+            "label": tensor_label,
+            "raw_label": tensor_label,
+            "tensor_label_raw": tensor_label,
+            "creation_order": creation_order,
+            "layer_type": source,
+            "layer_type_num": layer_type_num,
+            "func_name": None,
+            "input_output_address": extra_addr,
+            "tensor": t,
+            "module_address": module_frame.module_address if module_frame else None,
+            "module_type": module_frame.module_type if module_frame else None,
+            "module_pass_index": module_frame.pass_index if module_frame else None,
+        },
+        module_stack=state.module_stack,
+        history=tuple(state.history),
+        op_counts=state.op_counts,
+        pass_index=state.pass_index,
+        event_index=state.event_index,
+        op_index=None,
+        time_since_pass_start=time.time() - self.pass_start_time,
+        include_source_events=state.options.include_source_events,
+        sample_id=state.sample_id,
+    )
+    try:
+        if state.options.include_source_events:
+            spec = _evaluate_keep_op(ctx, state.options)
+            if spec.save_activation or spec.save_metadata:
+                ram_payload = None
+                disk_payload = None
+                if spec.save_activation:
+                    ram_payload, disk_payload = _resolve_storage(t, spec, state.storage_intent)
+                state.add_record(
+                    ActivationRecord(
+                        ctx=ctx,
+                        spec=spec,
+                        ram_payload=ram_payload,
+                        disk_payload=disk_payload,
+                    )
+                )
+    except Exception as exc:
+        state.add_predicate_failure(ctx, exc)
+        raise
+    finally:
+        state.append_context(ctx)
 
 
 def log_source_tensor_exhaustive(

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -780,6 +780,39 @@ class ModelLog:
             code_panel=code_panel,
         )
 
+    def preview_fastlog(
+        self,
+        predicate: Optional[Callable] = None,
+        keep_op: Optional[Callable] = None,
+        keep_module: Optional[Callable] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Render a fastlog predicate preview for this model graph.
+
+        Parameters
+        ----------
+        predicate, keep_op, keep_module:
+            Predicate callables that receive synthesized fastlog ``RecordContext``
+            objects.
+        **kwargs:
+            Forwarded to :func:`torchlens.visualization.fastlog_preview.preview_fastlog`.
+
+        Returns
+        -------
+        str
+            Graphviz DOT source.
+        """
+
+        from ..visualization.fastlog_preview import preview_fastlog as _impl
+
+        return _impl(
+            self,
+            predicate=predicate,
+            keep_op=keep_op,
+            keep_module=keep_module,
+            **kwargs,
+        )
+
     def summary(
         self,
         level: Literal[

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -288,7 +288,7 @@ class ModelLog:
         self._pass_finished = False
         # "exhaustive" captures all metadata; "fast" reuses exhaustive-pass
         # structure, only re-capturing tensor contents.
-        self.logging_mode = "exhaustive"
+        self.logging_mode: Literal["exhaustive", "fast", "predicate"] = "exhaustive"
         self._all_layers_logged = False
         self._all_layers_saved = False
         self.keep_unsaved_layers = keep_unsaved_layers

--- a/torchlens/decoration/model_prep.py
+++ b/torchlens/decoration/model_prep.py
@@ -236,7 +236,8 @@ def _prepare_model_session(
             model_log._mod_pass_labels[mod_id] = []
             model_log._mod_entered[mod_id] = []
             model_log._mod_exited[mod_id] = []
-    _create_session_param_logs(model_log, model, optimizer)
+    if model_log.logging_mode != "predicate":
+        _create_session_param_logs(model_log, model, optimizer)
     prepare_buffer_tensors(model_log, model)
 
 
@@ -755,6 +756,83 @@ def module_forward_decorator(orig_forward: Callable, module: nn.Module) -> Calla
                 ):
                     t = _state._decorated_identity(t)
             return out
+
+        if model_log.logging_mode == "predicate":
+            from ..fastlog._predicate import _evaluate_keep_module
+            from ..fastlog._record_context import _build_record_context
+            from ..fastlog._state import get_active_recording_state
+            from ..fastlog.types import ActivationRecord, ModuleStackFrame
+
+            state = get_active_recording_state()
+            mod_id = id(module)
+            model_log._mod_pass_num[mod_id] += 1
+            frame = ModuleStackFrame(
+                module_address=module.tl_module_address,
+                module_type=module.tl_module_type,
+                module_id=mod_id,
+                pass_index=model_log._mod_pass_num[mod_id],
+            )
+            state.module_stack.append(frame)
+            state.event_index += 1
+            enter_ctx = _build_record_context(
+                kind="module_enter",
+                layer_pass_log_or_op_data={
+                    "label": f"{frame.module_address}:enter:{frame.pass_index}",
+                    "module_address": frame.module_address,
+                    "module_type": frame.module_type,
+                    "module_pass_index": frame.pass_index,
+                },
+                module_stack=state.module_stack,
+                history=tuple(state.history),
+                op_counts=state.op_counts,
+                pass_index=state.pass_index,
+                event_index=state.event_index,
+                op_index=None,
+                time_since_pass_start=0.0,
+                include_source_events=state.options.include_source_events,
+                sample_id=state.sample_id,
+            )
+            try:
+                enter_spec = _evaluate_keep_module(enter_ctx, state.options)
+                if enter_spec.save_activation or enter_spec.save_metadata:
+                    state.add_record(ActivationRecord(ctx=enter_ctx, spec=enter_spec))
+            except Exception as exc:
+                state.add_predicate_failure(enter_ctx, exc)
+                raise
+            finally:
+                state.append_context(enter_ctx)
+            try:
+                return orig_forward(*args, **kwargs)
+            finally:
+                state.event_index += 1
+                exit_ctx = _build_record_context(
+                    kind="module_exit",
+                    layer_pass_log_or_op_data={
+                        "label": f"{frame.module_address}:exit:{frame.pass_index}",
+                        "module_address": frame.module_address,
+                        "module_type": frame.module_type,
+                        "module_pass_index": frame.pass_index,
+                    },
+                    module_stack=state.module_stack,
+                    history=tuple(state.history),
+                    op_counts=state.op_counts,
+                    pass_index=state.pass_index,
+                    event_index=state.event_index,
+                    op_index=None,
+                    time_since_pass_start=0.0,
+                    include_source_events=state.options.include_source_events,
+                    sample_id=state.sample_id,
+                )
+                try:
+                    exit_spec = _evaluate_keep_module(exit_ctx, state.options)
+                    if exit_spec.save_activation or exit_spec.save_metadata:
+                        state.add_record(ActivationRecord(ctx=exit_ctx, spec=exit_spec))
+                except Exception as exc:
+                    state.add_predicate_failure(exit_ctx, exc)
+                    raise
+                finally:
+                    state.append_context(exit_ctx)
+                    state.module_stack.pop()
 
         # ---- Exhaustive mode: full entry → forward → exit ----
         input_tensor_labels, input_tensor_labels_at_entry = _handle_module_entry(

--- a/torchlens/decoration/model_prep.py
+++ b/torchlens/decoration/model_prep.py
@@ -797,8 +797,7 @@ def module_forward_decorator(orig_forward: Callable, module: nn.Module) -> Calla
                 if enter_spec.save_activation or enter_spec.save_metadata:
                     state.add_record(ActivationRecord(ctx=enter_ctx, spec=enter_spec))
             except Exception as exc:
-                state.add_predicate_failure(enter_ctx, exc)
-                raise
+                state.handle_predicate_exception(enter_ctx, exc)
             finally:
                 state.append_context(enter_ctx)
             try:
@@ -828,8 +827,7 @@ def module_forward_decorator(orig_forward: Callable, module: nn.Module) -> Calla
                     if exit_spec.save_activation or exit_spec.save_metadata:
                         state.add_record(ActivationRecord(ctx=exit_ctx, spec=exit_spec))
                 except Exception as exc:
-                    state.add_predicate_failure(exit_ctx, exc)
-                    raise
+                    state.handle_predicate_exception(exit_ctx, exc)
                 finally:
                     state.append_context(exit_ctx)
                     state.module_stack.pop()

--- a/torchlens/fastlog/CLAUDE.md
+++ b/torchlens/fastlog/CLAUDE.md
@@ -1,0 +1,66 @@
+# fastlog/ — Predicate-Based Activation Recording
+
+## What This Does
+`torchlens.fastlog` records a sparse, predicate-selected subset of forward-pass events.
+It is a sibling path to `log_forward_pass()`: the decorated torch wrappers still fire,
+but fastlog builds lightweight `RecordContext` values and stores only events selected by
+`keep_op` or `keep_module` predicates.
+
+## Architecture
+
+Fastlog predicates fire inside the logging hot path after TorchLens has enough
+operation or module-event metadata to synthesize a frozen `RecordContext`, but before
+the result is appended to storage. Predicate calls are wrapped in `pause_logging()` so
+internal torch operations performed by user predicates do not recursively log events.
+
+Storage is resolved from `StreamingOptions`:
+
+- `bundle_path=None` records to RAM only.
+- `bundle_path` with `retain_in_memory=True` mirrors attached or detached RAM copies to disk.
+- `bundle_path` with `retain_in_memory=False` records disk-only and rejects `keep_grad=True`.
+
+`Recorder` is the session orchestrator. It prepares the model, owns the active
+`RecordingState`, opens one logging scope per `log()` call, coordinates predicate
+evaluation through the orchestrator, and finalizes RAM or disk indexes on context exit.
+One-shot `record()` is a thin wrapper around the same `Recorder` path.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Public `tl.fastlog` namespace exports. |
+| `types.py` | Source of truth for `CaptureSpec`, `RecordContext`, `ActivationRecord`, `Recording`, and trace records. |
+| `_state.py` | Mutable per-session recording state, storage backend wiring, predicate failure accumulation. |
+| `_orchestrator.py` | Runs one predicate pass and appends retained operation/module records. |
+| `storage_ram.py` | In-memory recording backend and indexes. |
+| `storage_disk.py` | Synchronous directory-bundle writer, JSONL index, manifest integration. |
+| `_record_one_shot.py` | Public `record()` implementation. |
+| `_recorder.py` | Public many-rollout `Recorder` context manager and DDP/FSDP handling. |
+| `dry_run.py` | Predicate trace without tensor payload retention. |
+| `recover.py` | Finalized bundle load and partial-bundle recovery. |
+| `_predicate.py` | Predicate normalization, error handling, and default decision resolution. |
+| `_record_context.py` | Canonical `RecordContext` construction and recent-history views. |
+| `_storage_resolver.py` | The only tensor copy/detach routing for fastlog payloads. |
+| `options.py` | Fastlog option dataclasses and merge logic. |
+| `exceptions.py` | Fastlog-specific public exception types. |
+| `cleanup.py` | Partial bundle cleanup helper. |
+
+## Conventions
+
+- Do not use `torch.no_grad()` in the recording hot path; fastlog must remain
+  training-compatible.
+- Do not call `.detach()` directly. Route tensor payload copies through
+  `_storage_resolver._resolve_storage()` and `safe_copy()`.
+- Keep frozen record dataclasses on `slots=True`.
+- Wrap predicate calls in `pause_logging()`.
+- Keep `RecordContext` fields centralized in `types.py` and `_record_context.py`.
+- Preserve rank-local DDP semantics: unwrap to `.module`, but do not claim true
+  distributed forward semantics.
+
+## Future Work
+
+- Async disk drain after the storage dependency and benchmarks support it.
+- True DDP forward semantics rather than rank-local unwrapped capture.
+- FSDP support if an unsharded event view becomes practical.
+- A narrow `to_model_log`-style conversion only if sparse captures can be represented
+  without violating `ModelLog` invariants.

--- a/torchlens/fastlog/__init__.py
+++ b/torchlens/fastlog/__init__.py
@@ -1,0 +1,40 @@
+"""Lightweight predicate-recording namespace for TorchLens."""
+
+from .exceptions import (
+    BundleNotFinalizedError,
+    PredicateError,
+    RecorderStateError,
+    RecordingConfigError,
+    RecordContextFieldError,
+    RecoveryError,
+)
+from .options import RecordingOptions, merge_recording_options
+from .types import (
+    ActivationRecord,
+    CaptureSpec,
+    ModuleStackFrame,
+    PredicateFailure,
+    Recording,
+    RecordingTrace,
+    RecordContext,
+    StorageIntent,
+)
+
+__all__ = [
+    "ActivationRecord",
+    "BundleNotFinalizedError",
+    "CaptureSpec",
+    "ModuleStackFrame",
+    "PredicateError",
+    "PredicateFailure",
+    "RecorderStateError",
+    "Recording",
+    "RecordingConfigError",
+    "RecordingOptions",
+    "RecordingTrace",
+    "RecordContext",
+    "RecordContextFieldError",
+    "RecoveryError",
+    "StorageIntent",
+    "merge_recording_options",
+]

--- a/torchlens/fastlog/__init__.py
+++ b/torchlens/fastlog/__init__.py
@@ -1,5 +1,11 @@
 """Lightweight predicate-recording namespace for TorchLens."""
 
+from typing import Any
+
+from .._deprecations import MISSING, MissingType
+from ..options import StreamingOptions
+from ._orchestrator import _run_predicate_pass
+from .cleanup import cleanup_partial
 from .exceptions import (
     BundleNotFinalizedError,
     PredicateError,
@@ -8,7 +14,8 @@ from .exceptions import (
     RecordContextFieldError,
     RecoveryError,
 )
-from .options import RecordingOptions, merge_recording_options
+from .options import PredicateErrorMode, PredicateFn, RecordingOptions, merge_recording_options
+from .recover import load, recover
 from .types import (
     ActivationRecord,
     CaptureSpec,
@@ -20,10 +27,96 @@ from .types import (
     StorageIntent,
 )
 
+
+def record(
+    model: Any,
+    input_args: Any,
+    input_kwargs: dict[str, Any] | None = None,
+    *,
+    keep_op: PredicateFn | None | MissingType = MISSING,
+    keep_module: PredicateFn | None | MissingType = MISSING,
+    default_op: bool | CaptureSpec | MissingType = MISSING,
+    default_module: bool | CaptureSpec | MissingType = MISSING,
+    history_size: int | MissingType = MISSING,
+    include_source_events: bool | MissingType = MISSING,
+    max_predicate_failures: int | MissingType = MISSING,
+    on_predicate_error: PredicateErrorMode | MissingType = MISSING,
+    streaming: StreamingOptions | None | MissingType = MISSING,
+    return_output: bool = False,
+    random_seed: int | None | MissingType = MISSING,
+) -> Recording | tuple[Any, Recording]:
+    """Record one model forward pass with fastlog predicates.
+
+    Parameters
+    ----------
+    model:
+        PyTorch module to execute.
+    input_args:
+        Tensor, list, or tuple of positional model inputs.
+    input_kwargs:
+        Optional keyword arguments for the model call.
+    keep_op, keep_module, default_op, default_module, history_size,
+    include_source_events, max_predicate_failures, on_predicate_error, streaming,
+    random_seed:
+        Fastlog recording options.
+    return_output:
+        Whether to return ``(model_output, recording)``.
+
+    Returns
+    -------
+    Recording | tuple[Any, Recording]
+        Fastlog recording, optionally with the model output.
+    """
+
+    options = merge_recording_options(
+        recording=None,
+        keep_op=keep_op,
+        keep_module=keep_module,
+        default_op=default_op,
+        default_module=default_module,
+        history_size=history_size,
+        include_source_events=include_source_events,
+        max_predicate_failures=max_predicate_failures,
+        on_predicate_error=on_predicate_error,
+        streaming=streaming,
+        random_seed=random_seed,
+    )
+    _validate_non_empty_capture(options)
+    output, recording = _run_predicate_pass(model, input_args, input_kwargs, options)
+    if return_output:
+        return output, recording
+    return recording
+
+
+def _validate_non_empty_capture(options: RecordingOptions) -> None:
+    """Reject statically empty fastlog configurations.
+
+    Parameters
+    ----------
+    options:
+        Fully merged fastlog recording options.
+
+    Raises
+    ------
+    RecordingConfigError
+        If no predicate or default can keep any event.
+    """
+
+    if (
+        options.keep_op is None
+        and options.keep_module is None
+        and options.default_op is False
+        and options.default_module is False
+    ):
+        raise RecordingConfigError("fastlog requires a predicate or a true default capture spec")
+
+
 __all__ = [
     "ActivationRecord",
     "BundleNotFinalizedError",
     "CaptureSpec",
+    "cleanup_partial",
+    "load",
     "ModuleStackFrame",
     "PredicateError",
     "PredicateFailure",
@@ -35,6 +128,8 @@ __all__ = [
     "RecordContext",
     "RecordContextFieldError",
     "RecoveryError",
+    "recover",
+    "record",
     "StorageIntent",
     "merge_recording_options",
 ]

--- a/torchlens/fastlog/__init__.py
+++ b/torchlens/fastlog/__init__.py
@@ -1,11 +1,9 @@
 """Lightweight predicate-recording namespace for TorchLens."""
 
-from typing import Any
-
-from .._deprecations import MISSING, MissingType
-from ..options import StreamingOptions
-from ._orchestrator import _run_predicate_pass
+from ._record_one_shot import record
+from ._recorder import Recorder
 from .cleanup import cleanup_partial
+from .dry_run import dry_run
 from .exceptions import (
     BundleNotFinalizedError,
     PredicateError,
@@ -14,112 +12,24 @@ from .exceptions import (
     RecordContextFieldError,
     RecoveryError,
 )
-from .options import PredicateErrorMode, PredicateFn, RecordingOptions, merge_recording_options
+from .options import RecordingOptions
 from .recover import load, recover
 from .types import (
     ActivationRecord,
     CaptureSpec,
     ModuleStackFrame,
-    PredicateFailure,
+    RecordContext,
     Recording,
     RecordingTrace,
-    RecordContext,
-    StorageIntent,
 )
-
-
-def record(
-    model: Any,
-    input_args: Any,
-    input_kwargs: dict[str, Any] | None = None,
-    *,
-    keep_op: PredicateFn | None | MissingType = MISSING,
-    keep_module: PredicateFn | None | MissingType = MISSING,
-    default_op: bool | CaptureSpec | MissingType = MISSING,
-    default_module: bool | CaptureSpec | MissingType = MISSING,
-    history_size: int | MissingType = MISSING,
-    include_source_events: bool | MissingType = MISSING,
-    max_predicate_failures: int | MissingType = MISSING,
-    on_predicate_error: PredicateErrorMode | MissingType = MISSING,
-    streaming: StreamingOptions | None | MissingType = MISSING,
-    return_output: bool = False,
-    random_seed: int | None | MissingType = MISSING,
-) -> Recording | tuple[Any, Recording]:
-    """Record one model forward pass with fastlog predicates.
-
-    Parameters
-    ----------
-    model:
-        PyTorch module to execute.
-    input_args:
-        Tensor, list, or tuple of positional model inputs.
-    input_kwargs:
-        Optional keyword arguments for the model call.
-    keep_op, keep_module, default_op, default_module, history_size,
-    include_source_events, max_predicate_failures, on_predicate_error, streaming,
-    random_seed:
-        Fastlog recording options.
-    return_output:
-        Whether to return ``(model_output, recording)``.
-
-    Returns
-    -------
-    Recording | tuple[Any, Recording]
-        Fastlog recording, optionally with the model output.
-    """
-
-    options = merge_recording_options(
-        recording=None,
-        keep_op=keep_op,
-        keep_module=keep_module,
-        default_op=default_op,
-        default_module=default_module,
-        history_size=history_size,
-        include_source_events=include_source_events,
-        max_predicate_failures=max_predicate_failures,
-        on_predicate_error=on_predicate_error,
-        streaming=streaming,
-        random_seed=random_seed,
-    )
-    _validate_non_empty_capture(options)
-    output, recording = _run_predicate_pass(model, input_args, input_kwargs, options)
-    if return_output:
-        return output, recording
-    return recording
-
-
-def _validate_non_empty_capture(options: RecordingOptions) -> None:
-    """Reject statically empty fastlog configurations.
-
-    Parameters
-    ----------
-    options:
-        Fully merged fastlog recording options.
-
-    Raises
-    ------
-    RecordingConfigError
-        If no predicate or default can keep any event.
-    """
-
-    if (
-        options.keep_op is None
-        and options.keep_module is None
-        and options.default_op is False
-        and options.default_module is False
-    ):
-        raise RecordingConfigError("fastlog requires a predicate or a true default capture spec")
-
 
 __all__ = [
     "ActivationRecord",
     "BundleNotFinalizedError",
     "CaptureSpec",
-    "cleanup_partial",
-    "load",
     "ModuleStackFrame",
     "PredicateError",
-    "PredicateFailure",
+    "Recorder",
     "RecorderStateError",
     "Recording",
     "RecordingConfigError",
@@ -128,8 +38,9 @@ __all__ = [
     "RecordContext",
     "RecordContextFieldError",
     "RecoveryError",
+    "cleanup_partial",
+    "dry_run",
+    "load",
     "recover",
     "record",
-    "StorageIntent",
-    "merge_recording_options",
 ]

--- a/torchlens/fastlog/_indexes.py
+++ b/torchlens/fastlog/_indexes.py
@@ -1,0 +1,79 @@
+"""Index file writers for fastlog directory bundles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .._io import TorchLensIOError
+from .types import Recording
+
+
+def write_pass_index(path: str | Path, recording: Recording) -> None:
+    """Write ``pass_index.json`` for a fastlog bundle.
+
+    Parameters
+    ----------
+    path:
+        Bundle directory path.
+    recording:
+        Recording whose per-pass index should be persisted.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the index file cannot be written.
+    """
+
+    pass_index: dict[str, list[str | None]] = {}
+    for pass_num, indexes in recording.by_pass.items():
+        pass_index[str(pass_num)] = [_record_blob_id(recording.records[index]) for index in indexes]
+    _write_json(Path(path) / "pass_index.json", pass_index)
+
+
+def write_label_index(path: str | Path, recording: Recording) -> None:
+    """Write ``label_index.json`` for a fastlog bundle.
+
+    Parameters
+    ----------
+    path:
+        Bundle directory path.
+    recording:
+        Recording whose label index should be persisted.
+
+    Raises
+    ------
+    TorchLensIOError
+        If the index file cannot be written.
+    """
+
+    label_index: dict[str, list[dict[str, int | str | None]]] = {}
+    for label, entries in recording.by_label.items():
+        label_index[label] = [
+            {
+                "pass_index": pass_index,
+                "record_index": record_index,
+                "blob_id": _record_blob_id(recording.records[record_index]),
+            }
+            for pass_index, record_index in entries
+        ]
+    _write_json(Path(path) / "label_index.json", label_index)
+
+
+def _record_blob_id(record: Any) -> str | None:
+    """Return a record's persisted blob id when present."""
+
+    blob_id = record.metadata.get("blob_id")
+    return str(blob_id) if blob_id is not None else None
+
+
+def _write_json(path: Path, data: Any) -> None:
+    """Write one JSON file with deterministic formatting."""
+
+    try:
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    except OSError as exc:
+        raise TorchLensIOError(f"Failed to write fastlog index at {path}.") from exc

--- a/torchlens/fastlog/_orchestrator.py
+++ b/torchlens/fastlog/_orchestrator.py
@@ -39,7 +39,7 @@ def _empty_recording(options: RecordingOptions) -> Recording:
             if options.streaming is None or options.streaming.bundle_path is None
             else Path(options.streaming.bundle_path)
         ),
-        n_passes=1,
+        n_passes=0,
         n_records=0,
         pass_start_times=[],
         pass_end_times=[],
@@ -59,6 +59,23 @@ def _normalize_input_args(input_args: Any) -> tuple[Any, ...]:
     if isinstance(input_args, list):
         return tuple(input_args)
     return (input_args,)
+
+
+def _reset_state_for_pass(
+    state: RecordingState,
+    *,
+    pass_index: int,
+    sample_id: str | int | None,
+) -> None:
+    """Reset per-pass state while preserving accumulated records and storage."""
+
+    state.history.clear()
+    state.op_counts.clear()
+    state.module_stack.clear()
+    state.sample_id = sample_id
+    state.pass_index = pass_index
+    state.event_index = 0
+    state.op_index = 0
 
 
 def _emit_root_module_event(
@@ -95,8 +112,7 @@ def _emit_root_module_event(
         if spec.save_activation or spec.save_metadata:
             state.add_record(ActivationRecord(ctx=ctx, spec=spec))
     except Exception as exc:
-        state.add_predicate_failure(ctx, exc)
-        raise
+        state.handle_predicate_exception(ctx, exc)
     finally:
         state.append_context(ctx)
 
@@ -106,6 +122,11 @@ def _run_predicate_pass(
     input_args: Any,
     input_kwargs: dict[str, Any] | None,
     options: RecordingOptions,
+    *,
+    state: RecordingState | None = None,
+    pass_index: int = 1,
+    sample_id: str | int | None = None,
+    finalize_storage: bool = True,
 ) -> tuple[Any, Recording]:
     """Run one predicate-mode forward pass and return output plus Recording."""
 
@@ -116,9 +137,13 @@ def _run_predicate_pass(
     model_log = ModelLog(str(type(model).__name__))
     model_log.logging_mode = "predicate"
     model_log.pass_start_time = time.time()
-    recording = _empty_recording(options)
+    if state is None:
+        recording = _empty_recording(options)
+        state = RecordingState(options=options, recording=recording)
+    else:
+        recording = state.recording
+    _reset_state_for_pass(state, pass_index=pass_index, sample_id=sample_id)
     recording.pass_start_times.append(model_log.pass_start_time)
-    state = RecordingState(options=options, recording=recording)
     input_tensors = get_vars_of_type_from_obj([args, kwargs], torch.Tensor, [torch.nn.Parameter])
     _ensure_model_prepared(model)
     _prepare_model_session(model_log, model)
@@ -161,8 +186,9 @@ def _run_predicate_pass(
         _cleanup_model_session(model, input_tensors)
         pass_end_time = time.time()
         recording.pass_end_times.append(pass_end_time)
-        object.__setattr__(recording, "n_passes", 1)
+        object.__setattr__(recording, "n_passes", max(recording.n_passes, pass_index))
         object.__setattr__(recording, "n_records", len(recording.records))
-        if not pass_failed:
+        if not pass_failed and finalize_storage:
             state.finalize_storage()
+            state.raise_accumulated_predicate_error()
     return model_output, recording

--- a/torchlens/fastlog/_orchestrator.py
+++ b/torchlens/fastlog/_orchestrator.py
@@ -129,6 +129,7 @@ def _run_predicate_pass(
         module_id=id(model),
         pass_index=1,
     )
+    pass_failed = False
     try:
         with active_recording_state(state), _state.active_logging(model_log):
             for index, tensor in enumerate(input_tensors):
@@ -152,10 +153,16 @@ def _run_predicate_pass(
                     frame=root_frame,
                 )
                 state.module_stack.pop()
+    except Exception as exc:
+        pass_failed = True
+        state.abort_storage(str(exc))
+        raise
     finally:
         _cleanup_model_session(model, input_tensors)
         pass_end_time = time.time()
         recording.pass_end_times.append(pass_end_time)
         object.__setattr__(recording, "n_passes", 1)
         object.__setattr__(recording, "n_records", len(recording.records))
+        if not pass_failed:
+            state.finalize_storage()
     return model_output, recording

--- a/torchlens/fastlog/_orchestrator.py
+++ b/torchlens/fastlog/_orchestrator.py
@@ -156,6 +156,6 @@ def _run_predicate_pass(
         _cleanup_model_session(model, input_tensors)
         pass_end_time = time.time()
         recording.pass_end_times.append(pass_end_time)
-        recording.n_passes = 1
-        recording.n_records = len(recording.records)
+        object.__setattr__(recording, "n_passes", 1)
+        object.__setattr__(recording, "n_records", len(recording.records))
     return model_output, recording

--- a/torchlens/fastlog/_orchestrator.py
+++ b/torchlens/fastlog/_orchestrator.py
@@ -1,0 +1,161 @@
+"""Internal predicate-pass orchestrator for fastlog."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from .. import _state
+from ..capture.source_tensors import log_source_tensor
+from ..data_classes.model_log import ModelLog
+from ..decoration.model_prep import (
+    _cleanup_model_session,
+    _ensure_model_prepared,
+    _prepare_model_session,
+)
+from ..utils.introspection import get_vars_of_type_from_obj
+from ..utils.rng import set_random_seed
+from ._predicate import _evaluate_keep_module
+from ._record_context import _build_record_context
+from ._state import RecordingState, active_recording_state
+from .options import RecordingOptions
+from .types import ActivationRecord, ModuleStackFrame, Recording
+
+
+def _empty_recording(options: RecordingOptions) -> Recording:
+    """Create an empty in-memory Recording for a predicate pass."""
+
+    return Recording(
+        records=[],
+        by_pass={},
+        by_label={},
+        by_module_address={},
+        bundle_path=(
+            None
+            if options.streaming is None or options.streaming.bundle_path is None
+            else Path(options.streaming.bundle_path)
+        ),
+        n_passes=1,
+        n_records=0,
+        pass_start_times=[],
+        pass_end_times=[],
+        predicate_failures=[],
+        predicate_failure_overflow_count=0,
+        keep_op_repr=repr(options.keep_op) if options.keep_op is not None else None,
+        keep_module_repr=repr(options.keep_module) if options.keep_module is not None else None,
+        history_size=options.history_size,
+    )
+
+
+def _normalize_input_args(input_args: Any) -> tuple[Any, ...]:
+    """Normalize public-style input args into a tuple for model invocation."""
+
+    if isinstance(input_args, tuple):
+        return input_args
+    if isinstance(input_args, list):
+        return tuple(input_args)
+    return (input_args,)
+
+
+def _emit_root_module_event(
+    *,
+    model_log: ModelLog,
+    state: RecordingState,
+    model: nn.Module,
+    kind: str,
+    frame: ModuleStackFrame,
+) -> None:
+    """Emit one synthetic root module event."""
+
+    state.event_index += 1
+    ctx = _build_record_context(
+        kind="module_enter" if kind == "enter" else "module_exit",
+        layer_pass_log_or_op_data={
+            "label": f"root:{kind}:1",
+            "module_address": "",
+            "module_type": type(model).__name__,
+            "module_pass_index": frame.pass_index,
+        },
+        module_stack=state.module_stack,
+        history=tuple(state.history),
+        op_counts=state.op_counts,
+        pass_index=state.pass_index,
+        event_index=state.event_index,
+        op_index=None,
+        time_since_pass_start=time.time() - model_log.pass_start_time,
+        include_source_events=state.options.include_source_events,
+        sample_id=state.sample_id,
+    )
+    try:
+        spec = _evaluate_keep_module(ctx, state.options)
+        if spec.save_activation or spec.save_metadata:
+            state.add_record(ActivationRecord(ctx=ctx, spec=spec))
+    except Exception as exc:
+        state.add_predicate_failure(ctx, exc)
+        raise
+    finally:
+        state.append_context(ctx)
+
+
+def _run_predicate_pass(
+    model: nn.Module,
+    input_args: Any,
+    input_kwargs: dict[str, Any] | None,
+    options: RecordingOptions,
+) -> tuple[Any, Recording]:
+    """Run one predicate-mode forward pass and return output plus Recording."""
+
+    if options.random_seed is not None:
+        set_random_seed(options.random_seed)
+    args = _normalize_input_args(input_args)
+    kwargs = input_kwargs or {}
+    model_log = ModelLog(str(type(model).__name__))
+    model_log.logging_mode = "predicate"
+    model_log.pass_start_time = time.time()
+    recording = _empty_recording(options)
+    recording.pass_start_times.append(model_log.pass_start_time)
+    state = RecordingState(options=options, recording=recording)
+    input_tensors = get_vars_of_type_from_obj([args, kwargs], torch.Tensor, [torch.nn.Parameter])
+    _ensure_model_prepared(model)
+    _prepare_model_session(model_log, model)
+    model_output = None
+    root_frame = ModuleStackFrame(
+        module_address="",
+        module_type=type(model).__name__,
+        module_id=id(model),
+        pass_index=1,
+    )
+    try:
+        with active_recording_state(state), _state.active_logging(model_log):
+            for index, tensor in enumerate(input_tensors):
+                log_source_tensor(model_log, tensor, "input", f"input.{index}")
+            state.module_stack.append(root_frame)
+            _emit_root_module_event(
+                model_log=model_log,
+                state=state,
+                model=model,
+                kind="enter",
+                frame=root_frame,
+            )
+            try:
+                model_output = model(*args, **kwargs)
+            finally:
+                _emit_root_module_event(
+                    model_log=model_log,
+                    state=state,
+                    model=model,
+                    kind="exit",
+                    frame=root_frame,
+                )
+                state.module_stack.pop()
+    finally:
+        _cleanup_model_session(model, input_tensors)
+        pass_end_time = time.time()
+        recording.pass_end_times.append(pass_end_time)
+        recording.n_passes = 1
+        recording.n_records = len(recording.records)
+    return model_output, recording

--- a/torchlens/fastlog/_predicate.py
+++ b/torchlens/fastlog/_predicate.py
@@ -1,0 +1,88 @@
+"""Predicate evaluation helpers for fastlog capture decisions."""
+
+from __future__ import annotations
+
+from .exceptions import PredicateError
+from .options import RecordingOptions
+from .types import CaptureSpec, RecordContext
+
+
+def _coerce_default_capture_spec(default: bool | CaptureSpec) -> CaptureSpec:
+    """Normalize a default capture value to a CaptureSpec."""
+
+    if isinstance(default, CaptureSpec):
+        return default
+    if default is True:
+        return CaptureSpec(save_activation=True, save_metadata=True)
+    if default is False:
+        return CaptureSpec(save_activation=False, save_metadata=False)
+    raise PredicateError("default capture decision must be bool or CaptureSpec")
+
+
+def _normalize_capture_decision(
+    result: bool | CaptureSpec | None,
+    ctx: RecordContext,
+    default: bool | CaptureSpec,
+) -> CaptureSpec:
+    """Normalize one predicate return value to a CaptureSpec.
+
+    Parameters
+    ----------
+    result:
+        Predicate return value.
+    ctx:
+        Event context supplied to the predicate.
+    default:
+        Slot default used when ``result`` is None.
+
+    Returns
+    -------
+    CaptureSpec
+        Normalized capture policy.
+
+    Raises
+    ------
+    PredicateError
+        If the predicate returned a value outside the supported contract.
+    """
+
+    default_spec = _coerce_default_capture_spec(default)
+    if result is True:
+        return CaptureSpec(
+            save_activation=True,
+            save_metadata=True,
+            keep_grad=default_spec.keep_grad,
+            device=default_spec.device,
+            dtype=default_spec.dtype,
+        )
+    if result is False:
+        return CaptureSpec(save_activation=False, save_metadata=False)
+    if result is None:
+        return default_spec
+    if isinstance(result, CaptureSpec):
+        return result
+    raise PredicateError(
+        "predicate must return bool, CaptureSpec, or None",
+        ctx=ctx,
+        result=result,
+    )
+
+
+def _evaluate_keep_op(ctx: RecordContext, options: RecordingOptions) -> CaptureSpec:
+    """Evaluate the operation/source predicate slot for one event."""
+
+    if options.keep_op is None:
+        result = None
+    else:
+        result = options.keep_op(ctx)
+    return _normalize_capture_decision(result, ctx, options.default_op)
+
+
+def _evaluate_keep_module(ctx: RecordContext, options: RecordingOptions) -> CaptureSpec:
+    """Evaluate the module predicate slot for one event."""
+
+    if options.keep_module is None:
+        result = None
+    else:
+        result = options.keep_module(ctx)
+    return _normalize_capture_decision(result, ctx, options.default_module)

--- a/torchlens/fastlog/_record_context.py
+++ b/torchlens/fastlog/_record_context.py
@@ -1,0 +1,155 @@
+"""Canonical RecordContext construction for fastlog."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, cast
+
+import torch
+
+from .types import EventKind, ModuleStackFrame, RecordContext
+
+
+def _read_field(source: Any, name: str, default: Any = None) -> Any:
+    """Read a field from a mapping or object with a default."""
+
+    if source is None:
+        return default
+    if isinstance(source, Mapping):
+        return source.get(name, default)
+    return getattr(source, name, default)
+
+
+def _normalize_module_stack(
+    module_stack: Iterable[ModuleStackFrame | Mapping[str, Any]] | None,
+) -> tuple[ModuleStackFrame, ...]:
+    """Normalize module stack input to ModuleStackFrame instances."""
+
+    if module_stack is None:
+        return ()
+    frames: list[ModuleStackFrame] = []
+    for frame in module_stack:
+        if isinstance(frame, ModuleStackFrame):
+            frames.append(frame)
+            continue
+        frames.append(
+            ModuleStackFrame(
+                module_address=str(frame.get("module_address", "")),
+                module_type=str(frame.get("module_type", "")),
+                module_id=int(frame.get("module_id", 0)),
+                pass_index=int(frame.get("pass_index", 0)),
+            )
+        )
+    return tuple(frames)
+
+
+def _recent_ops_for_event(
+    recent_events: Sequence[RecordContext],
+    include_source_events: bool,
+) -> tuple[RecordContext, ...]:
+    """Return the operation-visible subset of recent events."""
+
+    visible_kinds = {"op", "input", "buffer"} if include_source_events else {"op"}
+    return tuple(event for event in recent_events if event.kind in visible_kinds)
+
+
+def _build_record_context(
+    *,
+    kind: EventKind,
+    layer_pass_log_or_op_data: Any = None,
+    module_stack: Iterable[ModuleStackFrame | Mapping[str, Any]] | None = None,
+    history: Sequence[RecordContext] = (),
+    op_counts: Mapping[str, int] | None = None,
+    pass_index: int = 0,
+    event_index: int = 0,
+    op_index: int | None = None,
+    time_since_pass_start: float = 0.0,
+    include_source_events: bool = False,
+    sample_id: str | int | None = None,
+) -> RecordContext:
+    """Build the single source-of-truth RecordContext schema.
+
+    Parameters
+    ----------
+    kind:
+        Chronological event kind.
+    layer_pass_log_or_op_data:
+        Mapping or object containing operation/source/module fields.
+    module_stack:
+        Active module stack at event time.
+    history:
+        Sliding-window event history before this event.
+    op_counts:
+        Per-layer-type counts available to predicates.
+    pass_index:
+        Forward pass index for this recording session.
+    event_index:
+        Chronological event index within the pass.
+    op_index:
+        Operation index for torch-function events.
+    time_since_pass_start:
+        Elapsed seconds since the pass began.
+    include_source_events:
+        Whether source events should appear in ``recent_ops``.
+    sample_id:
+        Optional user-supplied rollout/sample id.
+
+    Returns
+    -------
+    RecordContext
+        Frozen predicate context with the canonical schema.
+    """
+
+    data = layer_pass_log_or_op_data
+    stack = _normalize_module_stack(module_stack)
+    recent_events = tuple(history)
+    layer_type = _read_field(data, "layer_type")
+    if layer_type is None:
+        layer_type = _read_field(data, "func_name")
+    if isinstance(layer_type, str):
+        layer_type = layer_type.lower().replace("_", "")
+    layer_type_num = _read_field(data, "layer_type_num")
+    if layer_type_num is None and layer_type is not None and op_counts is not None:
+        layer_type_num = op_counts.get(cast(str, layer_type))
+    tensor = _read_field(data, "tensor")
+    tensor_shape = _read_field(data, "tensor_shape")
+    tensor_dtype = _read_field(data, "tensor_dtype")
+    tensor_device = _read_field(data, "tensor_device")
+    tensor_requires_grad = _read_field(data, "tensor_requires_grad")
+    if isinstance(tensor, torch.Tensor):
+        tensor_shape = tuple(tensor.shape)
+        tensor_dtype = tensor.dtype
+        tensor_device = tensor.device
+        tensor_requires_grad = tensor.requires_grad
+    raw_label = _read_field(data, "tensor_label_raw", _read_field(data, "raw_label"))
+    label = _read_field(data, "label", raw_label)
+    if label is None:
+        label = f"{kind}_{event_index}"
+    return RecordContext(
+        kind=kind,
+        label=str(label),
+        raw_label=raw_label,
+        pass_index=pass_index,
+        event_index=event_index,
+        op_index=op_index,
+        layer_type=layer_type,
+        layer_type_num=layer_type_num,
+        creation_order=_read_field(data, "creation_order"),
+        func_name=_read_field(data, "func_name"),
+        module_address=_read_field(data, "module_address"),
+        module_type=_read_field(data, "module_type"),
+        module_pass_index=_read_field(data, "module_pass_index"),
+        module_stack=stack,
+        recent_events=recent_events,
+        recent_ops=_recent_ops_for_event(recent_events, include_source_events),
+        parent_labels=tuple(_read_field(data, "parent_labels", ())),
+        input_output_address=_read_field(data, "input_output_address"),
+        tensor_shape=tensor_shape,
+        tensor_dtype=tensor_dtype,
+        tensor_device=tensor_device,
+        tensor_requires_grad=tensor_requires_grad,
+        output_index=_read_field(data, "output_index"),
+        is_bottom_level_func=_read_field(data, "is_bottom_level_func"),
+        time_since_pass_start=time_since_pass_start,
+        sample_id=sample_id,
+    )

--- a/torchlens/fastlog/_record_one_shot.py
+++ b/torchlens/fastlog/_record_one_shot.py
@@ -1,0 +1,77 @@
+"""One-shot public fastlog recording API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import nn
+
+from ..options import StreamingOptions
+from ._recorder import Recorder
+from ._validation import validate_postprocess
+from .options import PredicateErrorMode, PredicateFn
+from .types import CaptureSpec, Recording
+
+
+def record(
+    model: nn.Module,
+    input_args: Any,
+    input_kwargs: dict[str, Any] | None = None,
+    *,
+    keep_op: PredicateFn | None = None,
+    keep_module: PredicateFn | None = None,
+    default_op: bool | CaptureSpec = False,
+    default_module: bool | CaptureSpec = False,
+    history_size: int = 8,
+    include_source_events: bool = False,
+    max_predicate_failures: int = 32,
+    on_predicate_error: PredicateErrorMode = "auto",
+    streaming: StreamingOptions | None = None,
+    return_output: bool = False,
+    postprocess: str = "none",
+    random_seed: int | None = None,
+) -> Recording | tuple[Any, Recording]:
+    """Record one model forward pass with fastlog predicates.
+
+    Parameters
+    ----------
+    model:
+        PyTorch module to execute.
+    input_args:
+        Tensor, list, or tuple of positional model inputs.
+    input_kwargs:
+        Optional keyword arguments for the model call.
+    keep_op, keep_module, default_op, default_module, history_size,
+    include_source_events, max_predicate_failures, on_predicate_error, streaming,
+    random_seed:
+        Fastlog recording options.
+    return_output:
+        Whether to return ``(model_output, recording)``.
+    postprocess:
+        Postprocess preset. Only ``"none"`` is implemented in this bundle.
+
+    Returns
+    -------
+    Recording | tuple[Any, Recording]
+        Fastlog recording, optionally with the model output.
+    """
+
+    validate_postprocess(postprocess)
+    with Recorder(
+        model,
+        keep_op=keep_op,
+        keep_module=keep_module,
+        default_op=default_op,
+        default_module=default_module,
+        history_size=history_size,
+        include_source_events=include_source_events,
+        max_predicate_failures=max_predicate_failures,
+        on_predicate_error=on_predicate_error,
+        streaming=streaming,
+        random_seed=random_seed,
+    ) as recorder:
+        output = recorder.log(input_args, input_kwargs)
+    recording = recorder.recording
+    if return_output:
+        return output, recording
+    return recording

--- a/torchlens/fastlog/_record_one_shot.py
+++ b/torchlens/fastlog/_record_one_shot.py
@@ -48,7 +48,7 @@ def record(
     return_output:
         Whether to return ``(model_output, recording)``.
     postprocess:
-        Postprocess preset. Only ``"none"`` is implemented in this bundle.
+        Optional postprocess enrichment preset.
 
     Returns
     -------
@@ -72,6 +72,8 @@ def record(
     ) as recorder:
         output = recorder.log(input_args, input_kwargs)
     recording = recorder.recording
+    if postprocess != "none":
+        recording = recording.enrich(postprocess)
     if return_output:
         return output, recording
     return recording

--- a/torchlens/fastlog/_recorder.py
+++ b/torchlens/fastlog/_recorder.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 
+import torch
 from torch import nn
 
 from .._deprecations import MISSING, MissingType
@@ -16,6 +18,80 @@ from ._validation import validate_recording_options
 from .exceptions import RecorderStateError
 from .options import PredicateErrorMode, PredicateFn, RecordingOptions, merge_recording_options
 from .types import CaptureSpec, Recording
+
+
+def _rank_prefixed_streaming_options(
+    streaming: StreamingOptions | None | MissingType,
+) -> StreamingOptions | None | MissingType:
+    """Return streaming options with a rank-local directory prefix.
+
+    Parameters
+    ----------
+    streaming:
+        Caller-supplied streaming options.
+
+    Returns
+    -------
+    StreamingOptions | None | MissingType
+        Options with ``bundle_path`` rewritten to include ``rank_NN`` when a
+        bundle path is configured.
+    """
+
+    if isinstance(streaming, MissingType) or streaming is None or streaming.bundle_path is None:
+        return streaming
+    rank = 0
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+    bundle_path = Path(streaming.bundle_path)
+    return StreamingOptions(
+        bundle_path=bundle_path.parent / f"rank_{rank:02d}" / bundle_path.name,
+        retain_in_memory=streaming.retain_in_memory,
+        activation_callback=streaming.activation_callback,
+    )
+
+
+def _unwrap_ddp_for_fastlog(
+    model: nn.Module,
+    streaming: StreamingOptions | None | MissingType,
+) -> tuple[nn.Module, StreamingOptions | None | MissingType]:
+    """Unwrap DDP/DataParallel wrappers for rank-local fastlog capture.
+
+    Parameters
+    ----------
+    model:
+        Candidate model supplied to fastlog.
+    streaming:
+        Caller-supplied streaming options.
+
+    Returns
+    -------
+    tuple[nn.Module, StreamingOptions | None | MissingType]
+        The model to execute and possibly rewritten streaming options.
+    """
+
+    try:
+        from torch.distributed.fsdp import FullyShardedDataParallel
+    except ImportError:
+        pass
+    else:
+        if isinstance(model, FullyShardedDataParallel):
+            raise RuntimeError(
+                "torchlens.fastlog does not support FullyShardedDataParallel (FSDP): "
+                "parameters are sharded across ranks and there is no unsharded module to log."
+            )
+
+    try:
+        from torch.nn.parallel import DistributedDataParallel
+    except ImportError:
+        distributed_data_parallel: type[nn.Module] | None = None
+    else:
+        distributed_data_parallel = DistributedDataParallel
+
+    if distributed_data_parallel is not None and isinstance(model, distributed_data_parallel):
+        return cast(nn.Module, model.module), _rank_prefixed_streaming_options(streaming)
+    if isinstance(model, nn.DataParallel):
+        return cast(nn.Module, model.module), _rank_prefixed_streaming_options(streaming)
+    return model, streaming
 
 
 class Recorder:
@@ -48,7 +124,8 @@ class Recorder:
             Fastlog recording options.
         """
 
-        self.model = model
+        unwrapped_model, streaming = _unwrap_ddp_for_fastlog(model, streaming)
+        self.model = unwrapped_model
         self.options = merge_recording_options(
             recording=None,
             keep_op=keep_op,

--- a/torchlens/fastlog/_recorder.py
+++ b/torchlens/fastlog/_recorder.py
@@ -1,0 +1,150 @@
+"""Public Recorder context manager for fastlog sessions."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Any
+
+from torch import nn
+
+from .._deprecations import MISSING, MissingType
+from ..decoration.model_prep import _ensure_model_prepared
+from ..options import StreamingOptions
+from ._orchestrator import _empty_recording, _run_predicate_pass
+from ._state import RecordingState
+from ._validation import validate_recording_options
+from .exceptions import RecorderStateError
+from .options import PredicateErrorMode, PredicateFn, RecordingOptions, merge_recording_options
+from .types import CaptureSpec, Recording
+
+
+class Recorder:
+    """Context manager for explicitly captured fastlog forwards."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        *,
+        keep_op: PredicateFn | None | MissingType = MISSING,
+        keep_module: PredicateFn | None | MissingType = MISSING,
+        default_op: bool | CaptureSpec | MissingType = MISSING,
+        default_module: bool | CaptureSpec | MissingType = MISSING,
+        history_size: int | MissingType = MISSING,
+        include_source_events: bool | MissingType = MISSING,
+        max_predicate_failures: int | MissingType = MISSING,
+        on_predicate_error: PredicateErrorMode | MissingType = MISSING,
+        streaming: StreamingOptions | None | MissingType = MISSING,
+        random_seed: int | None | MissingType = MISSING,
+    ) -> None:
+        """Initialize a recorder and perform construction-time validation.
+
+        Parameters
+        ----------
+        model:
+            PyTorch module to record.
+        keep_op, keep_module, default_op, default_module, history_size,
+        include_source_events, max_predicate_failures, on_predicate_error, streaming,
+        random_seed:
+            Fastlog recording options.
+        """
+
+        self.model = model
+        self.options = merge_recording_options(
+            recording=None,
+            keep_op=keep_op,
+            keep_module=keep_module,
+            default_op=default_op,
+            default_module=default_module,
+            history_size=history_size,
+            include_source_events=include_source_events,
+            max_predicate_failures=max_predicate_failures,
+            on_predicate_error=on_predicate_error,
+            streaming=streaming,
+            random_seed=random_seed,
+        )
+        validate_recording_options(self.options)
+        _ensure_model_prepared(self.model)
+        self._state: RecordingState | None = None
+        self._recording: Recording | None = None
+        self._entered = False
+        self._exited = False
+        self._next_pass_index = 1
+
+    def __enter__(self) -> "Recorder":
+        """Enter the recorder resource scope."""
+
+        if self._entered or self._exited:
+            raise RecorderStateError("Recorder cannot be re-entered")
+        recording = _empty_recording(self.options)
+        self._state = RecordingState(options=self.options, recording=recording)
+        self._entered = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Finalize or abort the recorder resource scope."""
+
+        _ = exc_type, traceback
+        if not self._entered or self._exited or self._state is None:
+            raise RecorderStateError("Recorder is not active")
+        if exc_value is None:
+            self._state.finalize_storage()
+            object.__setattr__(self._state.recording, "n_records", len(self._state.recording))
+            self._recording = self._state.recording
+        else:
+            self._state.abort_storage(str(exc_value))
+        self._entered = False
+        self._exited = True
+        if exc_value is None:
+            self._state.raise_accumulated_predicate_error()
+
+    def log(
+        self,
+        input_args: Any,
+        input_kwargs: dict[str, Any] | None = None,
+        *,
+        sample_id: str | int | None = None,
+    ) -> Any:
+        """Capture one forward pass and return the model output.
+
+        Parameters
+        ----------
+        input_args:
+            Tensor, tuple, or list of positional model inputs.
+        input_kwargs:
+            Optional keyword arguments for the model call.
+        sample_id:
+            Optional caller-provided sample identifier stored on event contexts.
+
+        Returns
+        -------
+        Any
+            Model forward output.
+        """
+
+        if not self._entered or self._exited or self._state is None:
+            raise RecorderStateError("Recorder.log() requires an active with-block")
+        output, _ = _run_predicate_pass(
+            self.model,
+            input_args,
+            input_kwargs,
+            self.options,
+            state=self._state,
+            pass_index=self._next_pass_index,
+            sample_id=sample_id,
+            finalize_storage=False,
+        )
+        self._next_pass_index += 1
+        return output
+
+    @property
+    def recording(self) -> Recording:
+        """Return the finalized recording after context-manager exit."""
+
+        if self._recording is None:
+            raise RecorderStateError("Recorder.recording is only available after __exit__")
+        return self._recording

--- a/torchlens/fastlog/_state.py
+++ b/torchlens/fastlog/_state.py
@@ -79,7 +79,7 @@ class RecordingState:
             )
         if record.ctx.module_address is not None:
             self.recording.by_module_address.setdefault(record.ctx.module_address, []).append(index)
-        self.recording.n_records = len(self.recording.records)
+        object.__setattr__(self.recording, "n_records", len(self.recording.records))
 
     def add_predicate_failure(self, ctx: RecordContext, exc: BaseException) -> None:
         """Record a predicate failure subject to the configured cap."""
@@ -94,8 +94,12 @@ class RecordingState:
             self.predicate_failures.append(failure)
         else:
             self.predicate_failure_overflow_count += 1
-        self.recording.predicate_failures = list(self.predicate_failures)
-        self.recording.predicate_failure_overflow_count = self.predicate_failure_overflow_count
+        object.__setattr__(self.recording, "predicate_failures", list(self.predicate_failures))
+        object.__setattr__(
+            self.recording,
+            "predicate_failure_overflow_count",
+            self.predicate_failure_overflow_count,
+        )
 
 
 def get_active_recording_state() -> RecordingState:

--- a/torchlens/fastlog/_state.py
+++ b/torchlens/fastlog/_state.py
@@ -1,0 +1,119 @@
+"""Session-local state for fastlog predicate recording."""
+
+from __future__ import annotations
+
+import traceback
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator
+
+from .options import RecordingOptions
+from .types import (
+    ActivationRecord,
+    ModuleStackFrame,
+    PredicateFailure,
+    RecordContext,
+    Recording,
+    StorageIntent,
+)
+
+_active_recording_state: "RecordingState | None" = None
+
+
+def _resolve_storage_intent(options: RecordingOptions) -> StorageIntent:
+    """Resolve storage destinations from StreamingOptions."""
+
+    if options.streaming is None or options.streaming.bundle_path is None:
+        return StorageIntent(in_ram=True, on_disk=False)
+    return StorageIntent(
+        in_ram=options.streaming.retain_in_memory,
+        on_disk=True,
+    )
+
+
+@dataclass(slots=True)
+class RecordingState:
+    """Mutable state for one active predicate recording pass."""
+
+    options: RecordingOptions
+    recording: Recording
+    history: deque[RecordContext] = field(default_factory=deque)
+    op_counts: dict[str, int] = field(default_factory=dict)
+    module_stack: list[ModuleStackFrame] = field(default_factory=list)
+    predicate_failures: list[PredicateFailure] = field(default_factory=list)
+    predicate_failure_overflow_count: int = 0
+    error_slot: BaseException | None = None
+    sample_id: str | int | None = None
+    pass_index: int = 0
+    event_index: int = 0
+    op_index: int = 0
+    storage_intent: StorageIntent = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Initialize derived storage policy."""
+
+        self.storage_intent = _resolve_storage_intent(self.options)
+
+    def append_context(self, ctx: RecordContext) -> None:
+        """Append an event context to the bounded sliding window."""
+
+        if self.options.history_size == 0:
+            return
+        self.history.append(ctx)
+        while len(self.history) > self.options.history_size:
+            self.history.popleft()
+
+    def add_record(self, record: ActivationRecord) -> None:
+        """Append a retained activation record and update indexes."""
+
+        index = len(self.recording.records)
+        self.recording.records.append(record)
+        self.recording.by_pass.setdefault(record.ctx.pass_index, []).append(index)
+        self.recording.by_label.setdefault(record.ctx.label, []).append(
+            (record.ctx.pass_index, index)
+        )
+        if record.ctx.raw_label is not None:
+            self.recording.by_label.setdefault(record.ctx.raw_label, []).append(
+                (record.ctx.pass_index, index)
+            )
+        if record.ctx.module_address is not None:
+            self.recording.by_module_address.setdefault(record.ctx.module_address, []).append(index)
+        self.recording.n_records = len(self.recording.records)
+
+    def add_predicate_failure(self, ctx: RecordContext, exc: BaseException) -> None:
+        """Record a predicate failure subject to the configured cap."""
+
+        failure = PredicateFailure(
+            event_index=ctx.event_index,
+            kind=ctx.kind,
+            label=ctx.label,
+            traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        )
+        if len(self.predicate_failures) < self.options.max_predicate_failures:
+            self.predicate_failures.append(failure)
+        else:
+            self.predicate_failure_overflow_count += 1
+        self.recording.predicate_failures = list(self.predicate_failures)
+        self.recording.predicate_failure_overflow_count = self.predicate_failure_overflow_count
+
+
+def get_active_recording_state() -> RecordingState:
+    """Return the active recording state or fail clearly."""
+
+    if _active_recording_state is None:
+        raise RuntimeError("fastlog predicate state is not active")
+    return _active_recording_state
+
+
+@contextmanager
+def active_recording_state(state: RecordingState) -> Iterator[RecordingState]:
+    """Install fastlog recording state for one active logging scope."""
+
+    global _active_recording_state
+    previous = _active_recording_state
+    _active_recording_state = state
+    try:
+        yield state
+    finally:
+        _active_recording_state = previous

--- a/torchlens/fastlog/_state.py
+++ b/torchlens/fastlog/_state.py
@@ -20,6 +20,7 @@ from .types import (
     Recording,
     StorageIntent,
 )
+from .exceptions import PredicateError
 
 _active_recording_state: "RecordingState | None" = None
 
@@ -72,6 +73,8 @@ class RecordingState:
     pass_index: int = 0
     event_index: int = 0
     op_index: int = 0
+    no_tensor_capture: bool = False
+    all_contexts: list[RecordContext] = field(default_factory=list)
     storage_intent: StorageIntent = field(init=False)
     storage_backend: _StorageBackend = field(init=False)
 
@@ -91,6 +94,7 @@ class RecordingState:
     def append_context(self, ctx: RecordContext) -> None:
         """Append an event context to the bounded sliding window."""
 
+        self.all_contexts.append(ctx)
         if self.options.history_size == 0:
             return
         self.history.append(ctx)
@@ -110,6 +114,8 @@ class RecordingState:
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         """Resolve payloads through the active storage backend."""
 
+        if self.no_tensor_capture:
+            return None, None
         return self.storage_backend.resolve_payloads(tensor, spec, self.storage_intent)
 
     def finalize_storage(self) -> None:
@@ -121,6 +127,13 @@ class RecordingState:
         """Abort the active storage backend after a failed pass."""
 
         self.storage_backend.abort(reason)
+
+    def effective_predicate_error_mode(self) -> str:
+        """Return the concrete predicate exception policy for this session."""
+
+        if self.options.on_predicate_error != "auto":
+            return self.options.on_predicate_error
+        return "fail-fast" if self.storage_intent.on_disk else "accumulate"
 
     def add_predicate_failure(self, ctx: RecordContext, exc: BaseException) -> None:
         """Record a predicate failure subject to the configured cap."""
@@ -140,6 +153,30 @@ class RecordingState:
             self.recording,
             "predicate_failure_overflow_count",
             self.predicate_failure_overflow_count,
+        )
+
+    def handle_predicate_exception(self, ctx: RecordContext, exc: BaseException) -> None:
+        """Apply the configured predicate exception policy."""
+
+        self.add_predicate_failure(ctx, exc)
+        if self.effective_predicate_error_mode() == "fail-fast":
+            raise exc
+
+    def raise_accumulated_predicate_error(self) -> None:
+        """Raise a final PredicateError when accumulated failures exist."""
+
+        if self.effective_predicate_error_mode() != "accumulate":
+            return
+        if not self.predicate_failures and self.predicate_failure_overflow_count == 0:
+            return
+        details = ""
+        if self.predicate_failures:
+            details = f": {self.predicate_failures[0].traceback.strip().splitlines()[-1]}"
+        raise PredicateError(
+            f"fastlog predicate failed during recording{details}",
+            failures=list(self.predicate_failures),
+            total_count=len(self.predicate_failures) + self.predicate_failure_overflow_count,
+            overflow=self.predicate_failure_overflow_count,
         )
 
 

--- a/torchlens/fastlog/_state.py
+++ b/torchlens/fastlog/_state.py
@@ -6,11 +6,14 @@ import traceback
 from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Iterator
+from typing import Iterator, Protocol
+
+import torch
 
 from .options import RecordingOptions
 from .types import (
     ActivationRecord,
+    CaptureSpec,
     ModuleStackFrame,
     PredicateFailure,
     RecordContext,
@@ -19,6 +22,27 @@ from .types import (
 )
 
 _active_recording_state: "RecordingState | None" = None
+
+
+class _StorageBackend(Protocol):
+    """Protocol implemented by fastlog storage backends."""
+
+    def append(self, record: ActivationRecord) -> None:
+        """Append one retained record."""
+
+    def resolve_payloads(
+        self,
+        tensor: torch.Tensor,
+        spec: CaptureSpec,
+        intent: StorageIntent,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Resolve payloads for one selected tensor."""
+
+    def finalize(self) -> None:
+        """Finalize storage."""
+
+    def abort(self, reason: str) -> None:
+        """Abort storage."""
 
 
 def _resolve_storage_intent(options: RecordingOptions) -> StorageIntent:
@@ -49,11 +73,20 @@ class RecordingState:
     event_index: int = 0
     op_index: int = 0
     storage_intent: StorageIntent = field(init=False)
+    storage_backend: _StorageBackend = field(init=False)
 
     def __post_init__(self) -> None:
         """Initialize derived storage policy."""
 
         self.storage_intent = _resolve_storage_intent(self.options)
+        if self.storage_intent.on_disk:
+            from .storage_disk import DiskStorageBackend
+
+            self.storage_backend = DiskStorageBackend(self.options, self.recording)
+        else:
+            from .storage_ram import RamStorageBackend
+
+            self.storage_backend = RamStorageBackend(self.recording)
 
     def append_context(self, ctx: RecordContext) -> None:
         """Append an event context to the bounded sliding window."""
@@ -67,19 +100,27 @@ class RecordingState:
     def add_record(self, record: ActivationRecord) -> None:
         """Append a retained activation record and update indexes."""
 
-        index = len(self.recording.records)
-        self.recording.records.append(record)
-        self.recording.by_pass.setdefault(record.ctx.pass_index, []).append(index)
-        self.recording.by_label.setdefault(record.ctx.label, []).append(
-            (record.ctx.pass_index, index)
-        )
-        if record.ctx.raw_label is not None:
-            self.recording.by_label.setdefault(record.ctx.raw_label, []).append(
-                (record.ctx.pass_index, index)
-            )
-        if record.ctx.module_address is not None:
-            self.recording.by_module_address.setdefault(record.ctx.module_address, []).append(index)
+        self.storage_backend.append(record)
         object.__setattr__(self.recording, "n_records", len(self.recording.records))
+
+    def resolve_storage(
+        self,
+        tensor: torch.Tensor,
+        spec: CaptureSpec,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Resolve payloads through the active storage backend."""
+
+        return self.storage_backend.resolve_payloads(tensor, spec, self.storage_intent)
+
+    def finalize_storage(self) -> None:
+        """Finalize the active storage backend."""
+
+        self.storage_backend.finalize()
+
+    def abort_storage(self, reason: str) -> None:
+        """Abort the active storage backend after a failed pass."""
+
+        self.storage_backend.abort(reason)
 
     def add_predicate_failure(self, ctx: RecordContext, exc: BaseException) -> None:
         """Record a predicate failure subject to the configured cap."""

--- a/torchlens/fastlog/_storage_resolver.py
+++ b/torchlens/fastlog/_storage_resolver.py
@@ -51,7 +51,7 @@ def _resolve_storage(
 
     if spec.keep_grad and intent.on_disk and not intent.in_ram:
         raise PredicateError("keep_grad=True is not valid for disk-only fastlog storage")
-    if spec.keep_grad and tensor.dtype in _INTEGER_DTYPES:
+    if spec.keep_grad and (tensor.dtype in _INTEGER_DTYPES or spec.dtype in _INTEGER_DTYPES):
         raise PredicateError("keep_grad=True is not valid for integer or bool tensors")
 
     ram_payload = None

--- a/torchlens/fastlog/_storage_resolver.py
+++ b/torchlens/fastlog/_storage_resolver.py
@@ -1,0 +1,65 @@
+"""Storage resolution for fastlog tensor payloads."""
+
+from __future__ import annotations
+
+import torch
+
+from .._state import pause_logging
+from ..utils.tensor_utils import safe_copy
+from .exceptions import PredicateError
+from .types import CaptureSpec, StorageIntent
+
+_INTEGER_DTYPES = {
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+    torch.bool,
+}
+
+
+def _apply_payload_transforms(tensor: torch.Tensor, spec: CaptureSpec) -> torch.Tensor:
+    """Apply device and dtype transforms after safe_copy."""
+
+    payload = tensor
+    with pause_logging():
+        if spec.dtype is not None:
+            payload = payload.to(dtype=spec.dtype)
+        if spec.device is not None:
+            payload = payload.to(device=spec.device)
+    return payload
+
+
+def _resolve_storage(
+    tensor: torch.Tensor,
+    spec: CaptureSpec,
+    intent: StorageIntent,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Resolve RAM and disk tensor payloads for one capture decision.
+
+    Returns
+    -------
+    tuple[torch.Tensor | None, torch.Tensor | None]
+        ``(ram_payload, disk_payload)``. Either payload may be None.
+
+    Raises
+    ------
+    PredicateError
+        If the requested storage policy is invalid for the tensor.
+    """
+
+    if spec.keep_grad and intent.on_disk and not intent.in_ram:
+        raise PredicateError("keep_grad=True is not valid for disk-only fastlog storage")
+    if spec.keep_grad and tensor.dtype in _INTEGER_DTYPES:
+        raise PredicateError("keep_grad=True is not valid for integer or bool tensors")
+
+    ram_payload = None
+    disk_payload = None
+    if intent.in_ram:
+        ram_payload = safe_copy(tensor, detach_tensor=not spec.keep_grad)
+        ram_payload = _apply_payload_transforms(ram_payload, spec)
+    if intent.on_disk:
+        disk_payload = safe_copy(tensor, detach_tensor=True)
+        disk_payload = _apply_payload_transforms(disk_payload, spec)
+    return ram_payload, disk_payload

--- a/torchlens/fastlog/_validation.py
+++ b/torchlens/fastlog/_validation.py
@@ -54,8 +54,6 @@ def validate_postprocess(postprocess: str) -> None:
             "postprocess must be 'none', 'module_path_strings', "
             "'param_addresses', or 'all-feasible'"
         )
-    if postprocess != "none":
-        raise RecordingConfigError("fastlog postprocess presets are implemented in a later step")
 
 
 def _validate_non_empty_capture(options: RecordingOptions) -> None:

--- a/torchlens/fastlog/_validation.py
+++ b/torchlens/fastlog/_validation.py
@@ -1,0 +1,89 @@
+"""Validation helpers for public fastlog APIs."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .exceptions import RecordingConfigError
+from .options import RecordingOptions
+from .types import CaptureSpec
+
+_POSTPROCESS_PRESETS: Final[set[str]] = {
+    "none",
+    "module_path_strings",
+    "param_addresses",
+    "all-feasible",
+}
+
+
+def validate_recording_options(options: RecordingOptions) -> None:
+    """Validate fastlog options that depend on combined public settings.
+
+    Parameters
+    ----------
+    options:
+        Fully merged fastlog recording options.
+
+    Raises
+    ------
+    RecordingConfigError
+        If no event can be selected or disk-only storage conflicts with a
+        static ``keep_grad=True`` default.
+    """
+
+    _validate_non_empty_capture(options)
+    _validate_disk_only_keep_grad_defaults(options)
+
+
+def validate_postprocess(postprocess: str) -> None:
+    """Validate a public postprocess preset name.
+
+    Parameters
+    ----------
+    postprocess:
+        Requested postprocess preset.
+
+    Raises
+    ------
+    RecordingConfigError
+        If the preset is not part of the public contract.
+    """
+
+    if postprocess not in _POSTPROCESS_PRESETS:
+        raise RecordingConfigError(
+            "postprocess must be 'none', 'module_path_strings', "
+            "'param_addresses', or 'all-feasible'"
+        )
+    if postprocess != "none":
+        raise RecordingConfigError("fastlog postprocess presets are implemented in a later step")
+
+
+def _validate_non_empty_capture(options: RecordingOptions) -> None:
+    """Reject statically empty fastlog configurations."""
+
+    if (
+        options.keep_op is None
+        and options.keep_module is None
+        and options.default_op is False
+        and options.default_module is False
+    ):
+        raise RecordingConfigError("fastlog requires a predicate or a true default capture spec")
+
+
+def _validate_disk_only_keep_grad_defaults(options: RecordingOptions) -> None:
+    """Reject static keep_grad defaults for disk-only storage."""
+
+    if (
+        options.streaming is None
+        or options.streaming.bundle_path is None
+        or options.streaming.retain_in_memory
+    ):
+        return
+    for name, default in (
+        ("default_op", options.default_op),
+        ("default_module", options.default_module),
+    ):
+        if isinstance(default, CaptureSpec) and default.keep_grad:
+            raise RecordingConfigError(
+                f"{name} cannot use keep_grad=True with disk-only fastlog storage"
+            )

--- a/torchlens/fastlog/cleanup.py
+++ b/torchlens/fastlog/cleanup.py
@@ -1,0 +1,56 @@
+"""Cleanup helpers for partial fastlog bundles."""
+
+from __future__ import annotations
+
+import shutil
+import warnings
+from pathlib import Path
+
+from .._io import TorchLensIOError
+from .._io.streaming import PARTIAL_SENTINEL
+
+
+def cleanup_partial(path: str | Path, *, force: bool = False) -> list[Path]:
+    """Remove partial fastlog bundles and sibling temp directories.
+
+    Parameters
+    ----------
+    path:
+        Fastlog bundle path or final path whose ``.tmp.*`` siblings should be inspected.
+    force:
+        Whether candidates without ``PARTIAL`` sentinels may be removed.
+
+    Returns
+    -------
+    list[Path]
+        Removed paths.
+
+    Raises
+    ------
+    TorchLensIOError
+        If any cleanup candidate is a symlink.
+    """
+
+    bundle_path = Path(path)
+    if bundle_path.is_symlink():
+        raise TorchLensIOError(f"Refusing to clean symlink path {bundle_path}.")
+    removed: list[Path] = []
+    candidates = []
+    if bundle_path.exists():
+        candidates.append(bundle_path)
+    candidates.extend(bundle_path.parent.glob(f"{bundle_path.name}.tmp.*"))
+    for candidate in candidates:
+        if candidate.is_symlink():
+            raise TorchLensIOError(f"Refusing to clean symlink temp directory {candidate}.")
+        if not candidate.is_dir():
+            continue
+        if force or (candidate / PARTIAL_SENTINEL).exists():
+            shutil.rmtree(candidate)
+            removed.append(candidate)
+        else:
+            warnings.warn(
+                f"Leaving non-partial fastlog directory {candidate}; pass force=True to remove it.",
+                UserWarning,
+                stacklevel=2,
+            )
+    return removed

--- a/torchlens/fastlog/dry_run.py
+++ b/torchlens/fastlog/dry_run.py
@@ -1,0 +1,60 @@
+"""Dry-run tracing API for fastlog predicates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import nn
+
+from ._recorder import Recorder
+from .options import PredicateFn
+from .types import RecordingTrace
+
+
+def dry_run(
+    model: nn.Module,
+    input_args: Any,
+    input_kwargs: dict[str, Any] | None = None,
+    *,
+    keep_op: PredicateFn | None = None,
+    keep_module: PredicateFn | None = None,
+    history_size: int = 8,
+    include_source_events: bool = False,
+    random_seed: int | None = None,
+) -> RecordingTrace:
+    """Run predicates over one forward pass without retaining tensor payloads.
+
+    Parameters
+    ----------
+    model:
+        PyTorch module to execute.
+    input_args:
+        Tensor, list, or tuple of positional model inputs.
+    input_kwargs:
+        Optional keyword arguments for the model call.
+    keep_op, keep_module, history_size, include_source_events, random_seed:
+        Fastlog dry-run options. Predicate exceptions propagate immediately.
+
+    Returns
+    -------
+    RecordingTrace
+        Chronological event contexts and any accumulated predicate failures.
+    """
+
+    with Recorder(
+        model,
+        keep_op=keep_op,
+        keep_module=keep_module,
+        history_size=history_size,
+        include_source_events=include_source_events,
+        on_predicate_error="fail-fast",
+        streaming=None,
+        random_seed=random_seed,
+    ) as recorder:
+        if recorder._state is None:  # noqa: SLF001
+            raise RuntimeError("Recorder state was not initialized")
+        recorder._state.no_tensor_capture = True  # noqa: SLF001
+        recorder.log(input_args, input_kwargs)
+        contexts = tuple(recorder._state.all_contexts)  # noqa: SLF001
+        failures = tuple(recorder._state.predicate_failures)  # noqa: SLF001
+    return RecordingTrace(contexts=contexts, predicate_failures=failures)

--- a/torchlens/fastlog/dry_run.py
+++ b/torchlens/fastlog/dry_run.py
@@ -56,5 +56,10 @@ def dry_run(
         recorder._state.no_tensor_capture = True  # noqa: SLF001
         recorder.log(input_args, input_kwargs)
         contexts = tuple(recorder._state.all_contexts)  # noqa: SLF001
+        kept_event_indexes = {
+            record.ctx.event_index
+            for record in recorder._state.recording.records  # noqa: SLF001
+        }
+        decisions = tuple(ctx.event_index in kept_event_indexes for ctx in contexts)
         failures = tuple(recorder._state.predicate_failures)  # noqa: SLF001
-    return RecordingTrace(contexts=contexts, predicate_failures=failures)
+    return RecordingTrace(contexts=contexts, decisions=decisions, predicate_failures=failures)

--- a/torchlens/fastlog/exceptions.py
+++ b/torchlens/fastlog/exceptions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -25,11 +24,20 @@ class BundleNotFinalizedError(RuntimeError):
     """Raised when loading a bundle that was not finalized cleanly."""
 
 
-@dataclass(frozen=True, slots=True)
 class RecordContextFieldError(AttributeError):
     """Raised when a predicate asks for a field outside the RecordContext schema."""
 
-    field: str
+    def __init__(self, field: str) -> None:
+        """Initialize a missing RecordContext field error.
+
+        Parameters
+        ----------
+        field:
+            Missing field name.
+        """
+
+        super().__init__(field)
+        self.field = field
 
     def __str__(self) -> str:
         """Return a concise field-access error message."""

--- a/torchlens/fastlog/exceptions.py
+++ b/torchlens/fastlog/exceptions.py
@@ -1,0 +1,76 @@
+"""Exception types for fastlog predicate recording."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .types import PredicateFailure, RecordContext
+
+
+class RecordingConfigError(ValueError):
+    """Raised when fastlog options are internally inconsistent."""
+
+
+class RecorderStateError(RuntimeError):
+    """Raised when a recorder is used outside its valid lifecycle."""
+
+
+class RecoveryError(RuntimeError):
+    """Raised when a partial fastlog bundle cannot be recovered."""
+
+
+class BundleNotFinalizedError(RuntimeError):
+    """Raised when loading a bundle that was not finalized cleanly."""
+
+
+@dataclass(frozen=True, slots=True)
+class RecordContextFieldError(AttributeError):
+    """Raised when a predicate asks for a field outside the RecordContext schema."""
+
+    field: str
+
+    def __str__(self) -> str:
+        """Return a concise field-access error message."""
+
+        return f"RecordContext has no field {self.field!r}"
+
+
+class PredicateError(RuntimeError):
+    """Raised when a predicate returns an invalid value or fails during evaluation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        ctx: "RecordContext | None" = None,
+        result: Any = None,
+        failures: list["PredicateFailure"] | None = None,
+        total_count: int | None = None,
+        overflow: int = 0,
+    ) -> None:
+        """Initialize a predicate error with optional event context.
+
+        Parameters
+        ----------
+        message:
+            Human-readable failure reason.
+        ctx:
+            Predicate event context, when available.
+        result:
+            Invalid predicate return value, when applicable.
+        failures:
+            Accumulated predicate failures for deferred reporting.
+        total_count:
+            Total number of predicate failures observed.
+        overflow:
+            Number of failures omitted because the failure list was capped.
+        """
+
+        super().__init__(message)
+        self.ctx = ctx
+        self.result = result
+        self.failures = failures or []
+        self.total_count = total_count if total_count is not None else len(self.failures)
+        self.overflow = overflow

--- a/torchlens/fastlog/options.py
+++ b/torchlens/fastlog/options.py
@@ -1,0 +1,193 @@
+"""Grouped options for fastlog predicate recording."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Final, Literal, Mapping, cast
+
+from .._deprecations import MISSING, MissingType
+from ..options import StreamingOptions
+from .types import CaptureSpec, RecordContext
+
+CaptureDecision = bool | CaptureSpec | None
+PredicateFn = Callable[[RecordContext], CaptureDecision]
+PredicateErrorMode = Literal["auto", "accumulate", "fail-fast"]
+
+_RECORDING_FIELDS: Final[tuple[str, ...]] = (
+    "keep_op",
+    "keep_module",
+    "default_op",
+    "default_module",
+    "history_size",
+    "include_source_events",
+    "max_predicate_failures",
+    "on_predicate_error",
+    "streaming",
+    "random_seed",
+)
+
+
+def _resolve_recording_option(
+    field_name: str,
+    supplied_value: Any,
+    default_value: Any,
+    specified_fields: set[str],
+) -> Any:
+    """Resolve an option field while tracking explicit caller presence."""
+
+    if supplied_value is MISSING:
+        return default_value
+    specified_fields.add(field_name)
+    return supplied_value
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class RecordingOptions:
+    """Grouped options for one fastlog predicate recording session."""
+
+    keep_op: PredicateFn | None = None
+    keep_module: PredicateFn | None = None
+    default_op: bool | CaptureSpec = False
+    default_module: bool | CaptureSpec = False
+    history_size: int = 8
+    include_source_events: bool = False
+    max_predicate_failures: int = 32
+    on_predicate_error: PredicateErrorMode = "auto"
+    streaming: StreamingOptions | None = None
+    random_seed: int | None = None
+    _specified_fields: frozenset[str] = field(
+        default_factory=frozenset,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __init__(
+        self,
+        keep_op: PredicateFn | None | MissingType = MISSING,
+        keep_module: PredicateFn | None | MissingType = MISSING,
+        default_op: bool | CaptureSpec | MissingType = MISSING,
+        default_module: bool | CaptureSpec | MissingType = MISSING,
+        history_size: int | MissingType = MISSING,
+        include_source_events: bool | MissingType = MISSING,
+        max_predicate_failures: int | MissingType = MISSING,
+        on_predicate_error: PredicateErrorMode | MissingType = MISSING,
+        streaming: StreamingOptions | None | MissingType = MISSING,
+        random_seed: int | None | MissingType = MISSING,
+    ) -> None:
+        """Initialize a frozen recording option bundle."""
+
+        specified_fields: set[str] = set()
+        values: dict[str, Any] = {
+            "keep_op": _resolve_recording_option("keep_op", keep_op, None, specified_fields),
+            "keep_module": _resolve_recording_option(
+                "keep_module", keep_module, None, specified_fields
+            ),
+            "default_op": _resolve_recording_option(
+                "default_op", default_op, False, specified_fields
+            ),
+            "default_module": _resolve_recording_option(
+                "default_module", default_module, False, specified_fields
+            ),
+            "history_size": _resolve_recording_option(
+                "history_size", history_size, 8, specified_fields
+            ),
+            "include_source_events": _resolve_recording_option(
+                "include_source_events", include_source_events, False, specified_fields
+            ),
+            "max_predicate_failures": _resolve_recording_option(
+                "max_predicate_failures", max_predicate_failures, 32, specified_fields
+            ),
+            "on_predicate_error": _resolve_recording_option(
+                "on_predicate_error", on_predicate_error, "auto", specified_fields
+            ),
+            "streaming": _resolve_recording_option("streaming", streaming, None, specified_fields),
+            "random_seed": _resolve_recording_option(
+                "random_seed", random_seed, None, specified_fields
+            ),
+        }
+        _validate_recording_values(values)
+        for field_name in _RECORDING_FIELDS:
+            object.__setattr__(self, field_name, values[field_name])
+        object.__setattr__(self, "_specified_fields", frozenset(specified_fields))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the option values as a plain dictionary."""
+
+        return {field_name: getattr(self, field_name) for field_name in _RECORDING_FIELDS}
+
+    def is_field_explicit(self, field_name: str) -> bool:
+        """Return whether a field was explicitly supplied by the caller."""
+
+        return field_name in self._specified_fields
+
+    @classmethod
+    def from_values(
+        cls,
+        values: Mapping[str, Any],
+        specified_fields: frozenset[str],
+    ) -> "RecordingOptions":
+        """Build an instance from already-resolved field values."""
+
+        _validate_recording_values(values)
+        instance = object.__new__(cls)
+        for field_name in _RECORDING_FIELDS:
+            object.__setattr__(instance, field_name, values[field_name])
+        object.__setattr__(instance, "_specified_fields", specified_fields)
+        return cast("RecordingOptions", instance)
+
+
+def _validate_recording_values(values: Mapping[str, Any]) -> None:
+    """Validate scalar recording option values."""
+
+    history_size = values["history_size"]
+    max_predicate_failures = values["max_predicate_failures"]
+    on_predicate_error = values["on_predicate_error"]
+    if not isinstance(history_size, int) or not 0 <= history_size <= 1024:
+        raise ValueError("history_size must be an integer in [0, 1024]")
+    if not isinstance(max_predicate_failures, int) or max_predicate_failures < 0:
+        raise ValueError("max_predicate_failures must be a non-negative integer")
+    if on_predicate_error not in {"auto", "accumulate", "fail-fast"}:
+        raise ValueError("on_predicate_error must be 'auto', 'accumulate', or 'fail-fast'")
+
+
+def merge_recording_options(
+    *,
+    recording: RecordingOptions | None,
+    keep_op: PredicateFn | None | MissingType = MISSING,
+    keep_module: PredicateFn | None | MissingType = MISSING,
+    default_op: bool | CaptureSpec | MissingType = MISSING,
+    default_module: bool | CaptureSpec | MissingType = MISSING,
+    history_size: int | MissingType = MISSING,
+    include_source_events: bool | MissingType = MISSING,
+    max_predicate_failures: int | MissingType = MISSING,
+    on_predicate_error: PredicateErrorMode | MissingType = MISSING,
+    streaming: StreamingOptions | None | MissingType = MISSING,
+    random_seed: int | None | MissingType = MISSING,
+) -> RecordingOptions:
+    """Merge flat recording kwargs into a grouped options object."""
+
+    base_values = recording.as_dict() if recording is not None else RecordingOptions().as_dict()
+    specified_fields = (
+        set(recording._specified_fields) if recording is not None else set()  # noqa: SLF001
+    )
+    incoming = {
+        "keep_op": keep_op,
+        "keep_module": keep_module,
+        "default_op": default_op,
+        "default_module": default_module,
+        "history_size": history_size,
+        "include_source_events": include_source_events,
+        "max_predicate_failures": max_predicate_failures,
+        "on_predicate_error": on_predicate_error,
+        "streaming": streaming,
+        "random_seed": random_seed,
+    }
+    for field_name, value in incoming.items():
+        if value is MISSING:
+            continue
+        if field_name in specified_fields:
+            raise ValueError(f"Recording option {field_name!r} was specified twice")
+        base_values[field_name] = value
+        specified_fields.add(field_name)
+    return RecordingOptions.from_values(base_values, frozenset(specified_fields))

--- a/torchlens/fastlog/recover.py
+++ b/torchlens/fastlog/recover.py
@@ -1,0 +1,230 @@
+"""Load and recover fastlog directory bundles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .._io import TorchLensIOError
+from .._io.manifest import Manifest, enforce_version_policy, sha256_of_file
+from .._io.paths import resolve_bundle_blob_path
+from .exceptions import BundleNotFinalizedError, RecoveryError
+from .storage_disk import record_from_json
+from .storage_ram import RamStorageBackend
+from .types import ActivationRecord, Recording
+
+
+def load(path: str | Path) -> Recording:
+    """Load a finalized fastlog bundle.
+
+    Parameters
+    ----------
+    path:
+        Fastlog bundle directory.
+
+    Returns
+    -------
+    Recording
+        Loaded recording with ``recovered=False``.
+
+    Raises
+    ------
+    BundleNotFinalizedError
+        If the bundle has no valid manifest.
+    TorchLensIOError
+        If the finalized bundle is malformed.
+    """
+
+    bundle_path = Path(path)
+    manifest_path = bundle_path / "manifest.json"
+    if not manifest_path.exists():
+        raise BundleNotFinalizedError("fastlog bundle is partial; use tl.fastlog.recover()")
+    try:
+        manifest = Manifest.read(manifest_path)
+    except TorchLensIOError as exc:
+        raise BundleNotFinalizedError(
+            "fastlog bundle manifest is invalid; use tl.fastlog.recover()"
+        ) from exc
+    _validate_fastlog_layout(bundle_path, manifest)
+    return _load_from_index(bundle_path, recovered=False, recovery_warnings=[])
+
+
+def recover(path: str | Path) -> Recording:
+    """Recover a finalized or partial fastlog bundle.
+
+    Parameters
+    ----------
+    path:
+        Fastlog bundle directory or streaming temp directory.
+
+    Returns
+    -------
+    Recording
+        Loaded or recovered recording.
+
+    Raises
+    ------
+    RecoveryError
+        If no recoverable index exists.
+    """
+
+    bundle_path = Path(path)
+    manifest_path = bundle_path / "manifest.json"
+    if manifest_path.exists():
+        try:
+            manifest = Manifest.read(manifest_path)
+            _validate_fastlog_layout(bundle_path, manifest)
+        except TorchLensIOError:
+            pass
+        else:
+            return _load_from_index(bundle_path, recovered=False, recovery_warnings=[])
+
+    index_path = bundle_path / "fastlog_index.jsonl"
+    if not index_path.exists():
+        raise RecoveryError("no recoverable index")
+    return _load_from_index(bundle_path, recovered=True, recovery_warnings=[])
+
+
+def _load_from_index(
+    bundle_path: Path,
+    *,
+    recovered: bool,
+    recovery_warnings: list[str],
+) -> Recording:
+    """Load records by scanning ``fastlog_index.jsonl``."""
+
+    metadata = _read_metadata(bundle_path / "metadata.json")
+    records: list[ActivationRecord] = []
+    warnings_out = list(recovery_warnings)
+    lines = _read_index_lines(bundle_path / "fastlog_index.jsonl")
+    for line_number, raw_line in enumerate(lines, start=1):
+        if raw_line == "" and line_number == len(lines):
+            warnings_out.append("truncated tail")
+            continue
+        try:
+            data = json.loads(raw_line)
+        except json.JSONDecodeError:
+            if line_number == len(lines):
+                warnings_out.append("truncated tail")
+            else:
+                warnings_out.append(f"malformed line {line_number}")
+            continue
+        if not isinstance(data, dict):
+            warnings_out.append(f"malformed line {line_number}")
+            continue
+        record = record_from_json(data)
+        if not _blob_is_recoverable(bundle_path, record, warnings_out):
+            continue
+        records.append(record)
+    recording = _recording_from_records(
+        records,
+        bundle_path=bundle_path,
+        metadata=metadata,
+        recovered=recovered,
+        recovery_warnings=warnings_out,
+    )
+    RamStorageBackend(recording).finalize()
+    return recording
+
+
+def _read_index_lines(path: Path) -> list[str]:
+    """Read index lines while preserving a missing trailing newline signal."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RecoveryError("no recoverable index") from exc
+    lines = text.splitlines()
+    if text and not text.endswith("\n"):
+        lines[-1] = ""
+    return lines
+
+
+def _blob_is_recoverable(
+    bundle_path: Path,
+    record: ActivationRecord,
+    recovery_warnings: list[str],
+) -> bool:
+    """Return whether a record's blob is present and hash-valid."""
+
+    blob_id = record.metadata.get("blob_id")
+    relative_path = record.metadata.get("relative_path")
+    expected_sha256 = record.metadata.get("sha256")
+    if blob_id is None or relative_path is None or expected_sha256 is None:
+        return True
+    try:
+        blob_path = resolve_bundle_blob_path(bundle_path, str(relative_path))
+    except TorchLensIOError:
+        recovery_warnings.append(f"malformed blob path {blob_id}")
+        return False
+    if not blob_path.exists():
+        recovery_warnings.append(f"missing blob {blob_id}")
+        return False
+    if sha256_of_file(blob_path) != expected_sha256:
+        recovery_warnings.append(f"hash mismatch {blob_id}")
+        return False
+    return True
+
+
+def _recording_from_records(
+    records: list[ActivationRecord],
+    *,
+    bundle_path: Path,
+    metadata: dict[str, Any],
+    recovered: bool,
+    recovery_warnings: list[str],
+) -> Recording:
+    """Build a Recording around loaded records."""
+
+    return Recording(
+        records=records,
+        by_pass={},
+        by_label={},
+        by_module_address={},
+        bundle_path=bundle_path,
+        n_passes=int(metadata.get("n_passes", 1)),
+        n_records=len(records),
+        pass_start_times=list(metadata.get("pass_start_times", [])),
+        pass_end_times=list(metadata.get("pass_end_times", [])),
+        predicate_failures=[],
+        predicate_failure_overflow_count=int(metadata.get("predicate_failure_overflow_count", 0)),
+        keep_op_repr=metadata.get("keep_op_repr"),
+        keep_module_repr=metadata.get("keep_module_repr"),
+        history_size=int(metadata.get("history_size", 0)),
+        recovered=recovered,
+        recovery_warnings=recovery_warnings,
+    )
+
+
+def _read_metadata(path: Path) -> dict[str, Any]:
+    """Read optional fastlog metadata JSON."""
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _validate_fastlog_layout(bundle_path: Path, manifest: Manifest) -> None:
+    """Validate the finalized fastlog directory layout."""
+
+    enforce_version_policy(manifest)
+    if manifest.bundle_format != "fastlog-directory":
+        raise TorchLensIOError("Expected fastlog-directory bundle format.")
+    required = (
+        "manifest.json",
+        "fastlog_index.jsonl",
+        "pass_index.json",
+        "label_index.json",
+        "metadata.json",
+        "blobs",
+    )
+    for name in required:
+        candidate = bundle_path / name
+        if not candidate.exists():
+            raise TorchLensIOError(f"Fastlog bundle is missing {name}.")
+    if not (bundle_path / "blobs").is_dir():
+        raise TorchLensIOError("Fastlog bundle blobs path is not a directory.")

--- a/torchlens/fastlog/storage_disk.py
+++ b/torchlens/fastlog/storage_disk.py
@@ -1,0 +1,357 @@
+"""Synchronous disk storage backend for fastlog recordings."""
+
+from __future__ import annotations
+
+import json
+import platform
+import sys
+import warnings
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .. import __version__ as TORCHLENS_VERSION
+from .._io import IO_FORMAT_VERSION, TorchLensIOError
+from .._io.manifest import Manifest, TensorEntry
+from .._io.streaming import BundleStreamWriter
+from ._indexes import write_label_index, write_pass_index
+from ._storage_resolver import _resolve_storage
+from .exceptions import PredicateError, RecordingConfigError
+from .options import RecordingOptions
+from .storage_ram import RamStorageBackend
+from .types import ActivationRecord, CaptureSpec, ModuleStackFrame, Recording, StorageIntent
+
+_GRAD_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.float64,
+    torch.complex64,
+    torch.complex128,
+}
+
+
+class DiskStorageBackend:
+    """Persist fastlog records to a sync directory bundle."""
+
+    def __init__(self, options: RecordingOptions, recording: Recording) -> None:
+        """Initialize a disk-backed fastlog storage backend.
+
+        Parameters
+        ----------
+        options:
+            Recording options for the active session.
+        recording:
+            Recording receiving retained records and indexes.
+
+        Raises
+        ------
+        RecordingConfigError
+            If static options request ``keep_grad=True`` in disk-only mode.
+        """
+
+        if options.streaming is None or options.streaming.bundle_path is None:
+            raise RecordingConfigError("DiskStorageBackend requires streaming.bundle_path")
+        self.options = options
+        self.recording = recording
+        self.disk_only = not options.streaming.retain_in_memory
+        self._validate_static_keep_grad()
+        self.writer = BundleStreamWriter(options.streaming.bundle_path)
+        self.index_path = self.writer.tmp_path / "fastlog_index.jsonl"
+        self._ram_backend = RamStorageBackend(recording)
+        self._tensor_entries: list[TensorEntry] = []
+        self._warned_device_move = False
+        self._finalized = False
+
+    def append(self, record: ActivationRecord) -> None:
+        """Append one record, writing its disk blob first when present.
+
+        Parameters
+        ----------
+        record:
+            Fastlog record selected by a predicate.
+
+        Raises
+        ------
+        PredicateError
+            If ``keep_grad=True`` is invalid for this storage mode or tensor.
+        """
+
+        self._validate_record_keep_grad(record)
+        stored_record = record
+        if record.disk_payload is not None:
+            blob_id = self.writer.next_blob_id()
+            entry = self.writer.write_blob(
+                blob_id,
+                record.disk_payload,
+                kind="activation",
+                label=record.ctx.label,
+            )
+            self._tensor_entries.append(entry)
+            stored_record.metadata.update(_entry_to_record_metadata(record, entry))
+            self._append_index_line(stored_record)
+        elif record.spec.save_metadata:
+            self._append_index_line(stored_record)
+        self._ram_backend.append(stored_record)
+
+    def resolve_payloads(
+        self,
+        tensor: torch.Tensor,
+        spec: CaptureSpec,
+        intent: StorageIntent,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Resolve tensor payloads for disk-backed capture.
+
+        Parameters
+        ----------
+        tensor:
+            Tensor selected for capture.
+        spec:
+            Capture policy for the selected tensor.
+        intent:
+            Storage intent resolved from streaming options.
+
+        Returns
+        -------
+        tuple[torch.Tensor | None, torch.Tensor | None]
+            RAM and disk payloads for the active storage mode.
+        """
+
+        return _resolve_storage(tensor, spec, intent)
+
+    def finalize(self) -> None:
+        """Finalize the fastlog directory bundle."""
+
+        if self._finalized:
+            return
+        self._ram_backend.finalize()
+        try:
+            write_pass_index(self.writer.tmp_path, self.recording)
+            write_label_index(self.writer.tmp_path, self.recording)
+            _write_metadata(self.writer.tmp_path / "metadata.json", self.recording, self.options)
+            manifest = _build_fastlog_manifest(self._tensor_entries)
+            manifest.write(self.writer.tmp_path / "manifest.json")
+            self.writer.tmp_path.rename(self.writer.final_path)
+        except (OSError, TorchLensIOError, ValueError) as exc:
+            self.abort(f"Failed to finalize fastlog bundle: {exc}")
+            raise
+        self.writer._closed = True
+        self.writer._finalized = True
+        self._finalized = True
+        object.__setattr__(self.recording, "bundle_path", self.writer.final_path)
+
+    def abort(self, reason: str) -> None:
+        """Abort the underlying streaming writer.
+
+        Parameters
+        ----------
+        reason:
+            Human-readable failure reason.
+        """
+
+        if not self._finalized:
+            self.writer.abort(reason)
+
+    def _validate_static_keep_grad(self) -> None:
+        """Reject static keep_grad defaults in disk-only mode."""
+
+        if not self.disk_only:
+            return
+        for name, default in (
+            ("default_op", self.options.default_op),
+            ("default_module", self.options.default_module),
+        ):
+            if isinstance(default, CaptureSpec) and default.keep_grad:
+                raise RecordingConfigError(
+                    f"{name} cannot use keep_grad=True with disk-only fastlog storage"
+                )
+
+    def _validate_record_keep_grad(self, record: ActivationRecord) -> None:
+        """Validate keep_grad constraints before persisting one record."""
+
+        if not record.spec.keep_grad:
+            return
+        if self.disk_only:
+            raise PredicateError("keep_grad=True is not valid for disk-only fastlog storage")
+        dtype = record.ctx.tensor_dtype
+        if dtype is not None and dtype not in _GRAD_DTYPES:
+            raise PredicateError("keep_grad=True is not valid for integer or bool tensors")
+        if (
+            record.spec.device is not None
+            and record.ctx.tensor_device is not None
+            and torch.device(record.spec.device) != record.ctx.tensor_device
+            and not self._warned_device_move
+        ):
+            warnings.warn(
+                "fastlog keep_grad=True with a device move may make autograd expensive.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self._warned_device_move = True
+
+    def _append_index_line(self, record: ActivationRecord) -> None:
+        """Append one JSONL metadata line for a retained record."""
+
+        line = json.dumps(record_to_json(record), sort_keys=True)
+        try:
+            with self.index_path.open("a", encoding="utf-8") as handle:
+                handle.write(line)
+                handle.write("\n")
+        except OSError as exc:
+            self.abort(f"Failed to append fastlog index: {exc}")
+            raise TorchLensIOError(f"Failed to append fastlog index at {self.index_path}.") from exc
+
+
+def record_to_json(record: ActivationRecord) -> dict[str, Any]:
+    """Convert one activation record into JSON-serializable metadata."""
+
+    return {
+        "ctx": _ctx_to_json(record.ctx),
+        "spec": _spec_to_json(record.spec),
+        "metadata": dict(record.metadata),
+        "recorded_at": record.recorded_at,
+    }
+
+
+def record_from_json(data: dict[str, Any]) -> ActivationRecord:
+    """Build an activation record from JSON-decoded fastlog metadata."""
+
+    ctx = _ctx_from_json(data["ctx"])
+    spec = _spec_from_json(data["spec"])
+    metadata = data.get("metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+    return ActivationRecord(
+        ctx=ctx,
+        spec=spec,
+        metadata=metadata,
+        recorded_at=float(data.get("recorded_at", 0.0)),
+    )
+
+
+def _entry_to_record_metadata(record: ActivationRecord, entry: TensorEntry) -> dict[str, Any]:
+    """Return persisted blob metadata for one record."""
+
+    metadata = entry.to_dict()
+    metadata["shape"] = (
+        entry.shape if record.ctx.tensor_shape is None else list(record.ctx.tensor_shape)
+    )
+    return metadata
+
+
+def _ctx_to_json(ctx: Any) -> dict[str, Any]:
+    """Convert a RecordContext into JSON data without recursive history."""
+
+    data = asdict(ctx)
+    data["module_stack"] = [asdict(frame) for frame in ctx.module_stack]
+    data["recent_events"] = []
+    data["recent_ops"] = []
+    data["tensor_dtype"] = _dtype_to_name(ctx.tensor_dtype)
+    data["tensor_device"] = None if ctx.tensor_device is None else str(ctx.tensor_device)
+    return data
+
+
+def _ctx_from_json(data: dict[str, Any]) -> Any:
+    """Convert JSON data into a RecordContext."""
+
+    from .types import RecordContext
+
+    values = dict(data)
+    values["module_stack"] = tuple(ModuleStackFrame(**frame) for frame in values["module_stack"])
+    values["recent_events"] = ()
+    values["recent_ops"] = ()
+    values["parent_labels"] = tuple(values.get("parent_labels", ()))
+    values["tensor_shape"] = (
+        None if values.get("tensor_shape") is None else tuple(values["tensor_shape"])
+    )
+    values["tensor_dtype"] = _dtype_from_name(values.get("tensor_dtype"))
+    values["tensor_device"] = (
+        None if values.get("tensor_device") is None else torch.device(values["tensor_device"])
+    )
+    return RecordContext(**values)
+
+
+def _spec_to_json(spec: CaptureSpec) -> dict[str, Any]:
+    """Convert a CaptureSpec into JSON data."""
+
+    return {
+        "save_activation": spec.save_activation,
+        "save_metadata": spec.save_metadata,
+        "keep_grad": spec.keep_grad,
+        "device": None if spec.device is None else str(spec.device),
+        "dtype": _dtype_to_name(spec.dtype),
+    }
+
+
+def _spec_from_json(data: dict[str, Any]) -> CaptureSpec:
+    """Build a CaptureSpec from JSON data."""
+
+    return CaptureSpec(
+        save_activation=bool(data.get("save_activation", True)),
+        save_metadata=bool(data.get("save_metadata", True)),
+        keep_grad=bool(data.get("keep_grad", False)),
+        device=data.get("device"),
+        dtype=_dtype_from_name(data.get("dtype")),
+    )
+
+
+def _dtype_to_name(dtype: torch.dtype | None) -> str | None:
+    """Return a portable dtype name."""
+
+    if dtype is None:
+        return None
+    return str(dtype).replace("torch.", "")
+
+
+def _dtype_from_name(name: str | None) -> torch.dtype | None:
+    """Resolve a portable dtype name to a torch dtype."""
+
+    if name is None:
+        return None
+    return getattr(torch, name)
+
+
+def _write_metadata(path: Path, recording: Recording, options: RecordingOptions) -> None:
+    """Write fastlog JSON metadata."""
+
+    metadata = {
+        "n_passes": recording.n_passes,
+        "n_records": len(recording.records),
+        "pass_start_times": recording.pass_start_times,
+        "pass_end_times": recording.pass_end_times,
+        "predicate_failure_overflow_count": recording.predicate_failure_overflow_count,
+        "keep_op_repr": recording.keep_op_repr,
+        "keep_module_repr": recording.keep_module_repr,
+        "history_size": options.history_size,
+    }
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(metadata, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _build_fastlog_manifest(tensor_entries: list[TensorEntry]) -> Manifest:
+    """Build a manifest for a finalized fastlog directory bundle."""
+
+    return Manifest(
+        io_format_version=IO_FORMAT_VERSION,
+        torchlens_version=TORCHLENS_VERSION,
+        torch_version=torch.__version__,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        platform=f"{platform.system().lower()}-{platform.machine().lower()}",
+        created_at=datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        bundle_format="fastlog-directory",
+        n_layers=0,
+        n_activation_blobs=sum(1 for entry in tensor_entries if entry.kind == "activation"),
+        n_gradient_blobs=sum(1 for entry in tensor_entries if entry.kind == "gradient"),
+        n_auxiliary_blobs=sum(
+            1 for entry in tensor_entries if entry.kind not in {"activation", "gradient"}
+        ),
+        tensors=tensor_entries,
+        unsupported_tensors=[],
+    )

--- a/torchlens/fastlog/storage_disk.py
+++ b/torchlens/fastlog/storage_disk.py
@@ -182,11 +182,11 @@ class DiskStorageBackend:
         if (
             record.spec.device is not None
             and record.ctx.tensor_device is not None
-            and torch.device(record.spec.device) != record.ctx.tensor_device
             and not self._warned_device_move
         ):
             warnings.warn(
-                "fastlog keep_grad=True with a device move may make autograd expensive.",
+                "fastlog keep_grad=True with an explicit device target may make autograd "
+                "expensive.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/torchlens/fastlog/storage_ram.py
+++ b/torchlens/fastlog/storage_ram.py
@@ -1,0 +1,101 @@
+"""In-memory storage backend for fastlog recordings."""
+
+from __future__ import annotations
+
+import torch
+
+from ._storage_resolver import _resolve_storage
+from .types import ActivationRecord, CaptureSpec, Recording, StorageIntent
+
+
+class RamStorageBackend:
+    """Append fastlog records to an in-memory recording."""
+
+    def __init__(self, recording: Recording) -> None:
+        """Initialize the RAM backend.
+
+        Parameters
+        ----------
+        recording:
+            Recording instance that receives retained records.
+        """
+
+        self.recording = recording
+
+    def resolve_payloads(
+        self,
+        tensor: torch.Tensor,
+        spec: CaptureSpec,
+        intent: StorageIntent,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Resolve tensor payloads for in-memory capture.
+
+        Parameters
+        ----------
+        tensor:
+            Tensor selected for capture.
+        spec:
+            Capture policy for the selected tensor.
+        intent:
+            Storage intent resolved from streaming options.
+
+        Returns
+        -------
+        tuple[torch.Tensor | None, torch.Tensor | None]
+            RAM and disk payloads. RAM-only mode returns no disk payload.
+        """
+
+        return _resolve_storage(tensor, spec, intent)
+
+    def append(self, record: ActivationRecord) -> None:
+        """Append one retained record and update recording indexes.
+
+        Parameters
+        ----------
+        record:
+            Fastlog activation record to retain.
+        """
+
+        index = len(self.recording.records)
+        self.recording.records.append(record)
+        self.recording.by_pass.setdefault(record.ctx.pass_index, []).append(index)
+        self.recording.by_label.setdefault(record.ctx.label, []).append(
+            (record.ctx.pass_index, index)
+        )
+        if record.ctx.raw_label is not None:
+            self.recording.by_label.setdefault(record.ctx.raw_label, []).append(
+                (record.ctx.pass_index, index)
+            )
+        if record.ctx.module_address is not None:
+            self.recording.by_module_address.setdefault(record.ctx.module_address, []).append(index)
+
+    def finalize(self) -> None:
+        """Finalize RAM indexes after a pass."""
+
+        self.recording.by_pass.clear()
+        self.recording.by_label.clear()
+        self.recording.by_module_address.clear()
+        for index, record in enumerate(self.recording.records):
+            self.recording.by_pass.setdefault(record.ctx.pass_index, []).append(index)
+            self.recording.by_label.setdefault(record.ctx.label, []).append(
+                (record.ctx.pass_index, index)
+            )
+            if record.ctx.raw_label is not None:
+                self.recording.by_label.setdefault(record.ctx.raw_label, []).append(
+                    (record.ctx.pass_index, index)
+                )
+            if record.ctx.module_address is not None:
+                self.recording.by_module_address.setdefault(record.ctx.module_address, []).append(
+                    index
+                )
+
+    def abort(self, reason: str) -> None:
+        """Ignore abort requests for RAM-only recordings.
+
+        Parameters
+        ----------
+        reason:
+            Human-readable abort reason.
+        """
+
+        _ = reason

--- a/torchlens/fastlog/types.py
+++ b/torchlens/fastlog/types.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 import torch
 
@@ -36,6 +36,9 @@ class CaptureSpec:
     keep_grad: bool = False
     device: torch.device | str | None = None
     dtype: torch.dtype | None = None
+
+
+CaptureDecision = bool | CaptureSpec | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,6 +90,24 @@ class RecordContext:
     time_since_pass_start: float
     sample_id: str | int | None = None
 
+    def __getattr__(self, name: str) -> Any:
+        """Raise a schema-specific error for unknown predicate fields.
+
+        Parameters
+        ----------
+        name:
+            Missing attribute name.
+
+        Raises
+        ------
+        RecordContextFieldError
+            Always raised for missing fields.
+        """
+
+        from .exceptions import RecordContextFieldError
+
+        raise RecordContextFieldError(name)
+
 
 @dataclass(frozen=True, slots=True)
 class ActivationRecord:
@@ -115,6 +136,7 @@ class RecordingTrace:
     """Predicate dry-run trace without retained tensor payloads."""
 
     contexts: tuple[RecordContext, ...]
+    decisions: tuple[bool, ...] = ()
     predicate_failures: tuple[PredicateFailure, ...] = ()
 
     @property
@@ -122,6 +144,77 @@ class RecordingTrace:
         """Return chronological dry-run events."""
 
         return self.contexts
+
+    def print_tree(self) -> str:
+        """Return a unicode-indented event tree for this trace."""
+
+        from ..visualization.fastlog_live import print_tree
+
+        return print_tree(self)
+
+    def to_pandas(self) -> Any:
+        """Return a pandas DataFrame representation of trace events."""
+
+        from ..visualization.fastlog_live import to_pandas
+
+        return to_pandas(self)
+
+    def show_graph(self, **kwargs: Any) -> str:
+        """Render a flat Graphviz graph of trace operation events."""
+
+        from ..visualization.fastlog_live import show_graph
+
+        return show_graph(self, **kwargs)
+
+    def summary(self) -> str:
+        """Return a concise human-readable dry-run summary."""
+
+        from ..visualization.fastlog_live import summary
+
+        return summary(self)
+
+    def timeline_html(self) -> Any:
+        """Return an IPython HTML timeline for this trace."""
+
+        from ..visualization.fastlog_live import timeline_html
+
+        return timeline_html(self)
+
+    def repredicate(
+        self,
+        other_keep_op: Callable[[RecordContext], CaptureDecision] | None = None,
+        other_keep_module: Callable[[RecordContext], CaptureDecision] | None = None,
+    ) -> "RecordingTrace":
+        """Return a new trace with decisions from new predicates.
+
+        Parameters
+        ----------
+        other_keep_op:
+            Predicate for op, input, and buffer events.
+        other_keep_module:
+            Predicate for module entry and exit events.
+
+        Returns
+        -------
+        RecordingTrace
+            New trace sharing the same event tuple and predicate failures.
+        """
+
+        from ._predicate import _normalize_capture_decision
+
+        decisions: list[bool] = []
+        for ctx in self.contexts:
+            predicate = (
+                other_keep_module if ctx.kind in {"module_enter", "module_exit"} else other_keep_op
+            )
+            result = predicate(ctx) if predicate is not None else False
+            spec = _normalize_capture_decision(result, ctx, False)
+            decisions.append(spec.save_activation or spec.save_metadata)
+        return RecordingTrace(
+            contexts=self.contexts,
+            decisions=tuple(decisions),
+            predicate_failures=self.predicate_failures,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,9 +285,21 @@ class Recording:
 
         return f"Recording(n_passes={self.n_passes}, n_records={len(self.records)})"
 
-    def enrich(self, steps: list[str]) -> "Recording":
-        """Return this recording after validating enrichment step names."""
+    def enrich(self, steps: list[str] | str) -> "Recording":
+        """Return a new recording with requested incremental enrichments.
 
-        if steps:
-            raise NotImplementedError("fastlog enrichment is implemented in a later step")
-        return self
+        Parameters
+        ----------
+        steps:
+            Enrichment names, or ``"all-feasible"`` for all currently computable
+            enrichments.
+
+        Returns
+        -------
+        Recording
+            New immutable recording value with enriched records.
+        """
+
+        from ..postprocess.incremental import enrich_recording
+
+        return enrich_recording(self, steps)

--- a/torchlens/fastlog/types.py
+++ b/torchlens/fastlog/types.py
@@ -118,7 +118,7 @@ class RecordingTrace:
     predicate_failures: tuple[PredicateFailure, ...] = ()
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class Recording:
     """Result of a fastlog recording session."""
 

--- a/torchlens/fastlog/types.py
+++ b/torchlens/fastlog/types.py
@@ -117,6 +117,12 @@ class RecordingTrace:
     contexts: tuple[RecordContext, ...]
     predicate_failures: tuple[PredicateFailure, ...] = ()
 
+    @property
+    def events(self) -> tuple[RecordContext, ...]:
+        """Return chronological dry-run events."""
+
+        return self.contexts
+
 
 @dataclass(frozen=True, slots=True)
 class Recording:

--- a/torchlens/fastlog/types.py
+++ b/torchlens/fastlog/types.py
@@ -1,0 +1,194 @@
+"""Core dataclasses for fastlog predicate recording."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+
+EventKind = Literal["op", "module_enter", "module_exit", "input", "buffer"]
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureSpec:
+    """Capture policy returned by predicate callbacks.
+
+    Parameters
+    ----------
+    save_activation:
+        Whether tensor payloads should be retained for this event.
+    save_metadata:
+        Whether non-payload metadata should be retained for this event.
+    keep_grad:
+        Whether the in-RAM tensor clone should stay attached to autograd.
+    device:
+        Optional target device for retained payloads.
+    dtype:
+        Optional target dtype for retained payloads.
+    """
+
+    save_activation: bool = True
+    save_metadata: bool = True
+    keep_grad: bool = False
+    device: torch.device | str | None = None
+    dtype: torch.dtype | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorageIntent:
+    """Resolved storage destinations for a capture decision."""
+
+    in_ram: bool
+    on_disk: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleStackFrame:
+    """One frame in the active module stack."""
+
+    module_address: str
+    module_type: str
+    module_id: int
+    pass_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecordContext:
+    """Predicate input schema for one chronological fastlog event."""
+
+    kind: EventKind
+    label: str
+    raw_label: str | None
+    pass_index: int
+    event_index: int
+    op_index: int | None
+    layer_type: str | None
+    layer_type_num: int | None
+    creation_order: int | None
+    func_name: str | None
+    module_address: str | None
+    module_type: str | None
+    module_pass_index: int | None
+    module_stack: tuple[ModuleStackFrame, ...]
+    recent_events: tuple["RecordContext", ...]
+    recent_ops: tuple["RecordContext", ...]
+    parent_labels: tuple[str, ...]
+    input_output_address: str | None
+    tensor_shape: tuple[int, ...] | None
+    tensor_dtype: torch.dtype | None
+    tensor_device: torch.device | None
+    tensor_requires_grad: bool | None
+    output_index: int | None
+    is_bottom_level_func: bool | None
+    time_since_pass_start: float
+    sample_id: str | int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ActivationRecord:
+    """One retained fastlog event."""
+
+    ctx: RecordContext
+    spec: CaptureSpec
+    ram_payload: torch.Tensor | None = None
+    disk_payload: torch.Tensor | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    recorded_at: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True, slots=True)
+class PredicateFailure:
+    """One captured predicate exception."""
+
+    event_index: int
+    kind: EventKind
+    label: str
+    traceback: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecordingTrace:
+    """Predicate dry-run trace without retained tensor payloads."""
+
+    contexts: tuple[RecordContext, ...]
+    predicate_failures: tuple[PredicateFailure, ...] = ()
+
+
+@dataclass(slots=True)
+class Recording:
+    """Result of a fastlog recording session."""
+
+    records: list[ActivationRecord]
+    by_pass: dict[int, list[int]]
+    by_label: dict[str, list[tuple[int, int]]]
+    by_module_address: dict[str, list[int]]
+    bundle_path: Path | None
+    n_passes: int
+    n_records: int
+    pass_start_times: list[float]
+    pass_end_times: list[float]
+    predicate_failures: list[PredicateFailure]
+    predicate_failure_overflow_count: int
+    keep_op_repr: str | None
+    keep_module_repr: str | None
+    history_size: int
+    recovered: bool = False
+    recovery_warnings: list[str] = field(default_factory=list)
+
+    def __getitem__(self, key: int | str) -> ActivationRecord | list[ActivationRecord]:
+        """Return records by integer index or raw/final label."""
+
+        if isinstance(key, int):
+            return self.records[key]
+        indexes = self.by_label[key]
+        return [self.records[index] for _, index in indexes]
+
+    def __iter__(self) -> Iterator[ActivationRecord]:
+        """Iterate over retained activation records."""
+
+        return iter(self.records)
+
+    def __len__(self) -> int:
+        """Return the number of retained records."""
+
+        return len(self.records)
+
+    def iter_pass(self, pass_num: int) -> Iterator[ActivationRecord]:
+        """Iterate over records retained for one pass."""
+
+        for index in self.by_pass.get(pass_num, []):
+            yield self.records[index]
+
+    def to_pandas(self) -> Any:
+        """Return a pandas DataFrame representation of retained records."""
+
+        import pandas as pd
+
+        rows = [
+            {
+                "kind": record.ctx.kind,
+                "label": record.ctx.label,
+                "pass_index": record.ctx.pass_index,
+                "event_index": record.ctx.event_index,
+                "save_activation": record.spec.save_activation,
+                "save_metadata": record.spec.save_metadata,
+            }
+            for record in self.records
+        ]
+        return pd.DataFrame(rows)
+
+    def summary(self) -> str:
+        """Return a concise human-readable recording summary."""
+
+        return f"Recording(n_passes={self.n_passes}, n_records={len(self.records)})"
+
+    def enrich(self, steps: list[str]) -> "Recording":
+        """Return this recording after validating enrichment step names."""
+
+        if steps:
+            raise NotImplementedError("fastlog enrichment is implemented in a later step")
+        return self

--- a/torchlens/postprocess/graph_traversal.py
+++ b/torchlens/postprocess/graph_traversal.py
@@ -65,7 +65,9 @@ def _add_output_layers(
         new_output_node.func_applied = identity
         new_output_node.func_name = "none"
         new_output_node.func_call_stack = _get_func_call_stack(
-            self.num_context_lines, source_loading_enabled=self.save_source_context
+            self.num_context_lines,
+            source_loading_enabled=self.save_source_context,
+            disable_col_offset=False,
         )
         new_output_node.func_time = 0
         new_output_node.func_rng_states = (

--- a/torchlens/postprocess/incremental.py
+++ b/torchlens/postprocess/incremental.py
@@ -1,0 +1,129 @@
+"""Opt-in incremental enrichments for fastlog recordings."""
+
+from __future__ import annotations
+
+from dataclasses import fields, replace
+from typing import Literal, cast
+
+from ..fastlog.exceptions import RecordingConfigError
+from ..fastlog.types import ActivationRecord, Recording
+
+EnrichmentStep = Literal["module_path_strings", "param_addresses"]
+_ALL_FEASIBLE: tuple[EnrichmentStep, ...] = ("module_path_strings",)
+_ALL_STEPS: set[str] = {"module_path_strings", "param_addresses"}
+
+
+def _copy_record_with_metadata(
+    record: ActivationRecord, metadata: dict[str, object]
+) -> ActivationRecord:
+    """Return a copy of an activation record with merged metadata."""
+
+    merged_metadata = dict(record.metadata)
+    merged_metadata.update(metadata)
+    return replace(record, metadata=merged_metadata)
+
+
+def _replace_recording_records(recording: Recording, records: list[ActivationRecord]) -> Recording:
+    """Return a recording copy with a new records list and count."""
+
+    return replace(recording, records=records, n_records=len(records))
+
+
+def add_module_path_strings(recording: Recording) -> Recording:
+    """Annotate records with module address strings from their captured stack.
+
+    Parameters
+    ----------
+    recording:
+        Source fastlog recording.
+
+    Returns
+    -------
+    Recording
+        New recording whose records include ``metadata["module_path_strings"]`` and
+        ``metadata["module_path"]``.
+    """
+
+    records = []
+    for record in recording.records:
+        module_path_strings = tuple(frame.module_address for frame in record.ctx.module_stack)
+        module_path = ".".join(address for address in module_path_strings if address)
+        records.append(
+            _copy_record_with_metadata(
+                record,
+                {
+                    "module_path_strings": module_path_strings,
+                    "module_path": module_path,
+                },
+            )
+        )
+    return _replace_recording_records(recording, records)
+
+
+def _activation_record_has_param_addresses() -> bool:
+    """Return whether capture-time param-address data exists on ActivationRecord."""
+
+    return any(field.name == "parent_param_addresses" for field in fields(ActivationRecord))
+
+
+def add_param_addresses(recording: Recording) -> Recording:
+    """Attach captured parent parameter addresses to record metadata.
+
+    Parameters
+    ----------
+    recording:
+        Source fastlog recording.
+
+    Returns
+    -------
+    Recording
+        New recording with ``metadata["parent_param_addresses"]`` populated.
+
+    Raises
+    ------
+    RecordingConfigError
+        If this build did not capture ``ActivationRecord.parent_param_addresses``.
+    """
+
+    if not _activation_record_has_param_addresses():
+        raise RecordingConfigError(
+            "param_addresses enrichment requires capture-time "
+            "ActivationRecord.parent_param_addresses data, which is not available"
+        )
+    records = []
+    for record in recording.records:
+        addresses = getattr(record, "parent_param_addresses")
+        records.append(
+            _copy_record_with_metadata(record, {"parent_param_addresses": tuple(addresses or ())})
+        )
+    return _replace_recording_records(recording, records)
+
+
+def _normalize_steps(steps: list[str] | str) -> tuple[EnrichmentStep, ...]:
+    """Normalize public enrichment step input."""
+
+    if steps == "all-feasible":
+        return _ALL_FEASIBLE
+    if isinstance(steps, str):
+        requested: tuple[str, ...] = (steps,)
+    else:
+        requested = tuple(steps)
+    unknown = sorted(set(requested) - _ALL_STEPS)
+    if unknown:
+        raise RecordingConfigError(
+            "Recording.enrich steps must be 'module_path_strings', "
+            "'param_addresses', or 'all-feasible'"
+        )
+    return tuple(cast("EnrichmentStep", step) for step in requested)
+
+
+def enrich_recording(recording: Recording, steps: list[str] | str) -> Recording:
+    """Apply requested incremental enrichments to a recording."""
+
+    enriched = recording
+    for step in _normalize_steps(steps):
+        if step == "module_path_strings":
+            enriched = add_module_path_strings(enriched)
+        elif step == "param_addresses":
+            enriched = add_param_addresses(enriched)
+    return enriched

--- a/torchlens/utils/introspection.py
+++ b/torchlens/utils/introspection.py
@@ -24,6 +24,44 @@ from torch import nn
 _ATTR_SKIP_SET = frozenset({"T", "mT", "real", "imag", "H"})
 
 
+def _get_code_qualname(frame: FrameType) -> Optional[str]:
+    """Return ``co_qualname`` when available on this Python version.
+
+    Args:
+        frame: Stack frame whose code object should be inspected.
+
+    Returns:
+        Qualified code object name, or None when unavailable.
+    """
+    if sys.version_info < (3, 11):
+        return None
+    return getattr(frame.f_code, "co_qualname", None)
+
+
+def _get_col_offset(frame: FrameType) -> Optional[int]:
+    """Return the current instruction's column offset when available.
+
+    Args:
+        frame: Stack frame whose current bytecode instruction should be inspected.
+
+    Returns:
+        Column offset for the current instruction, or None when unavailable.
+    """
+    if sys.version_info < (3, 11):
+        return None
+    try:
+        for instruction in dis.get_instructions(frame.f_code):
+            if instruction.offset != frame.f_lasti:
+                continue
+            positions = instruction.positions
+            if positions is None:
+                return None
+            return positions.col_offset
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
 def get_vars_of_type_from_obj(
     obj: Any,
     which_type: Type,
@@ -373,7 +411,11 @@ def remove_attributes_with_prefix(obj: Any, prefix: str) -> None:
             delattr(obj, field)
 
 
-def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: bool = True) -> List:
+def _get_func_call_stack(
+    num_context_lines: int = 7,
+    source_loading_enabled: bool = True,
+    disable_col_offset: bool = False,
+) -> List:
     """Build a list of FuncCallLocation objects for the current call stack.
 
     Filters out torchlens internals and ``_call_impl`` frames, keeping only
@@ -390,6 +432,8 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
             ``2 * num_context_lines + 1``.
         source_loading_enabled: Whether each ``FuncCallLocation`` should
             lazily load source text and function metadata on demand.
+        disable_col_offset: If True, skip bytecode inspection for column
+            offsets and store None for ``col_offset``.
 
     Returns:
         List[FuncCallLocation] ordered shallow-to-deep.
@@ -405,30 +449,8 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
     def _is_torchlens_internal(filename: str) -> bool:
         return filename.startswith(_TORCHLENS_PKG_DIR)
 
-    def _get_code_qualname(frame: FrameType) -> Optional[str]:
-        """Return ``co_qualname`` when available on this Python version."""
-        if sys.version_info < (3, 11):
-            return None
-        return getattr(frame.f_code, "co_qualname", None)
-
-    def _get_col_offset(frame: FrameType) -> Optional[int]:
-        """Return the current instruction's column offset when available."""
-        if sys.version_info < (3, 11):
-            return None
-        try:
-            for instruction in dis.get_instructions(frame.f_code):
-                if instruction.offset != frame.f_lasti:
-                    continue
-                positions = instruction.positions
-                if positions is None:
-                    return None
-                return positions.col_offset
-        except (TypeError, ValueError):
-            return None
-        return None
-
     # Phase 1: Collect lightweight frame data — only co_filename, co_name, f_lineno.
-    # Do NOT do f_locals/f_globals dict lookups yet (expensive, ~50/call).
+    # Do NOT do f_locals/f_globals dict lookups or bytecode walks yet.
     raw_frames = []
     frame = sys._getframe(0)
     while frame is not None:
@@ -438,8 +460,6 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
                 frame.f_code.co_name,
                 frame.f_lineno,
                 frame.f_code.co_firstlineno,
-                _get_code_qualname(frame),
-                _get_col_offset(frame),
                 frame,  # keep reference for phase 2 func_obj lookup
             )
         )
@@ -454,7 +474,7 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
     filtered_indices = []
 
     for idx in range(len(raw_frames) - 1, -1, -1):
-        filename, func_name, lineno, _, _, _, frame_ref = raw_frames[idx]
+        filename, func_name, lineno, _, frame_ref = raw_frames[idx]
 
         # Skip torchlens internals and PyTorch _call_impl
         if _is_torchlens_internal(filename):
@@ -466,7 +486,7 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
             tracking = True
             # Look for the user-script frame that called log_forward_pass
             for j in range(idx + 1, len(raw_frames)):
-                j_filename, j_func_name, _, _, _, _, _ = raw_frames[j]
+                j_filename, j_func_name, _, _, _ = raw_frames[j]
                 if not _is_torchlens_internal(j_filename) and "_call_impl" not in j_func_name:
                     pre_forward_frame_idx = j
                     break
@@ -479,12 +499,10 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
         filtered_indices.append(pre_forward_frame_idx)
 
     # Phase 2: Build FuncCallLocation objects only for surviving frames (~5-10).
-    # Do the expensive f_locals/f_globals dict lookup only here.
+    # Do expensive f_locals/f_globals lookups and bytecode walks only here.
     result = []
     for idx in filtered_indices:
-        filename, func_name, lineno, code_firstlineno, code_qualname, col_offset, frame_ref = (
-            raw_frames[idx]
-        )
+        filename, func_name, lineno, code_firstlineno, frame_ref = raw_frames[idx]
         loc = FuncCallLocation(
             file=filename,
             line_number=lineno,
@@ -496,8 +514,8 @@ def _get_func_call_stack(num_context_lines: int = 7, source_loading_enabled: boo
                 else None
             ),
             code_firstlineno=code_firstlineno,
-            code_qualname=code_qualname,
-            col_offset=col_offset,
+            code_qualname=_get_code_qualname(frame_ref),
+            col_offset=None if disable_col_offset else _get_col_offset(frame_ref),
             source_loading_enabled=source_loading_enabled,
         )
         result.append(loc)

--- a/torchlens/visualization/fastlog_live.py
+++ b/torchlens/visualization/fastlog_live.py
@@ -1,0 +1,241 @@
+"""Live visualization helpers for fastlog dry-run traces."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from html import escape
+from typing import Any
+
+import graphviz
+
+from ..fastlog.types import RecordContext, RecordingTrace
+
+_RAIL_COLORS = (
+    "#4E79A7",
+    "#F28E2B",
+    "#E15759",
+    "#76B7B2",
+    "#59A14F",
+    "#EDC948",
+    "#B07AA1",
+    "#FF9DA7",
+)
+
+
+def _shape_text(ctx: RecordContext) -> str:
+    """Return a compact tensor shape string."""
+
+    if ctx.tensor_shape is None:
+        return ""
+    return "x".join(str(dim) for dim in ctx.tensor_shape)
+
+
+def _dtype_text(ctx: RecordContext) -> str:
+    """Return a compact dtype string."""
+
+    if ctx.tensor_dtype is None:
+        return ""
+    return str(ctx.tensor_dtype).replace("torch.", "")
+
+
+def _event_kept(trace: RecordingTrace, index: int) -> bool:
+    """Return whether a trace event was selected by the predicate."""
+
+    if index >= len(trace.decisions):
+        return False
+    return trace.decisions[index]
+
+
+def _module_key(ctx: RecordContext) -> str:
+    """Return the best module grouping key for an event."""
+
+    if ctx.module_address:
+        return ctx.module_address
+    if ctx.module_stack:
+        return ctx.module_stack[-1].module_address
+    return "self"
+
+
+def _module_color(module_address: str, color_map: dict[str, str]) -> str:
+    """Return a stable rail color for a module address."""
+
+    if module_address not in color_map:
+        color_map[module_address] = _RAIL_COLORS[len(color_map) % len(_RAIL_COLORS)]
+    return color_map[module_address]
+
+
+def print_tree(trace: RecordingTrace) -> str:
+    """Return a unicode-indented tree of dry-run events.
+
+    Parameters
+    ----------
+    trace:
+        Dry-run trace to render.
+
+    Returns
+    -------
+    str
+        One row per event, indented by module stack depth.
+    """
+
+    rows: list[str] = []
+    for index, ctx in enumerate(trace.events):
+        depth = len(ctx.module_stack)
+        prefix = "  " * max(depth - 1, 0) + ("└─ " if depth else "")
+        kept = "kept" if _event_kept(trace, index) else "skip"
+        module = _module_key(ctx)
+        op_type = ctx.layer_type or ctx.func_name or ctx.kind
+        rows.append(f"{prefix}{ctx.event_index:04d} {ctx.kind} {op_type} [{module}] {kept}")
+    return "\n".join(rows)
+
+
+def to_pandas(trace: RecordingTrace) -> Any:
+    """Return a pandas DataFrame with one row per trace event."""
+
+    import pandas as pd
+
+    rows = [
+        {
+            "pass_num": ctx.pass_index,
+            "step_num": ctx.event_index,
+            "kind": ctx.kind,
+            "op_type": ctx.layer_type or ctx.func_name,
+            "module_address": _module_key(ctx),
+            "shape": ctx.tensor_shape,
+            "dtype": ctx.tensor_dtype,
+        }
+        for ctx in trace.events
+    ]
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "pass_num",
+            "step_num",
+            "kind",
+            "op_type",
+            "module_address",
+            "shape",
+            "dtype",
+        ],
+    )
+
+
+def _graph_label(ctx: RecordContext, kept: bool, rail_color: str) -> str:
+    """Return a Graphviz HTML-like label with a module rail cell."""
+
+    op_type = escape(str(ctx.layer_type or ctx.func_name or ctx.kind))
+    shape = escape(_shape_text(ctx))
+    dtype = escape(_dtype_text(ctx))
+    status = "kept" if kept else "skip"
+    return (
+        '<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">'
+        f'<TR><TD BGCOLOR="{rail_color}" WIDTH="8"> </TD>'
+        f'<TD ALIGN="LEFT">{op_type}</TD></TR>'
+        f'<TR><TD BGCOLOR="{rail_color}" WIDTH="8"> </TD>'
+        f'<TD ALIGN="LEFT">{shape} {dtype}</TD></TR>'
+        f'<TR><TD BGCOLOR="{rail_color}" WIDTH="8"> </TD>'
+        f'<TD ALIGN="LEFT">{status}</TD></TR>'
+        "</TABLE>>"
+    )
+
+
+def show_graph(
+    trace: RecordingTrace,
+    *,
+    vis_outpath: str | None = None,
+    vis_save_only: bool = True,
+    vis_fileformat: str = "pdf",
+) -> str:
+    """Render a flat Graphviz graph of op events with module-color rails.
+
+    Parameters
+    ----------
+    trace:
+        Dry-run trace to render.
+    vis_outpath:
+        Optional output path stem.
+    vis_save_only:
+        Whether to render without opening a viewer when ``vis_outpath`` is set.
+    vis_fileformat:
+        Graphviz output format.
+
+    Returns
+    -------
+    str
+        Graphviz DOT source.
+    """
+
+    dot = graphviz.Digraph("fastlog_dry_run")
+    dot.attr(rankdir="LR")
+    color_map: dict[str, str] = {}
+    op_contexts = [ctx for ctx in trace.events if ctx.kind in {"op", "input", "buffer"}]
+    event_to_index = {ctx.event_index: index for index, ctx in enumerate(trace.events)}
+    for op_number, ctx in enumerate(op_contexts):
+        trace_index = event_to_index[ctx.event_index]
+        module_address = _module_key(ctx)
+        rail_color = _module_color(module_address, color_map)
+        fillcolor = "#98FB98" if _event_kept(trace, trace_index) else "#E6E6E6"
+        dot.node(
+            f"event_{ctx.event_index}",
+            label=_graph_label(ctx, _event_kept(trace, trace_index), rail_color),
+            shape="box",
+            style="filled,rounded",
+            fillcolor=fillcolor,
+            tooltip=module_address,
+        )
+        if op_number > 0:
+            dot.edge(f"event_{op_contexts[op_number - 1].event_index}", f"event_{ctx.event_index}")
+    if vis_outpath is not None:
+        dot.render(vis_outpath, format=vis_fileformat, cleanup=True, view=not vis_save_only)
+    return dot.source
+
+
+def summary(trace: RecordingTrace) -> str:
+    """Return counts for a dry-run trace."""
+
+    by_kind = Counter(ctx.kind for ctx in trace.events)
+    by_op_type = Counter(str(ctx.layer_type or ctx.func_name or ctx.kind) for ctx in trace.events)
+    kept = sum(1 for index, _ in enumerate(trace.events) if _event_kept(trace, index))
+    lines = [
+        f"RecordingTrace(total_events={len(trace.events)}, kept={kept}, rejected={len(trace.events) - kept})",
+        "by_kind: " + ", ".join(f"{name}={count}" for name, count in sorted(by_kind.items())),
+        "by_op_type: " + ", ".join(f"{name}={count}" for name, count in sorted(by_op_type.items())),
+    ]
+    if trace.predicate_failures:
+        lines.append(f"predicate_failures={len(trace.predicate_failures)}")
+    return "\n".join(lines)
+
+
+def timeline_html(trace: RecordingTrace) -> Any:
+    """Return a horizontal module-row timeline as ``IPython.display.HTML``."""
+
+    from IPython.display import HTML
+
+    module_rows: dict[str, list[RecordContext]] = defaultdict(list)
+    for ctx in trace.events:
+        module_rows[_module_key(ctx)].append(ctx)
+    row_html: list[str] = []
+    max_events = max((len(events) for events in module_rows.values()), default=1)
+    for module_address, events in module_rows.items():
+        tags = []
+        for ctx in events:
+            label = escape(str(ctx.layer_type or ctx.func_name or ctx.kind))
+            tags.append(f'<span class="tl-fastlog-tag">{label}</span>')
+        row_html.append(
+            '<div class="tl-fastlog-row">'
+            f'<div class="tl-fastlog-module">{escape(module_address)}</div>'
+            f'<div class="tl-fastlog-events" style="grid-template-columns: repeat({max_events}, max-content);">'
+            + "".join(tags)
+            + "</div></div>"
+        )
+    html = (
+        "<style>"
+        ".tl-fastlog-row{display:grid;grid-template-columns:180px 1fr;gap:8px;margin:4px 0;"
+        "font-family:system-ui,sans-serif;font-size:12px}"
+        ".tl-fastlog-module{font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}"
+        ".tl-fastlog-events{display:grid;gap:4px;overflow-x:auto}"
+        ".tl-fastlog-tag{display:inline-block;padding:2px 6px;border:1px solid #bbb;"
+        "background:#f2f2f2;border-radius:4px;white-space:nowrap}"
+        "</style><div>" + "".join(row_html) + "</div>"
+    )
+    return HTML(html)

--- a/torchlens/visualization/fastlog_preview.py
+++ b/torchlens/visualization/fastlog_preview.py
@@ -1,0 +1,299 @@
+"""Preview fastlog predicate decisions on a full ModelLog graph."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ..fastlog._predicate import _normalize_capture_decision
+from ..fastlog._record_context import _build_record_context
+from ..fastlog.exceptions import RecordContextFieldError
+from ..fastlog.types import CaptureDecision, ModuleStackFrame, RecordContext
+from .node_spec import NodeSpec
+
+
+class Decision(Enum):
+    """Preview rendering decision for one layer."""
+
+    KEPT = "kept"
+    REJECTED = "rejected"
+    UNREACHABLE = "unreachable"
+    EXCEPTION = "exception"
+
+
+@dataclass(frozen=True, slots=True)
+class PreviewNode:
+    """Cached preview state for one rendered layer."""
+
+    ctx: RecordContext
+    decision: Decision
+    tooltip: str | None = None
+
+
+Predicate = Callable[[RecordContext], CaptureDecision]
+
+
+def _module_stack_from_layer(layer_pass_log: Any) -> tuple[ModuleStackFrame, ...]:
+    """Build a synthetic module stack from a ``LayerPassLog``.
+
+    Parameters
+    ----------
+    layer_pass_log:
+        Layer pass object from a fully postprocessed ``ModelLog``.
+
+    Returns
+    -------
+    tuple[ModuleStackFrame, ...]
+        Synthetic stack frames suitable for preview predicates.
+    """
+
+    frames: list[ModuleStackFrame] = []
+    module_addresses = tuple(getattr(layer_pass_log, "containing_modules", ()) or ())
+    for index, module_address in enumerate(module_addresses, start=1):
+        module_type = ""
+        source_model_log = getattr(layer_pass_log, "source_model_log", None)
+        if source_model_log is not None:
+            modules = getattr(source_model_log, "_module_logs", {})
+            try:
+                module_log = modules[module_address]
+            except (KeyError, TypeError):
+                module_log = None
+            module_type = str(getattr(module_log, "module_type", ""))
+        frames.append(
+            ModuleStackFrame(
+                module_address=str(module_address),
+                module_type=module_type,
+                module_id=0,
+                pass_index=index,
+            )
+        )
+    return tuple(frames)
+
+
+def _kind_from_layer(layer_pass_log: Any) -> str:
+    """Return the fastlog event kind represented by a layer pass."""
+
+    if bool(getattr(layer_pass_log, "is_input_layer", False)):
+        return "input"
+    if bool(getattr(layer_pass_log, "is_buffer_layer", False)):
+        return "buffer"
+    return "op"
+
+
+def _context_from_layer(
+    layer_pass_log: Any,
+    *,
+    history: tuple[RecordContext, ...],
+    event_index: int,
+    op_counts: dict[str, int],
+) -> RecordContext:
+    """Build a preview ``RecordContext`` for a layer pass."""
+
+    module_stack = _module_stack_from_layer(layer_pass_log)
+    module_frame = module_stack[-1] if module_stack else None
+    raw_label = getattr(layer_pass_log, "tensor_label_raw", None)
+    layer_type = getattr(layer_pass_log, "layer_type", None)
+    if isinstance(layer_type, str):
+        op_counts[layer_type] = op_counts.get(layer_type, 0) + 1
+    return _build_record_context(
+        kind=_kind_from_layer(layer_pass_log),  # type: ignore[arg-type]
+        layer_pass_log_or_op_data={
+            "label": getattr(layer_pass_log, "layer_label", raw_label),
+            "raw_label": raw_label,
+            "tensor_label_raw": raw_label,
+            "creation_order": getattr(layer_pass_log, "creation_order", None),
+            "layer_type": layer_type,
+            "layer_type_num": getattr(layer_pass_log, "layer_type_num", None),
+            "func_name": getattr(layer_pass_log, "func_name", None),
+            "parent_labels": tuple(getattr(layer_pass_log, "parent_layers", ()) or ()),
+            "tensor_shape": getattr(layer_pass_log, "tensor_shape", None),
+            "tensor_dtype": getattr(layer_pass_log, "tensor_dtype", None),
+            "output_index": getattr(layer_pass_log, "iterable_output_index", None),
+            "is_bottom_level_func": getattr(layer_pass_log, "is_bottom_level_func", None),
+            "input_output_address": getattr(layer_pass_log, "io_role", None),
+            "module_address": module_frame.module_address if module_frame else None,
+            "module_type": module_frame.module_type if module_frame else None,
+            "module_pass_index": module_frame.pass_index if module_frame else None,
+        },
+        module_stack=module_stack,
+        history=history,
+        op_counts=op_counts,
+        pass_index=max(int(getattr(layer_pass_log, "pass_num", 1)) - 1, 0),
+        event_index=event_index,
+        op_index=int(getattr(layer_pass_log, "operation_num", event_index)),
+        time_since_pass_start=0.0,
+        include_source_events=True,
+    )
+
+
+def _select_predicate(
+    predicate: Predicate | None,
+    keep_op: Predicate | None,
+    keep_module: Predicate | None,
+) -> Predicate | None:
+    """Resolve the predicate callable for previewed layer events."""
+
+    if predicate is not None:
+        return predicate
+    if keep_op is not None:
+        return keep_op
+    return keep_module
+
+
+def _evaluate_preview_node(
+    layer_pass_log: Any,
+    ctx: RecordContext,
+    predicate: Predicate | None,
+) -> PreviewNode:
+    """Evaluate one preview predicate and capture display metadata."""
+
+    if not bool(getattr(layer_pass_log, "has_input_ancestor", True)):
+        return PreviewNode(ctx=ctx, decision=Decision.UNREACHABLE)
+    if predicate is None:
+        return PreviewNode(ctx=ctx, decision=Decision.REJECTED)
+    try:
+        result = predicate(ctx)
+        spec = _normalize_capture_decision(result, ctx, False)
+    except RecordContextFieldError as exc:
+        return PreviewNode(ctx=ctx, decision=Decision.EXCEPTION, tooltip=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return PreviewNode(ctx=ctx, decision=Decision.EXCEPTION, tooltip=repr(exc))
+    if spec.save_activation or spec.save_metadata:
+        return PreviewNode(ctx=ctx, decision=Decision.KEPT)
+    return PreviewNode(ctx=ctx, decision=Decision.REJECTED)
+
+
+def _build_preview_nodes(model_log: Any, predicate: Predicate | None) -> dict[str, PreviewNode]:
+    """Evaluate preview decisions for all layer passes in a model log."""
+
+    history: list[RecordContext] = []
+    op_counts: dict[str, int] = {}
+    preview_nodes: dict[str, PreviewNode] = {}
+    for event_index, layer_pass_log in enumerate(model_log.layer_list, start=1):
+        ctx = _context_from_layer(
+            layer_pass_log,
+            history=tuple(history),
+            event_index=event_index,
+            op_counts=op_counts,
+        )
+        preview_node = _evaluate_preview_node(layer_pass_log, ctx, predicate)
+        preview_nodes[getattr(layer_pass_log, "layer_label_no_pass", ctx.label)] = preview_node
+        preview_nodes[getattr(layer_pass_log, "layer_label", ctx.label)] = preview_node
+        history.append(ctx)
+    return preview_nodes
+
+
+def _append_predicate_input_lines(lines: list[str], ctx: RecordContext) -> None:
+    """Append predicate input details to a node label."""
+
+    lines.append(f"op_type: {ctx.layer_type}")
+    lines.append(f"raw_label: {ctx.raw_label}")
+    lines.append(f"module_path: {ctx.module_address}")
+
+
+def _append_module_event_lines(lines: list[str], layer_log: Any) -> None:
+    """Append module entry/exit details when available."""
+
+    entered = tuple(getattr(layer_log, "modules_entered", ()) or ())
+    exited = tuple(getattr(layer_log, "modules_exited", ()) or ())
+    if entered:
+        lines.append("module_enter: " + ", ".join(str(item) for item in entered))
+    if exited:
+        lines.append("module_exit: " + ", ".join(str(item) for item in exited))
+
+
+def _make_node_spec_fn(
+    preview_nodes: dict[str, PreviewNode],
+    *,
+    color_kept: str,
+    color_rejected: str,
+    color_unreachable: str,
+    color_predicate_error: str,
+    show_predicate_inputs: bool,
+    show_module_events: bool,
+) -> Callable[[Any, NodeSpec], NodeSpec | None]:
+    """Build the runtime ``node_spec_fn`` used by ``render_graph``."""
+
+    colors = {
+        Decision.KEPT: color_kept,
+        Decision.REJECTED: color_rejected,
+        Decision.UNREACHABLE: color_unreachable,
+        Decision.EXCEPTION: color_predicate_error,
+    }
+
+    def node_spec_fn(layer_log: Any, default_spec: NodeSpec) -> NodeSpec:
+        """Paint one node from cached preview state."""
+
+        preview_node = preview_nodes.get(getattr(layer_log, "layer_label", ""))
+        lines = list(default_spec.lines)
+        if preview_node is None:
+            return default_spec
+        lines.append(f"fastlog: {preview_node.decision.value}")
+        if show_predicate_inputs:
+            _append_predicate_input_lines(lines, preview_node.ctx)
+        if show_module_events:
+            _append_module_event_lines(lines, layer_log)
+        return default_spec.replace(
+            lines=lines,
+            fillcolor=colors[preview_node.decision],
+            tooltip=preview_node.tooltip or default_spec.tooltip,
+        )
+
+    return node_spec_fn
+
+
+def preview_fastlog(
+    model_log: Any,
+    predicate: Predicate | None = None,
+    keep_op: Predicate | None = None,
+    keep_module: Predicate | None = None,
+    color_kept: str = "#98FB98",
+    color_rejected: str = "#E6E6E6",
+    color_unreachable: str = "#F7D460",
+    color_predicate_error: str = "#FF7AB6",
+    show_predicate_inputs: bool = True,
+    show_module_events: bool = True,
+    **render_kwargs: Any,
+) -> str:
+    """Render a full ``ModelLog`` colored by fastlog predicate decisions.
+
+    Parameters
+    ----------
+    model_log:
+        Fully logged model graph to preview.
+    predicate, keep_op, keep_module:
+        Predicate callables that receive synthesized ``RecordContext`` objects.
+    color_kept, color_rejected, color_unreachable, color_predicate_error:
+        Fill colors for preview decisions.
+    show_predicate_inputs:
+        Whether to append selected predicate fields to node labels.
+    show_module_events:
+        Whether to append module entry/exit fields already present on layer logs.
+    **render_kwargs:
+        Forwarded to ``ModelLog.render_graph``.
+
+    Returns
+    -------
+    str
+        Graphviz DOT source.
+    """
+
+    # TODO(fastlog-dagua): add native dagua support after the v1 Graphviz preview ships.
+    if render_kwargs.get("vis_renderer") == "dagua":
+        raise NotImplementedError(
+            "fastlog preview currently supports Graphviz only; dagua support is planned."
+        )
+    resolved_predicate = _select_predicate(predicate, keep_op, keep_module)
+    preview_nodes = _build_preview_nodes(model_log, resolved_predicate)
+    node_spec_fn = _make_node_spec_fn(
+        preview_nodes,
+        color_kept=color_kept,
+        color_rejected=color_rejected,
+        color_unreachable=color_unreachable,
+        color_predicate_error=color_predicate_error,
+        show_predicate_inputs=show_predicate_inputs,
+        show_module_events=show_module_events,
+    )
+    return model_log.render_graph(node_spec_fn=node_spec_fn, **render_kwargs)


### PR DESCRIPTION
## Summary

Adds `tl.fastlog` -- a high-throughput activation recording subsystem for
PyTorch models whose computation graph can change between forward passes
(adaptive transformers, RL policies, generation loops, MoE routing). Until
now, dynamic-graph models had no fast path; every forward paid full
exhaustive cold-start. `tl.fastlog` closes that gap with a predicate-driven
capture model, RAM + disk backends, two-tier visualization, and training-
compatible RAM modes.

Single PR per user direction. v2.x additive. No breaking changes.

## Public API (all under `tl.fastlog`)

- `tl.fastlog.record(model, input_args, input_kwargs=None, *, keep_op=, keep_module=, ...)` -- one-shot
- `with tl.fastlog.Recorder(model, ...) as rec: out = rec.log(batch)` -- many-rollout context manager
- `tl.fastlog.dry_run(model, x, ...)` -- predicate iteration without saving tensors
- `tl.fastlog.load(path)` / `tl.fastlog.recover(path)` -- bundle loaders
- `model_log.preview_fastlog(predicate=...)` -- annotated graph view of what fast-mode would capture (also `tl.preview_fastlog`)
- Types: `Recording`, `RecordContext`, `CaptureSpec`, `RecordingOptions`, `RecordingTrace`, `ActivationRecord`, `ModuleStackFrame`

## What's in the box

- **Predicate-driven capture.** `keep_op` / `keep_module` callbacks
  receive a frozen `RecordContext` (NOT a `LayerLog`), with a sliding
  window of recent events including module entry/exit. Returns
  `bool | CaptureSpec | None`.
- **Module entry/exit as first-class events.** Lightweight branch in
  `module_forward_decorator` push/pops `_module_stack` in `try/finally`;
  predicate fires on enter and exit.
- **Storage modes.** RAM-only / RAM+disk mirror / disk-only, all driven
  by existing `StreamingOptions(bundle_path=, retain_in_memory=)`. No
  new public storage knob. All clones routed through `safe_copy`; no
  bare `.detach()` anywhere.
- **`keep_grad=True` works in v1** for RAM-clone-attached storage; disk-
  only sessions reject `keep_grad=True` with hard errors at
  construction (defaults) or runtime-before-write (predicate returns).
- **Sync disk default**, async deferred until safetensors >= 0.8 stable
  + benchmarks. Disk bundle layout: `manifest.json`,
  `fastlog_index.jsonl` (append-only), `pass_index.json`,
  `label_index.json`, `metadata.json` (no pickle for fastlog bundles),
  `blobs/*.safetensors`.
- **`tl.fastlog.recover(path)`** with deterministic decision tree for
  malformed manifests, missing/truncated/malformed JSONL, missing blobs,
  hash mismatches.
- **Two-tier visualization.** `preview_fastlog` reuses `render_graph`
  with a generated `node_spec_fn` (no `MODE_REGISTRY` change); `dry_run`
  returns a `RecordingTrace` with `print_tree`, `to_pandas`,
  `show_graph` (graphviz with module rails), `repredicate` for cheap
  iteration.
- **Opt-in postprocess.** `Recording.enrich(["module_path_strings",
  "all-feasible"])` -- narrow named presets that describe what's
  computable from sparse predicate captures. (`param_addresses` reserved
  pending capture-time field; raises clearly.)

## Bonus: `_get_col_offset` perf fix (~10.9x speedup)

First commit in this PR is a precursor performance fix: deferred
`_get_col_offset` and `_get_code_qualname` to phase 2 of frame filtering.
On a 20-layer MLP benchmark, `log_forward_pass` mean time dropped from
0.460s to 0.042s. Benefits the existing exhaustive path; the
`disable_col_offset` kwarg lets fastlog opt fully out.

## Process

The plan went through 4 rounds of adversarial codex review (BLOCK / BLOCK /
BLOCK with 3 narrow issues / APPROVE) before any implementation started.
16 research reports (8 factors x 2 cognitive-diversity agents) under
`memory/fastlog_sprint/results/` informed the plan. Implementation in 6
codex bundles; sprint branch is the result.

## Test plan

- [x] `ruff format && ruff check`: clean
- [x] `mypy torchlens/`: clean
- [x] `pytest tests/ -m smoke`: 37 passed
- [x] `pytest tests/test_fastlog/ -v`: 92 passed, 2 xfailed (documented)
- [x] `pytest tests/ -m "not slow"`: 1315 passed, 21 skipped (zero regressions)
- [x] Coverage on `torchlens.fastlog`: 88%
- [x] Tutorial notebook executes end-to-end: yes

## Documented xfails

- `test_async_disk_storage_pending`: v1 sync-only by design.
- `test_preview_and_dry_run_contexts_match_field_by_field`: preview
  RecordContext fidelity vs dry_run is complete enough for normal
  usage but not exact field-by-field; flagged for follow-up.

## NOT supported in v1 (documented in tutorial)

- True DDP forward semantics (only rank-local unwrapped capture)
- FSDP (existing rejection error stays)
- async disk drain
- `Recording.to_model_log()` -- fundamentally undeliverable for sparse captures
- `keep_grad=True` with disk-only sessions (use RAM+disk mirror)

## Plan + research artifacts

- Plan: `memory/fastlog_sprint/plan/EXECUTION_PLAN.md`
- 4 adversarial review rounds: `memory/fastlog_sprint/plan/adversarial_review_round_{1,2,3,4}.md`
- 16 research reports: `memory/fastlog_sprint/results/`
- 6 implementation bundle status: `memory/fastlog_sprint/implementation/results/`