### PR TITLE
fix(ci): unblock smoke + dep-audit (pre-existing on main)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,4 +50,9 @@ jobs:
           uv pip install --system pip-audit
 
       - name: Run pip-audit
-        run: pip-audit
+        # CVE-2026-3219 affects pip itself (the package installed on
+        # the GitHub runner image). It's outside this project's
+        # dependency surface and not actionable from pyproject.toml.
+        # Ignore that single ID; remove this once a pip release with
+        # the fix is generally available.
+        run: pip-audit --ignore-vuln CVE-2026-3219

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,12 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
 
+      - name: Install graphviz (system dep -- the `dot` binary used by
+          tests that render visualization output)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+
       - name: Install torch (${{ matrix.torch }}, CPU wheel)
         run: |
           uv pip install --system "torch==${{ matrix.torch }}" \

--- a/tests/test_real_world_models.py
+++ b/tests/test_real_world_models.py
@@ -1,10 +1,10 @@
 """Tests for real-world models.
 
-All optional-dependency imports are local (inside test functions) using
-pytest.importorskip() for non-torchvision packages. Tests with missing
-packages show as SKIPPED, never ERROR.
-
-Only torch, torchvision, pytest, and torchlens are imported at the top level.
+All optional-dependency imports use ``pytest.importorskip()`` so the
+file collects (and skips gracefully) on environments without the
+optional deps installed. Without the module-level guard below, a
+top-level ``import torchvision`` errors out the entire pytest collection
+on slim CI environments that only install ``[dev]`` extras.
 
 Tests that take >5 minutes are marked @pytest.mark.slow. To skip them:
     pytest tests/test_real_world_models.py -m "not slow"
@@ -15,12 +15,16 @@ from os.path import join as opj
 import numpy as np
 import pytest
 import torch
-import torchvision
 
-from conftest import VIS_OUTPUT_DIR
+# Module-level skip when torchvision is unavailable. pytest.importorskip
+# raises pytest.skip.Exception during collection, which marks the whole
+# file SKIPPED rather than ERROR.
+torchvision = pytest.importorskip("torchvision")
 
-import example_models
-from torchlens import show_model_graph, validate_forward_pass
+from conftest import VIS_OUTPUT_DIR  # noqa: E402
+
+import example_models  # noqa: E402
+from torchlens import show_model_graph, validate_forward_pass  # noqa: E402
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Two pre-existing CI failures on main, fixed in one PR.

### 1. Smoke (`Tests` workflow)
`tests/test_real_world_models.py` had `import torchvision` at the top
level. The smoke job installs only `[dev]` extras (no torchvision), so
collection fails with `ModuleNotFoundError: No module named 'torchvision'`
before any smoke test can run.

Fix: switch to `torchvision = pytest.importorskip("torchvision")` so the
module SKIPs gracefully on slim envs. Three downstream imports get
`# noqa: E402` because they now sit below the importorskip guard. No
behavior change when torchvision is present.

### 2. Dependency audit (`Quality` workflow)
`pip-audit` flagged `CVE-2026-3219` against pip itself (the package
installed on the GitHub runner image). It is outside this project's
dependency surface and not actionable from `pyproject.toml`.

Fix: pass `--ignore-vuln CVE-2026-3219` with a TODO comment to remove
once a pip release containing the fix is generally available.

## Test plan
- [x] `ruff check .` clean
- [x] `mypy torchlens/` clean
- [x] `pytest tests/ -m smoke -x --tb=short` passes locally with
      torchvision present (37 passed)
- [x] `pytest tests/test_real_world_models.py --collect-only` reports
      "no tests collected" (gracefully skipped) when torchvision is
      blocked
- [x] CI on this PR will be the real verification

## Notes
- Did NOT add torchvision to `[dev]` extras -- that would slow CI by
  pulling timm / transformers / etc. The skip is the cheaper fix.
- Did NOT alter test selection or skip any individual tests.