### PR TITLE
feat(backward): gradient disk streaming and tutorial (PR 3 of 3)

### DIFF
--- a/notebooks/backward_tutorial.ipynb
+++ b/notebooks/backward_tutorial.ipynb
@@ -1,0 +1,453 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Backward-pass capture with TorchLens\n",
+    "\n",
+    "Backward capture records the autograd graph that PyTorch executes after a logged forward pass. It lets you inspect per-layer output gradients, traverse `grad_fn` topology, connect backward nodes to forward layers, validate captured gradients, render the backward graph, and stream gradient tensors to disk when RAM matters.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import tempfile\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd().parent if Path.cwd().name == \"notebooks\" else Path.cwd()))\n",
+    "\n",
+    "import torch\n",
+    "from torch import nn\n",
+    "import torchlens as tl\n",
+    "\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "\n",
+    "class TinyBackwardNet(nn.Module):\n",
+    "    \"\"\"Small network used throughout this tutorial.\"\"\"\n",
+    "\n",
+    "    def __init__(self) -> None:\n",
+    "        \"\"\"Initialize layers.\"\"\"\n",
+    "\n",
+    "        super().__init__()\n",
+    "        self.fc1 = nn.Linear(4, 5)\n",
+    "        self.fc2 = nn.Linear(5, 2)\n",
+    "\n",
+    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"Run the network.\"\"\"\n",
+    "\n",
+    "        hidden = torch.relu(self.fc1(x))\n",
+    "        viewed = hidden.view(hidden.shape[0], 5)\n",
+    "        return self.fc2(viewed)\n",
+    "\n",
+    "\n",
+    "def fresh_model_and_input() -> tuple[TinyBackwardNet, torch.Tensor]:\n",
+    "    \"\"\"Return a deterministic model/input pair.\"\"\"\n",
+    "\n",
+    "    torch.manual_seed(7)\n",
+    "    return TinyBackwardNet(), torch.randn(3, 4, requires_grad=True)\n",
+    "\n",
+    "\n",
+    "def logged_with_backward(**kwargs: object) -> tl.ModelLog:\n",
+    "    \"\"\"Capture a forward pass and then a scalar backward pass.\"\"\"\n",
+    "\n",
+    "    model, x = fresh_model_and_input()\n",
+    "    model_log = tl.log_forward_pass(model, x, layers_to_save=\"all\", save_gradients=True, **kwargs)\n",
+    "    loss = model_log[model_log.output_layers[0]].activation.sum()\n",
+    "    model_log.log_backward(loss)\n",
+    "    return model_log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Pattern 1: basic gradient access per layer\n",
+    "\n",
+    "Call `log_forward_pass(..., save_gradients=True)`, build a scalar loss from a saved activation, and pass it to `model_log.log_backward(loss)`. Saved layer gradients are then available through normal layer lookup.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_log = logged_with_backward()\n",
+    "\n",
+    "assert model_log.has_gradients\n",
+    "assert model_log.layers_with_saved_gradients\n",
+    "first_gradient_layer = model_log.layers_with_saved_gradients[0]\n",
+    "first_gradient = model_log[first_gradient_layer].gradient\n",
+    "\n",
+    "assert isinstance(first_gradient, torch.Tensor)\n",
+    "assert first_gradient.shape == model_log[first_gradient_layer].tensor_shape\n",
+    "first_gradient_layer, tuple(first_gradient.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Pattern 2: backward graph topology\n",
+    "\n",
+    "The `grad_fns` accessor exposes the backward graph in discovery order. Intervening nodes are autograd operations that do not have a one-to-one forward layer match.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grad_fn_count = len(model_log.grad_fns)\n",
+    "intervening = [grad_fn for grad_fn in model_log.grad_fns if grad_fn.is_intervening]\n",
+    "root = model_log.grad_fn_logs[model_log.backward_root_grad_fn_id]\n",
+    "\n",
+    "assert grad_fn_count > 0\n",
+    "assert intervening\n",
+    "assert root.next_grad_fn_ids\n",
+    "\n",
+    "grad_fn_count, root.label, len(intervening)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Pattern 3: cross-references between forward and backward\n",
+    "\n",
+    "Forward layers and backward grad-fn logs point back to each other when TorchLens can identify the correspondence.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paired_grad_fns = [\n",
+    "    grad_fn for grad_fn in model_log.grad_fns if grad_fn.corresponding_layer is not None\n",
+    "]\n",
+    "\n",
+    "assert paired_grad_fns\n",
+    "for grad_fn in paired_grad_fns:\n",
+    "    assert grad_fn.corresponding_layer.corresponding_grad_fn is grad_fn\n",
+    "\n",
+    "paired_grad_fns[0].corresponding_layer.layer_label, paired_grad_fns[0].label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Pattern 4: per-layer gradient selection\n",
+    "\n",
+    "`gradients_to_save` can be independent from `layers_to_save`. When `gradients_to_save` is omitted but backward capture is enabled, TorchLens defaults it from `layers_to_save`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model, x = fresh_model_and_input()\n",
+    "selected_log = tl.log_forward_pass(\n",
+    "    model,\n",
+    "    x,\n",
+    "    layers_to_save=[\"relu\"],\n",
+    "    gradients_to_save=[\"relu\"],\n",
+    ")\n",
+    "selected_log.log_backward(selected_log[selected_log.output_layers[0]].activation.sum())\n",
+    "\n",
+    "assert selected_log.layers_with_saved_gradients\n",
+    "assert all(\"relu\" in label for label in selected_log.layers_with_saved_gradients)\n",
+    "\n",
+    "model, x = fresh_model_and_input()\n",
+    "defaulted_log = tl.log_forward_pass(model, x, layers_to_save=[\"relu\"], save_gradients=True)\n",
+    "defaulted_log.log_backward(defaulted_log[defaulted_log.output_layers[0]].activation.sum())\n",
+    "\n",
+    "assert defaulted_log.layers_with_saved_gradients == selected_log.layers_with_saved_gradients\n",
+    "selected_log.layers_with_saved_gradients"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Pattern 5: multi-loss capture with `recording_backward()`\n",
+    "\n",
+    "Use `recording_backward()` when you want to manage `.backward()` calls yourself, including `retain_graph=True` for multiple losses on the same graph.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model, x = fresh_model_and_input()\n",
+    "multi_log = tl.log_forward_pass(model, x, layers_to_save=\"all\", save_gradients=True)\n",
+    "output = multi_log[multi_log.output_layers[0]].activation\n",
+    "loss_a = output[:, 0].sum()\n",
+    "loss_b = output[:, 1].sum()\n",
+    "\n",
+    "with multi_log.recording_backward():\n",
+    "    loss_a.backward(retain_graph=True)\n",
+    "    loss_b.backward()\n",
+    "\n",
+    "assert multi_log.backward_num_passes == 2\n",
+    "assert all(grad_fn.num_passes >= 1 for grad_fn in multi_log.grad_fns)\n",
+    "multi_log.backward_num_passes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Pattern 6: backward visualization\n",
+    "\n",
+    "`show_backward_graph()` renders the captured autograd graph. `save_only=True` is useful in notebooks and CI because it writes a file without opening a viewer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    out_base = Path(tmpdir) / \"backward_graph\"\n",
+    "    dot_source = tl.show_backward_graph(\n",
+    "        model_log,\n",
+    "        vis_outpath=str(out_base),\n",
+    "        vis_save_only=True,\n",
+    "        vis_fileformat=\"pdf\",\n",
+    "    )\n",
+    "    rendered = out_base.with_suffix(\".pdf\")\n",
+    "    assert rendered.exists()\n",
+    "    assert rendered.stat().st_size > 0\n",
+    "    assert \"digraph\" in dot_source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## Pattern 7: `validate_backward_pass`\n",
+    "\n",
+    "Validation compares TorchLens backward capture against a stock autograd run. The perturbation option intentionally corrupts saved gradients and should fail.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model, x = fresh_model_and_input()\n",
+    "assert tl.validate_backward_pass(model, x)\n",
+    "\n",
+    "model, x = fresh_model_and_input()\n",
+    "assert not tl.validate_backward_pass(model, x, perturb_saved_gradients=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## Pattern 8: saving and loading a bundle with backward data\n",
+    "\n",
+    "Portable bundles include backward flat fields, grad-fn logs, cross-references, and saved gradients.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    bundle_path = Path(tmpdir) / \"backward_bundle.tl\"\n",
+    "    tl.save(model_log, bundle_path)\n",
+    "    restored = tl.load(bundle_path, lazy=True)\n",
+    "    label = restored.layers_with_saved_gradients[0]\n",
+    "\n",
+    "    assert restored.has_backward_log\n",
+    "    assert restored.backward_num_passes == model_log.backward_num_passes\n",
+    "    assert len(restored.grad_fn_logs) == len(model_log.grad_fn_logs)\n",
+    "    assert restored.grad_fns[0].passes\n",
+    "    assert isinstance(restored[label].gradient, torch.Tensor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "## Pattern 9: streaming gradients to disk\n",
+    "\n",
+    "`save_gradients_to` streams saved gradients into a portable bundle and `keep_gradients_in_memory=False` leaves lazy refs behind. Accessing `layer.gradient` materializes the tensor from disk.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    bundle_path = Path(tmpdir) / \"streamed_backward.tl\"\n",
+    "    model, x = fresh_model_and_input()\n",
+    "    streamed_log = tl.log_forward_pass(\n",
+    "        model,\n",
+    "        x,\n",
+    "        layers_to_save=\"all\",\n",
+    "        save_gradients=True,\n",
+    "        save_gradients_to=bundle_path,\n",
+    "        keep_gradients_in_memory=False,\n",
+    "    )\n",
+    "    streamed_log.log_backward(streamed_log[streamed_log.output_layers[0]].activation.sum())\n",
+    "\n",
+    "    label = streamed_log.layers_with_saved_gradients[0]\n",
+    "    assert streamed_log[label].__dict__[\"gradient\"] is None\n",
+    "    assert streamed_log[label].gradient_ref is not None\n",
+    "    assert isinstance(streamed_log[label].gradient, torch.Tensor)\n",
+    "\n",
+    "    lazy_streamed = tl.load(bundle_path, lazy=True)\n",
+    "    assert lazy_streamed[label].__dict__[\"gradient\"] is None\n",
+    "    assert isinstance(lazy_streamed[label].gradient, torch.Tensor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## Pattern 10: custom `autograd.Function`\n",
+    "\n",
+    "Custom autograd functions are preserved in the backward graph and marked with `is_custom`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DoubleFn(torch.autograd.Function):\n",
+    "    \"\"\"Custom function for tutorial coverage.\"\"\"\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def forward(ctx: torch.autograd.function.FunctionCtx, x: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"Return doubled input.\"\"\"\n",
+    "\n",
+    "        return x * 2\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def backward(ctx: torch.autograd.function.FunctionCtx, grad: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"Return doubled upstream gradient.\"\"\"\n",
+    "\n",
+    "        return grad * 2\n",
+    "\n",
+    "\n",
+    "class CustomFnNet(nn.Module):\n",
+    "    \"\"\"Tiny model that uses a custom autograd function.\"\"\"\n",
+    "\n",
+    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"Run the model.\"\"\"\n",
+    "\n",
+    "        return DoubleFn.apply(x).sum()\n",
+    "\n",
+    "\n",
+    "custom_log = tl.log_forward_pass(\n",
+    "    CustomFnNet(), torch.randn(2, 4, requires_grad=True), save_gradients=True\n",
+    ")\n",
+    "custom_log.log_backward(custom_log[custom_log.output_layers[0]].activation)\n",
+    "\n",
+    "assert any(grad_fn.is_custom for grad_fn in custom_log.grad_fns)\n",
+    "[grad_fn.label for grad_fn in custom_log.grad_fns if grad_fn.is_custom]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "## Gotchas\n",
+    "\n",
+    "Higher-order gradients: basic `create_graph=True` capture works, but exhaustive higher-order coverage is still deferred.\n",
+    "\n",
+    "Inference mode: backward capture needs autograd history. If a workflow opts into `train_mode=True`, active `torch.inference_mode()` is rejected because inference tensors cannot retain that history.\n",
+    "\n",
+    "Distributed training: backward data is rank-local. With DDP or multi-rank jobs, capture each rank intentionally and manage synchronization outside TorchLens.\n",
+    "\n",
+    "Deferred features: fastlog gradients, per-grad-fn memory-cost attribution, and side-by-side forward/backward visualization remain parking-lot items in `todos.md`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model, x = fresh_model_and_input()\n",
+    "higher_order_log = tl.log_forward_pass(model, x, save_gradients=True)\n",
+    "higher_order_log.log_backward(\n",
+    "    higher_order_log[higher_order_log.output_layers[0]].activation.sum(), create_graph=True\n",
+    ")\n",
+    "assert higher_order_log.backward_num_passes == 1\n",
+    "\n",
+    "try:\n",
+    "    with torch.inference_mode():\n",
+    "        model, x = fresh_model_and_input()\n",
+    "        tl.log_forward_pass(model, x, gradients_to_save=\"all\")\n",
+    "except ValueError as exc:\n",
+    "    assert \"inference\" in str(exc).lower()\n",
+    "else:\n",
+    "    raise AssertionError(\"inference_mode should reject train-mode backward capture\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_backward_streaming.py
+++ b/tests/test_backward_streaming.py
@@ -1,0 +1,170 @@
+"""Smoke tests for backward gradient disk streaming."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("safetensors")
+
+import torchlens as tl
+from torchlens._io.manifest import Manifest
+
+
+class _TinyStreamingBackwardModel(nn.Module):
+    """Small model used by backward streaming tests."""
+
+    def __init__(self) -> None:
+        """Initialize the model."""
+
+        super().__init__()
+        self.fc1 = nn.Linear(3, 4)
+        self.fc2 = nn.Linear(4, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a forward pass.
+
+        Parameters
+        ----------
+        x:
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Model output tensor.
+        """
+
+        return self.fc2(torch.relu(self.fc1(x)))
+
+
+def _logged_backward_stream(
+    bundle_path: Path,
+    *,
+    keep_gradients_in_memory: bool = True,
+) -> tuple[tl.ModelLog, dict[str, torch.Tensor]]:
+    """Capture a backward pass with streamed gradients.
+
+    Parameters
+    ----------
+    bundle_path:
+        Destination bundle path.
+    keep_gradients_in_memory:
+        Whether gradients should remain in memory after bundle finalization.
+
+    Returns
+    -------
+    tuple[tl.ModelLog, dict[str, torch.Tensor]]
+        Captured log and eager gradient clones keyed by saved layer label.
+    """
+
+    torch.manual_seed(0)
+    model = _TinyStreamingBackwardModel()
+    inputs = torch.randn(2, 3, requires_grad=True)
+    model_log = tl.log_forward_pass(
+        model,
+        inputs,
+        layers_to_save="all",
+        save_gradients=True,
+        save_gradients_to=bundle_path,
+        keep_gradients_in_memory=keep_gradients_in_memory,
+    )
+    model_log.log_backward(model_log[model_log.output_layers[0]].activation.sum())
+    expected = (
+        {
+            label: model_log[label].gradient.detach().clone()
+            for label in model_log.layers_with_saved_gradients
+        }
+        if keep_gradients_in_memory
+        else {}
+    )
+    return model_log, expected
+
+
+@pytest.mark.smoke
+def test_log_backward_streams_gradients_to_disk(tmp_path: Path) -> None:
+    """Gradient streaming should write gradient blobs into the bundle."""
+
+    bundle_path = tmp_path / "backward_stream.tl"
+    model_log, _expected = _logged_backward_stream(bundle_path)
+    manifest = Manifest.read(bundle_path / "manifest.json")
+
+    assert bundle_path.exists()
+    assert model_log.has_backward_log
+    assert any(entry.kind == "gradient" for entry in manifest.tensors)
+    assert len(model_log.layers_with_saved_gradients) > 0
+
+
+@pytest.mark.smoke
+def test_lazy_load_gradient_from_bundle(tmp_path: Path) -> None:
+    """Lazy-loaded gradients should materialize on field access."""
+
+    bundle_path = tmp_path / "backward_stream.tl"
+    _model_log, expected = _logged_backward_stream(bundle_path)
+    lazy_log = tl.load(bundle_path, lazy=True)
+    label = next(iter(expected))
+    layer = lazy_log[label]
+
+    assert layer.__dict__["gradient"] is None
+    assert layer.gradient_ref is not None
+    assert torch.equal(layer.gradient, expected[label])
+    assert isinstance(layer.__dict__["gradient"], torch.Tensor)
+
+
+@pytest.mark.smoke
+def test_bundle_save_load_roundtrip_with_backward(tmp_path: Path) -> None:
+    """Bundle save/load should preserve backward metadata and cross-references."""
+
+    source_path = tmp_path / "backward_stream.tl"
+    model_log, expected = _logged_backward_stream(source_path)
+    roundtrip_path = tmp_path / "roundtrip.tl"
+
+    tl.save(model_log, roundtrip_path)
+    restored = tl.load(roundtrip_path, lazy=True)
+    label = next(iter(expected))
+    grad_fn = next(grad_fn for grad_fn in restored.grad_fns if grad_fn.corresponding_layer)
+
+    assert restored.has_backward_log is True
+    assert restored.backward_num_passes == model_log.backward_num_passes
+    assert restored.backward_memory_backend == model_log.backward_memory_backend
+    assert len(restored.grad_fn_logs) == len(model_log.grad_fn_logs)
+    assert restored.grad_fn_order == model_log.grad_fn_order
+    assert grad_fn.corresponding_layer.corresponding_grad_fn is grad_fn
+    assert torch.equal(restored[label].gradient, expected[label])
+
+
+@pytest.mark.smoke
+def test_train_mode_disk_save_rejected_for_gradients(tmp_path: Path) -> None:
+    """Training mode should reject gradient disk streaming."""
+
+    model = _TinyStreamingBackwardModel()
+    inputs = torch.randn(2, 3, requires_grad=True)
+
+    with pytest.raises(ValueError, match="gradient disk saves"):
+        tl.log_forward_pass(
+            model,
+            inputs,
+            layers_to_save="all",
+            save_gradients=True,
+            save_gradients_to=tmp_path / "bad.tl",
+            train_mode=True,
+        )
+
+
+@pytest.mark.smoke
+def test_keep_gradients_in_memory_false(tmp_path: Path) -> None:
+    """Explicit gradient eviction should keep lazy refs and drop live tensors."""
+
+    bundle_path = tmp_path / "backward_stream.tl"
+    model_log, _expected = _logged_backward_stream(
+        bundle_path,
+        keep_gradients_in_memory=False,
+    )
+    layer = model_log[model_log.layers_with_saved_gradients[0]]
+
+    assert layer.__dict__["gradient"] is None
+    assert layer.gradient_ref is not None
+    assert isinstance(layer.gradient, torch.Tensor)

