### PR TITLE
feat(visualization): cylinder shape for buffer nodes

### DIFF
--- a/tests/test_buffer_visibility.py
+++ b/tests/test_buffer_visibility.py
@@ -230,6 +230,24 @@ def test_always_shows_all_no_marker(tmp_path: Path) -> None:
 
 
 @pytest.mark.smoke
+def test_visible_buffer_uses_cylinder_shape(tmp_path: Path) -> None:
+    """Visible buffers render as white cylinders instead of gray boxes."""
+
+    log = _log_model(_BatchNormWithArchitecturalBuffer())
+    try:
+        dot_source = _render_dot(log, tmp_path, "always")
+    finally:
+        log.cleanup()
+
+    buffer_node_lines = _buffer_node_lines(dot_source)
+    causal_mask_lines = [line for line in buffer_node_lines if "causal_mask" in line]
+
+    assert len(causal_mask_lines) == 1
+    assert "shape=cylinder" in causal_mask_lines[0]
+    assert "#888888" not in causal_mask_lines[0]
+
+
+@pytest.mark.smoke
 def test_legacy_true_matches_always(tmp_path: Path) -> None:
     """Legacy ``True`` buffer visibility maps to ``always``."""
 

--- a/torchlens/visualization/rendering.py
+++ b/torchlens/visualization/rendering.py
@@ -170,7 +170,6 @@ OUTPUT_COLOR = "#ff9999"  # Light red/salmon
 PARAMS_NODE_BG_COLOR = "#E6E6E6"  # Generic param (no ParamLog available)
 TRAINABLE_PARAMS_BG_COLOR = "#D9D9D9"  # Light gray for trainable params
 FROZEN_PARAMS_BG_COLOR = "#B0B0B0"  # Darker gray for frozen params
-BUFFER_NODE_COLOR = "#888888"  # Medium gray for buffer nodes
 GRADIENT_ARROW_COLOR = "#9197F6"  # Light blue/purple for backward edges
 DEFAULT_BG_COLOR = "white"
 BOOL_NODE_COLOR = "#F7D460"  # Yellow for terminal boolean layers
@@ -1588,8 +1587,8 @@ def _get_node_address_shape_color(
         else:
             buffer_address = f"{source_node.buffer_address}:{source_node.buffer_pass}"
         node_address = "<br/>@" + buffer_address
-        node_shape = "box"
-        node_color = BUFFER_NODE_COLOR
+        node_shape = "cylinder"
+        node_color = "black"
     elif node.is_output_layer or node.is_input_layer:
         node_address = "<br/>@" + node.io_role
         node_shape = "oval"


### PR DESCRIPTION
Replaces #159, which was auto-closed when its base (`codex/buffer-vis-tristate`) was deleted on merge of #158.

Switches the visual treatment of visible buffer nodes from a gray box to a white cylinder, and drops the now-unused `BUFFER_NODE_COLOR` constant. Shape carries the "stored model state" semantic; the gray color axis stays reserved for the param-state ladder.

Phase 2 of the buffer-visualization revamp -- builds on #158.

## Changes

- `torchlens/visualization/rendering.py`: removed `BUFFER_NODE_COLOR`; visible buffer nodes now use `shape="cylinder"` with default white fill.
- `tests/test_buffer_visibility.py`: added `test_visible_buffer_uses_cylinder_shape` smoke test.

## Quality gates (run by codex on the original branch before rebase; content is identical)

- ruff format / ruff check: passed
- mypy torchlens/: passed
- pytest -m smoke: 51 passed
- pytest tests/test_buffer_visibility.py: 6 passed
- pytest tests/test_real_world_models.py -m "not slow": 23 passed, 1 skipped
- pytest tests/test_output_aesthetics.py: 12 passed