--- a/torchlens/_io/scrub.py
+++ b/torchlens/_io/scrub.py
@@ -379,6 +379,8 @@ def _blob_kind_for_field(owner: Any, field_name: str) -> str:
         return "func_config"
     if field_name == "extra_attributes":
         return "module_meta"
+    if field_name in {"grad_inputs", "grad_outputs"}:
+        return "grad_fn_grad"
     raise TorchLensIOError(f"No blob kind mapping defined for {type(owner).__name__}.{field_name}.")
 
 

--- a/torchlens/_io/streaming.py
+++ b/torchlens/_io/streaming.py
@@ -150,8 +150,9 @@ class BundleStreamWriter:
 
         self._ensure_writable()
         if not isinstance(tensor, torch.Tensor):
+            postfunc_name = "gradient_postfunc" if kind == "gradient" else "activation_postfunc"
             reason = (
-                "Streaming activation save requires activation_postfunc outputs to be torch.Tensor "
+                f"Streaming {kind} save requires {postfunc_name} outputs to be torch.Tensor "
                 f"instances, but blob_id={blob_id} ({label}) received {type(tensor).__name__}."
             )
             self.abort(reason)
@@ -165,7 +166,7 @@ class BundleStreamWriter:
             else:
                 reason_text = "unsupported tensor"
             reason = (
-                f"Unsupported tensor for streaming activation save at {label} "
+                f"Unsupported tensor for streaming {kind} save at {label} "
                 f"(blob_id={blob_id}, kind={kind}): {reason_text}"
             )
             self.abort(reason)

--- a/torchlens/capture/backward.py
+++ b/torchlens/capture/backward.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Iterator
 
 import torch
 
+from .._io.streaming import BundleStreamWriter
 from .._state import pause_logging
 from ..data_classes.grad_fn_log import GradFnLog
 from .tensor_tracking import _add_backward_hook
@@ -380,7 +381,62 @@ def _ensure_layer_gradient_hooks(model_log: Any) -> None:
             _add_backward_hook(model_log, activation, layer.tensor_label_raw)
 
 
-def log_backward(self: Any, loss: torch.Tensor, **backward_kwargs: Any) -> Any:
+def _configure_gradient_streaming(
+    model_log: Any,
+    *,
+    save_gradients_to: str | None,
+    keep_gradients_in_memory: bool | None,
+) -> None:
+    """Configure deferred bundle finalization for streamed gradients.
+
+    Parameters
+    ----------
+    model_log:
+        ModelLog receiving streamed gradient blobs.
+    save_gradients_to:
+        Optional bundle path for gradient streaming.
+    keep_gradients_in_memory:
+        Whether gradients should remain in memory after finalization.
+    """
+
+    if keep_gradients_in_memory is not None:
+        model_log._keep_gradients_in_memory = keep_gradients_in_memory
+    if save_gradients_to is not None:
+        if getattr(model_log, "_activation_writer", None) is not None:
+            raise ValueError("Cannot set save_gradients_to after a streaming writer exists.")
+        model_log._activation_writer = BundleStreamWriter(save_gradients_to)
+        model_log._defer_streaming_bundle_finalization = True
+        model_log.save_gradients = True
+
+
+def _finalize_gradient_streaming(model_log: Any) -> None:
+    """Finalize a deferred gradient-streaming bundle after backward capture."""
+
+    writer = getattr(model_log, "_activation_writer", None)
+    if writer is None or not getattr(model_log, "_defer_streaming_bundle_finalization", False):
+        return
+
+    from ..postprocess.finalization import (
+        _evict_streamed_activations,
+        _evict_streamed_gradients,
+        _finalize_streamed_bundle,
+    )
+
+    _finalize_streamed_bundle(model_log)
+    if not getattr(model_log, "_keep_activations_in_memory", True):
+        _evict_streamed_activations(model_log)
+    if not getattr(model_log, "_keep_gradients_in_memory", True):
+        _evict_streamed_gradients(model_log)
+
+
+def log_backward(
+    self: Any,
+    loss: torch.Tensor,
+    *,
+    save_gradients_to: str | None = None,
+    keep_gradients_in_memory: bool | None = None,
+    **backward_kwargs: Any,
+) -> Any:
     """Run ``loss.backward`` while capturing the backward graph.
 
     Parameters
@@ -395,6 +451,11 @@ def log_backward(self: Any, loss: torch.Tensor, **backward_kwargs: Any) -> Any:
     Any
         The same ModelLog, for chaining.
     """
+    _configure_gradient_streaming(
+        self,
+        save_gradients_to=save_gradients_to,
+        keep_gradients_in_memory=keep_gradients_in_memory,
+    )
     _ensure_layer_gradient_hooks(self)
 
     def run() -> Any:
@@ -402,18 +463,32 @@ def log_backward(self: Any, loss: torch.Tensor, **backward_kwargs: Any) -> Any:
         return loss.backward(**backward_kwargs)
 
     _run_backward_with_capture(self, loss, run)
+    _finalize_gradient_streaming(self)
     return self
 
 
 class RecordingBackward:
     """Context manager that captures every ``Tensor.backward`` call inside it."""
 
-    def __init__(self, model_log: Any) -> None:
+    def __init__(
+        self,
+        model_log: Any,
+        *,
+        save_gradients_to: str | None = None,
+        keep_gradients_in_memory: bool | None = None,
+    ) -> None:
         self.model_log = model_log
+        self.save_gradients_to = save_gradients_to
+        self.keep_gradients_in_memory = keep_gradients_in_memory
         self._original_backward: Callable[..., Any] | None = None
 
     def __enter__(self) -> "RecordingBackward":
         """Patch ``torch.Tensor.backward`` and return this context object."""
+        _configure_gradient_streaming(
+            self.model_log,
+            save_gradients_to=self.save_gradients_to,
+            keep_gradients_in_memory=self.keep_gradients_in_memory,
+        )
         _ensure_layer_gradient_hooks(self.model_log)
         self._original_backward = torch.Tensor.backward
         model_log = self.model_log
@@ -435,9 +510,16 @@ class RecordingBackward:
         """Restore ``torch.Tensor.backward``."""
         if self._original_backward is not None:
             torch.Tensor.backward = self._original_backward  # type: ignore[assignment]
+        if exc_type is None:
+            _finalize_gradient_streaming(self.model_log)
 
 
-def recording_backward(self: Any) -> RecordingBackward:
+def recording_backward(
+    self: Any,
+    *,
+    save_gradients_to: str | None = None,
+    keep_gradients_in_memory: bool | None = None,
+) -> RecordingBackward:
     """Return a context manager that records user-managed backward calls.
 
     Returns
@@ -445,4 +527,8 @@ def recording_backward(self: Any) -> RecordingBackward:
     RecordingBackward
         Context manager that patches ``Tensor.backward`` inside the block.
     """
-    return RecordingBackward(self)
+    return RecordingBackward(
+        self,
+        save_gradients_to=save_gradients_to,
+        keep_gradients_in_memory=keep_gradients_in_memory,
+    )

--- a/torchlens/data_classes/grad_fn_log.py
+++ b/torchlens/data_classes/grad_fn_log.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, Union
 
 import pandas as pd
 import torch
 
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..constants import GRAD_FN_LOG_FIELD_ORDER
 from .grad_fn_pass_log import GradFnPassLog
 
@@ -43,6 +44,21 @@ def _clone_grad_value(value: Any) -> Any:
 class GradFnLog:
     """Metadata and runtime passes for one autograd ``grad_fn`` node."""
 
+    PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
+        "grad_fn_id": FieldPolicy.KEEP,
+        "name": FieldPolicy.KEEP,
+        "module_path": FieldPolicy.KEEP,
+        "is_custom": FieldPolicy.KEEP,
+        "label": FieldPolicy.KEEP,
+        "grad_fn_type": FieldPolicy.KEEP,
+        "grad_fn_type_num": FieldPolicy.KEEP,
+        "grad_fn_total_num": FieldPolicy.KEEP,
+        "is_intervening": FieldPolicy.KEEP,
+        "corresponding_layer": FieldPolicy.KEEP,
+        "next_grad_fn_ids": FieldPolicy.KEEP,
+        "passes": FieldPolicy.KEEP,
+    }
+
     grad_fn_id: int
     name: str
     module_path: str
@@ -55,6 +71,26 @@ class GradFnLog:
     corresponding_layer: "LayerLog | None" = None
     next_grad_fn_ids: list[int] = field(default_factory=list)
     passes: dict[int, GradFnPassLog] = field(default_factory=dict)
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return pickle state with an IO format marker."""
+
+        state = self.__dict__.copy()
+        state["io_format_version"] = IO_FORMAT_VERSION
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickle state and fill fields added in newer versions."""
+
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(
+            state,
+            defaults={
+                "next_grad_fn_ids": [],
+                "passes": {},
+            },
+        )
+        self.__dict__.update(state)
 
     @property
     def num_passes(self) -> int:

--- a/torchlens/data_classes/grad_fn_pass_log.py
+++ b/torchlens/data_classes/grad_fn_pass_log.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 import pandas as pd
 
+from .._io import FieldPolicy, IO_FORMAT_VERSION, default_fill_state, read_io_format_version
 from ..constants import GRAD_FN_PASS_LOG_FIELD_ORDER
 
 
@@ -14,11 +15,41 @@ from ..constants import GRAD_FN_PASS_LOG_FIELD_ORDER
 class GradFnPassLog:
     """Runtime data for one execution of an autograd ``grad_fn`` node."""
 
+    PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
+        "pass_num": FieldPolicy.KEEP,
+        "grad_inputs": FieldPolicy.BLOB_RECURSIVE,
+        "grad_outputs": FieldPolicy.BLOB_RECURSIVE,
+        "time_started": FieldPolicy.KEEP,
+        "time_finished": FieldPolicy.KEEP,
+    }
+
     pass_num: int
     grad_inputs: Any = None
     grad_outputs: Any = None
     time_started: float | None = None
     time_finished: float | None = None
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return pickle state with an IO format marker."""
+
+        state = self.__dict__.copy()
+        state["io_format_version"] = IO_FORMAT_VERSION
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickle state and fill fields added in newer versions."""
+
+        read_io_format_version(state, cls_name=type(self).__name__)
+        default_fill_state(
+            state,
+            defaults={
+                "grad_inputs": None,
+                "grad_outputs": None,
+                "time_started": None,
+                "time_finished": None,
+            },
+        )
+        self.__dict__.update(state)
 
     def to_pandas(self) -> pd.DataFrame:
         """Export this pass as a one-row DataFrame.

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -224,8 +224,20 @@ class LayerPassLog:
         "activation_ref": FieldPolicy.DROP,
         "gradient_ref": FieldPolicy.DROP,
         "_pending_blob_id": FieldPolicy.DROP,
+        "_pending_gradient_blob_id": FieldPolicy.DROP,
         "parent_layer_log": FieldPolicy.DROP,
     }
+
+    def __getattribute__(self, name: str) -> Any:
+        """Materialize lazy gradients when the public ``gradient`` field is accessed."""
+
+        if name == "gradient":
+            state = object.__getattribute__(self, "__dict__")
+            gradient = state.get("gradient")
+            if gradient is None and state.get("gradient_ref") is not None:
+                return object.__getattribute__(self, "materialize_gradient")()
+            return gradient
+        return object.__getattribute__(self, name)
 
     def __init__(self, fields_dict: Dict):
         """Initialise from a complete fields dictionary.
@@ -418,6 +430,7 @@ class LayerPassLog:
         self.activation_ref: Optional["LazyActivationRef"] = None
         self.gradient_ref: Optional["LazyActivationRef"] = None
         self._pending_blob_id: Optional[str] = None
+        self._pending_gradient_blob_id: Optional[str] = None
         self.parent_layer_log: Optional["LayerLog"] = None
 
     @property
@@ -624,8 +637,9 @@ class LayerPassLog:
         torch.Size([2, 3])
         """
 
-        if isinstance(self.gradient, torch.Tensor):
-            return self.gradient
+        gradient = self.__dict__.get("gradient")
+        if isinstance(gradient, torch.Tensor):
+            return gradient
         if self.gradient_ref is None:
             raise TorchLensIOError("no gradient_ref to materialize from")
         self.gradient = self.gradient_ref.materialize(map_location=map_location)
@@ -649,6 +663,7 @@ class LayerPassLog:
                 "activation_ref": None,
                 "gradient_ref": None,
                 "_pending_blob_id": None,
+                "_pending_gradient_blob_id": None,
             },
         )
         self.__dict__.update(state)
@@ -816,6 +831,16 @@ class LayerPassLog:
         self.grad_shape = grad_to_save.shape
         self.grad_dtype = grad_to_save.dtype
         self.grad_memory = get_tensor_memory_amount(grad_to_save)
+        writer = getattr(model_log, "_activation_writer", None) if model_log is not None else None
+        if writer is not None and getattr(model_log, "_defer_streaming_bundle_finalization", False):
+            blob_id = writer.next_blob_id()
+            self._pending_gradient_blob_id = blob_id
+            writer.write_blob(
+                blob_id,
+                self.gradient,
+                kind="gradient",
+                label=self._streaming_label,
+            )
 
     # ********************************************
     # ************* Fetcher Functions ************

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -235,6 +235,8 @@ class ModelLog:
         "_pre_forward_rng_states": FieldPolicy.DROP,
         "_activation_writer": FieldPolicy.DROP,
         "_keep_activations_in_memory": FieldPolicy.DROP,
+        "_keep_gradients_in_memory": FieldPolicy.DROP,
+        "_defer_streaming_bundle_finalization": FieldPolicy.DROP,
         "_activation_sink": FieldPolicy.DROP,
         "_in_exhaustive_pass": FieldPolicy.DROP,
         "pass_start_time": FieldPolicy.KEEP,
@@ -340,6 +342,8 @@ class ModelLog:
         self.mark_input_output_distances = mark_input_output_distances
         self._activation_writer: Optional["BundleStreamWriter"] = None
         self._keep_activations_in_memory: bool = True
+        self._keep_gradients_in_memory: bool = True
+        self._defer_streaming_bundle_finalization: bool = False
         self._activation_sink: Optional[Callable[[str, torch.Tensor], None]] = None
         self._in_exhaustive_pass: bool = True
 
@@ -563,6 +567,8 @@ class ModelLog:
                 "_module_build_data": None,
                 "_activation_writer": None,
                 "_keep_activations_in_memory": True,
+                "_keep_gradients_in_memory": True,
+                "_defer_streaming_bundle_finalization": False,
                 "_activation_sink": None,
                 "_in_exhaustive_pass": False,
                 "_source_code_blob": {},
@@ -593,6 +599,11 @@ class ModelLog:
         for grad_fn in self.grad_fn_logs.values():
             if isinstance(grad_fn.corresponding_layer, str):
                 grad_fn.corresponding_layer = self.layer_logs.get(grad_fn.corresponding_layer)
+            if grad_fn.corresponding_layer is not None:
+                grad_fn.corresponding_layer.corresponding_grad_fn = grad_fn
+                if hasattr(grad_fn.corresponding_layer, "passes"):
+                    for layer_pass in grad_fn.corresponding_layer.passes.values():
+                        layer_pass.corresponding_grad_fn = grad_fn
 
     # ********************************************
     # ********** Computed Properties *************

--- a/torchlens/postprocess/__init__.py
+++ b/torchlens/postprocess/__init__.py
@@ -196,7 +196,9 @@ def postprocess(
     with _vtimed(self, "  Step 18: Mark pass finished"):
         _set_pass_finished(self)
 
-    should_finalize_streaming = self._activation_writer is not None
+    should_finalize_streaming = self._activation_writer is not None and not getattr(
+        self, "_defer_streaming_bundle_finalization", False
+    )
     if should_finalize_streaming:
         with _vtimed(self, "  Step 19: Finalize streamed bundle"):
             _finalize_streamed_bundle(self)
@@ -260,7 +262,9 @@ def postprocess_fast(self: "ModelLog") -> None:
     # in fast mode (Step 10 is skipped). Existing module logs remain valid. (#108)
     _set_pass_finished(self)
 
-    should_finalize_streaming = self._activation_writer is not None
+    should_finalize_streaming = self._activation_writer is not None and not getattr(
+        self, "_defer_streaming_bundle_finalization", False
+    )
     if should_finalize_streaming:
         _finalize_streamed_bundle(self)
     if should_finalize_streaming and not self._keep_activations_in_memory:

--- a/torchlens/postprocess/finalization.py
+++ b/torchlens/postprocess/finalization.py
@@ -21,7 +21,7 @@ Step 18 (_set_pass_finished): Marks ModelLog and all LayerPassLogs as finished, 
 import time
 from collections import defaultdict, deque
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, TYPE_CHECKING, Tuple
+from typing import Dict, List, Literal, NamedTuple, Optional, TYPE_CHECKING, Tuple, cast
 
 import torch
 
@@ -790,7 +790,7 @@ def _set_pass_finished(self) -> None:
 
 
 def _finalize_streamed_bundle(self: "ModelLog") -> None:
-    """Step 19: Finalize any in-progress streamed activation bundle.
+    """Step 19: Finalize any in-progress streamed tensor bundle.
 
     Parameters
     ----------
@@ -816,7 +816,7 @@ def _finalize_streamed_bundle(self: "ModelLog") -> None:
         include_captured_args=self.save_function_args,
         include_rng_states=self.save_rng_states,
     )
-    scrubbed_state, blob_specs = _reuse_streamed_activation_blob_ids(
+    scrubbed_state, blob_specs = _reuse_streamed_blob_ids(
         self,
         scrubbed_state=scrubbed_state,
         blob_specs=blob_specs,
@@ -831,10 +831,11 @@ def _finalize_streamed_bundle(self: "ModelLog") -> None:
         "_source_bundle_manifest_sha256",
         sha256_of_file(Path(final_path) / "manifest.json"),
     )
-    _attach_streamed_activation_refs(
+    _attach_streamed_tensor_refs(
         self, scrubbed_state=scrubbed_state, writer=writer, final_path=final_path
     )
     self._activation_writer = None
+    self._defer_streaming_bundle_finalization = False
 
 
 def _evict_streamed_activations(self: "ModelLog") -> None:
@@ -851,14 +852,28 @@ def _evict_streamed_activations(self: "ModelLog") -> None:
             layer_entry.activation = None
 
 
-def _reuse_streamed_activation_blob_ids(
+def _evict_streamed_gradients(self: "ModelLog") -> None:
+    """Drop in-memory gradients once streaming refs have been attached.
+
+    Parameters
+    ----------
+    self:
+        Model log whose streamed gradients should be evicted.
+    """
+
+    for layer_entry in self.layer_list:
+        if getattr(layer_entry, "gradient_ref", None) is not None:
+            layer_entry.gradient = None
+
+
+def _reuse_streamed_blob_ids(
     model_log: "ModelLog",
     *,
     scrubbed_state: dict,
     blob_specs: list[tuple[str, torch.Tensor, str, str]],
     writer: BundleStreamWriter,
 ) -> tuple[dict, list[tuple[str, torch.Tensor, str, str]]]:
-    """Patch scrubbed activation refs to reuse blob ids written during capture.
+    """Patch scrubbed tensor refs to reuse blob ids written during capture.
 
     Parameters
     ----------
@@ -885,28 +900,36 @@ def _reuse_streamed_activation_blob_ids(
 
     skipped_blob_ids: set[str] = set()
     for live_layer, scrubbed_layer in zip(model_log.layer_list, scrubbed_layers):
-        activation_blob = getattr(scrubbed_layer, "activation", None)
-        if not isinstance(activation_blob, BlobRef):
-            continue
-        pending_blob_id = getattr(live_layer, "_pending_blob_id", None)
-        if pending_blob_id is None:
-            continue
-        skipped_blob_ids.add(activation_blob.blob_id)
-        scrubbed_layer.activation = BlobRef(blob_id=pending_blob_id, kind=activation_blob.kind)
-        writer.relabel_blob(pending_blob_id, live_layer._streaming_label)
+        for tensor_field, pending_field in (
+            ("activation", "_pending_blob_id"),
+            ("gradient", "_pending_gradient_blob_id"),
+        ):
+            tensor_blob = getattr(scrubbed_layer, tensor_field, None)
+            if not isinstance(tensor_blob, BlobRef):
+                continue
+            pending_blob_id = getattr(live_layer, pending_field, None)
+            if pending_blob_id is None:
+                continue
+            skipped_blob_ids.add(tensor_blob.blob_id)
+            setattr(
+                scrubbed_layer,
+                tensor_field,
+                BlobRef(blob_id=pending_blob_id, kind=tensor_blob.kind),
+            )
+            writer.relabel_blob(pending_blob_id, live_layer._streaming_label)
 
     filtered_blob_specs = [spec for spec in blob_specs if spec[0] not in skipped_blob_ids]
     return scrubbed_state, filtered_blob_specs
 
 
-def _attach_streamed_activation_refs(
+def _attach_streamed_tensor_refs(
     model_log: "ModelLog",
     *,
     scrubbed_state: dict,
     writer: BundleStreamWriter,
     final_path: str | Path,
 ) -> None:
-    """Attach ``LazyActivationRef`` placeholders for persisted activation blobs.
+    """Attach ``LazyActivationRef`` placeholders for persisted direct tensor blobs.
 
     Parameters
     ----------
@@ -928,20 +951,28 @@ def _attach_streamed_activation_refs(
         )
 
     for live_layer, scrubbed_layer in zip(model_log.layer_list, scrubbed_layers):
-        activation_blob = getattr(scrubbed_layer, "activation", None)
-        if not isinstance(activation_blob, BlobRef):
-            continue
-        manifest_entry = writer.get_entry(activation_blob.blob_id)
-        live_layer.activation_ref = LazyActivationRef(
-            blob_id=manifest_entry.blob_id,
-            shape=tuple(manifest_entry.shape),
-            dtype=_dtype_from_manifest_string(manifest_entry.dtype),
-            device_at_save=manifest_entry.device_at_save,
-            source_bundle_path=Path(final_path),
-            relative_path=manifest_entry.relative_path,
-            kind="activation",
-            expected_sha256=manifest_entry.sha256,
-        )
+        for tensor_field, ref_field, kind in (
+            ("activation", "activation_ref", "activation"),
+            ("gradient", "gradient_ref", "gradient"),
+        ):
+            tensor_blob = getattr(scrubbed_layer, tensor_field, None)
+            if not isinstance(tensor_blob, BlobRef):
+                continue
+            manifest_entry = writer.get_entry(tensor_blob.blob_id)
+            setattr(
+                live_layer,
+                ref_field,
+                LazyActivationRef(
+                    blob_id=manifest_entry.blob_id,
+                    shape=tuple(manifest_entry.shape),
+                    dtype=_dtype_from_manifest_string(manifest_entry.dtype),
+                    device_at_save=manifest_entry.device_at_save,
+                    source_bundle_path=Path(final_path),
+                    relative_path=manifest_entry.relative_path,
+                    kind=cast(Literal["activation", "gradient"], kind),
+                    expected_sha256=manifest_entry.sha256,
+                ),
+            )
 
 
 def _dtype_from_manifest_string(dtype_name: str) -> torch.dtype:

--- a/torchlens/user_funcs.py
+++ b/torchlens/user_funcs.py
@@ -41,7 +41,7 @@ from ._literals import (
     VisNodePlacementLiteral,
     VisRendererLiteral,
 )
-from ._training_validation import validate_training_compatibility
+from ._training_validation import TrainingModeConfigError, validate_training_compatibility
 from .data_classes.model_log import (
     ModelLog,
 )
@@ -221,6 +221,8 @@ def _run_model_and_save_specified_activations(
     detect_loops: bool = True,
     save_activations_to: str | Path | None = None,
     keep_activations_in_memory: bool = True,
+    save_gradients_to: str | Path | None = None,
+    keep_gradients_in_memory: bool = True,
     activation_sink: Callable[[str, torch.Tensor], None] | None = None,
     verbose: bool = False,
     train_mode: bool = False,
@@ -265,6 +267,9 @@ def _run_model_and_save_specified_activations(
         save_activations_to: Optional portable bundle directory for streaming activation save.
         keep_activations_in_memory: Whether streamed activations should remain in memory
             after finalization.
+        save_gradients_to: Optional portable bundle directory for streaming gradient save.
+        keep_gradients_in_memory: Whether streamed gradients should remain in memory after
+            backward finalization.
         activation_sink: Optional callback invoked with ``(label, tensor)`` for each
             saved activation.
         verbose: If True, print timed progress messages at each major pipeline stage.
@@ -306,9 +311,12 @@ def _run_model_and_save_specified_activations(
     model_log._source_model_ref = make_weak_model_ref(model)
     model_log._activation_sink = activation_sink
     model_log._keep_activations_in_memory = keep_activations_in_memory
+    model_log._keep_gradients_in_memory = keep_gradients_in_memory
+    model_log._defer_streaming_bundle_finalization = save_gradients_to is not None
     model_log._in_exhaustive_pass = True
-    if save_activations_to is not None:
-        model_log._activation_writer = BundleStreamWriter(save_activations_to)
+    bundle_path = save_gradients_to if save_gradients_to is not None else save_activations_to
+    if bundle_path is not None:
+        model_log._activation_writer = BundleStreamWriter(bundle_path)
     try:
         model_log._run_and_log_inputs_through_model(
             model, input_args, input_kwargs, layers_to_save, gradients_to_save, random_seed
@@ -360,6 +368,8 @@ def log_forward_pass(
     detect_loops: bool | MissingType = MISSING,
     save_activations_to: str | Path | None | MissingType = MISSING,
     keep_activations_in_memory: bool | MissingType = MISSING,
+    save_gradients_to: str | Path | None | MissingType = MISSING,
+    keep_gradients_in_memory: bool | MissingType = MISSING,
     activation_sink: Callable[[str, torch.Tensor], None] | None | MissingType = MISSING,
     unwrap_when_done: bool = False,
     verbose: bool = False,
@@ -460,6 +470,11 @@ def log_forward_pass(
         save_activations_to: Deprecated alias for ``streaming.bundle_path``.
         keep_activations_in_memory: Deprecated alias for
             ``streaming.retain_in_memory``.
+        save_gradients_to: Optional portable bundle directory for streaming saved gradients.
+            If omitted while ``save_activations_to`` is set and gradient capture is enabled,
+            gradients are written into the same bundle path.
+        keep_gradients_in_memory: Whether streamed gradients should remain in memory after
+            ``log_backward`` or ``recording_backward`` finalizes the bundle.
         activation_sink: Deprecated alias for ``streaming.activation_callback``.
         unwrap_when_done: If True, restore original torch callables after logging.
             Default False - torch stays wrapped for subsequent calls.
@@ -533,6 +548,12 @@ def log_forward_pass(
         keep_activations_in_memory=keep_activations_in_memory,
         activation_sink=activation_sink,
     )
+    save_gradients_to_value = (
+        None if isinstance(save_gradients_to, MissingType) else save_gradients_to
+    )
+    keep_gradients_in_memory_value = (
+        True if isinstance(keep_gradients_in_memory, MissingType) else keep_gradients_in_memory
+    )
 
     if visualization_options.mode not in ["none", "rolled", "unrolled"]:
         raise ValueError("Visualization option must be either 'none', 'rolled', or 'unrolled'.")
@@ -550,6 +571,9 @@ def log_forward_pass(
     else:
         train_mode_value = train_mode
     backward_opted_in = gradients_to_save is not MISSING
+    gradient_streaming_requested = save_gradients_to_value is not None
+    if gradient_streaming_requested:
+        save_gradients = True
     if backward_opted_in:
         if train_mode_explicit and train_mode_value is False:
             raise ValueError(
@@ -561,6 +585,22 @@ def log_forward_pass(
     gradients_to_save_resolved = (
         layers_to_save if gradients_to_save is MISSING else gradients_to_save
     )
+    if (
+        save_gradients
+        and save_gradients_to_value is None
+        and streaming_options.bundle_path is not None
+    ):
+        save_gradients_to_value = streaming_options.bundle_path
+    if (
+        save_gradients_to_value is not None
+        and streaming_options.bundle_path is not None
+        and Path(save_gradients_to_value) != Path(streaming_options.bundle_path)
+    ):
+        raise ValueError("save_activations_to and save_gradients_to must use the same bundle path.")
+    if train_mode_value and save_gradients_to_value is not None:
+        raise TrainingModeConfigError(
+            "train_mode=True is not compatible with slow/replay gradient disk saves"
+        )
 
     validate_training_compatibility(
         train_mode=train_mode_value,
@@ -583,6 +623,11 @@ def log_forward_pass(
             "release. For selective streaming use activation_sink=callable, or capture "
             'with layers_to_save="all" and filter post-hoc with '
             "torchlens.save(..., include_activations=True)."
+        )
+    if save_gradients_to_value is not None and uses_two_pass:
+        raise TorchLensIOError(
+            'save_gradients_to is only supported with gradients_to_save="all" in this '
+            "release. Capture all gradients and filter post-hoc with torchlens.save(...)."
         )
 
     if not uses_two_pass:
@@ -610,6 +655,8 @@ def log_forward_pass(
             detect_loops=detect_recurrent_patterns,
             save_activations_to=streaming_options.bundle_path,
             keep_activations_in_memory=streaming_options.retain_in_memory,
+            save_gradients_to=save_gradients_to_value,
+            keep_gradients_in_memory=keep_gradients_in_memory_value,
             activation_sink=streaming_options.activation_callback,
             verbose=verbose,
             train_mode=train_mode_value,
@@ -643,6 +690,8 @@ def log_forward_pass(
             detect_loops=detect_recurrent_patterns,
             save_activations_to=streaming_options.bundle_path,
             keep_activations_in_memory=streaming_options.retain_in_memory,
+            save_gradients_to=save_gradients_to_value,
+            keep_gradients_in_memory=keep_gradients_in_memory_value,
             activation_sink=streaming_options.activation_callback,
             verbose=verbose,
             train_mode=train_mode_value,


### PR DESCRIPTION
PR 3 of 3 (final) for the backward-pass first-class support sprint.

Summary:
- Adds gradient streaming to disk parallel to activation streaming.
  - New controls: save_gradients_to and keep_gradients_in_memory.
  - Wires LazyActivationRef end-to-end for streamed gradients.
  - Bundle save/load round-trips backward data, GradFnLog/GradFnPassLog state, cross-references, and lazy gradients.
- Adds notebooks/backward_tutorial.ipynb covering the backward-pass patterns from PR 1, PR 2, and PR 3.
- Sprint complete; remaining deferred items stay in todos.md parking lot.