### PR TITLE
feat(data-classes): add extra_data dict to layer logs and input_metadata to ModelLog

### DIFF
--- a/tests/test_extra_data_plumbing.py
+++ b/tests/test_extra_data_plumbing.py
@@ -1,0 +1,128 @@
+"""Tests for user-managed annotation dictionaries on TorchLens logs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.constants import (
+    LAYER_LOG_FIELD_ORDER,
+    LAYER_PASS_LOG_FIELD_ORDER,
+    MODEL_LOG_FIELD_ORDER,
+)
+from torchlens.data_classes.layer_log import LayerLog
+from torchlens.data_classes.layer_pass_log import LayerPassLog
+from torchlens.data_classes.model_log import ModelLog
+
+
+class TinyExtraDataModel(nn.Module):
+    """Tiny deterministic model for extra-data plumbing tests."""
+
+    def __init__(self) -> None:
+        """Initialize the model's only learnable layer."""
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run one linear layer followed by ReLU."""
+        return torch.relu(self.linear(x))
+
+
+def _fresh_log() -> ModelLog:
+    """Create a small fresh model log."""
+    torch.manual_seed(0)
+    model = TinyExtraDataModel()
+    inputs = torch.ones(1, 2)
+    return tl.log_forward_pass(model, inputs, layers_to_save="all", random_seed=0)
+
+
+def _first_logs(model_log: ModelLog) -> Tuple[LayerPassLog, LayerLog]:
+    """Return one layer-pass log and its aggregate layer log."""
+    layer_pass_log = model_log.layer_list[0]
+    layer_log = model_log.layer_logs[layer_pass_log.layer_label_no_pass]
+    return layer_pass_log, layer_log
+
+
+@pytest.mark.smoke
+def test_extra_data_fields_default_to_empty_dicts() -> None:
+    """New annotation fields should default to independent empty dictionaries."""
+    model_log = _fresh_log()
+    layer_pass_log, layer_log = _first_logs(model_log)
+
+    assert model_log.input_metadata == {}
+    assert isinstance(model_log.input_metadata, dict)
+    assert layer_pass_log.extra_data == {}
+    assert isinstance(layer_pass_log.extra_data, dict)
+    assert layer_log.extra_data == {}
+    assert isinstance(layer_log.extra_data, dict)
+
+
+def test_extra_data_fields_accept_arbitrary_python_objects() -> None:
+    """Annotation dictionaries should accept user-owned Python objects without validation."""
+    model_log = _fresh_log()
+    layer_pass_log, layer_log = _first_logs(model_log)
+    array = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    model_log.input_metadata["stimulus"] = {"text": "hello", "tokens": [1, 2, 3]}
+    layer_pass_log.extra_data.update({"scores": [0.1, 0.2], "array": array})
+    layer_log.extra_data["note"] = "layer-level annotation"
+
+    assert model_log.input_metadata["stimulus"]["tokens"] == [1, 2, 3]
+    assert layer_pass_log.extra_data["scores"] == [0.1, 0.2]
+    np.testing.assert_array_equal(layer_pass_log.extra_data["array"], array)
+    assert layer_log.extra_data["note"] == "layer-level annotation"
+
+
+def test_extra_data_fields_do_not_share_dict_state_between_logs() -> None:
+    """Mutating one log's annotation dictionaries should not affect another log."""
+    first_log = _fresh_log()
+    second_log = _fresh_log()
+    first_layer_pass, first_layer_log = _first_logs(first_log)
+    second_layer_pass, second_layer_log = _first_logs(second_log)
+
+    first_log.input_metadata["id"] = "first"
+    first_layer_pass.extra_data["pass"] = "first"
+    first_layer_log.extra_data["layer"] = "first"
+
+    assert second_log.input_metadata == {}
+    assert second_layer_pass.extra_data == {}
+    assert second_layer_log.extra_data == {}
+
+
+def test_extra_data_fields_are_in_field_order_constants() -> None:
+    """New fields should be present in each class's canonical FIELD_ORDER."""
+    assert "input_metadata" in MODEL_LOG_FIELD_ORDER
+    assert "extra_data" in LAYER_PASS_LOG_FIELD_ORDER
+    assert "extra_data" in LAYER_LOG_FIELD_ORDER
+
+
+def test_extra_data_fields_roundtrip_through_bundle_save_load(tmp_path: Path) -> None:
+    """User annotations should survive portable bundle save/load."""
+    model_log = _fresh_log()
+    layer_pass_log, layer_log = _first_logs(model_log)
+    array = np.array([1, 2, 3])
+
+    model_log.input_metadata["stimulus"] = {"word": "torchlens", "index": 7}
+    layer_pass_log.extra_data["custom_metric"] = {"values": [1.0, 2.0], "label": "pass"}
+    layer_pass_log.extra_data["array"] = array
+    layer_log.extra_data["rdm"] = {"shape": [2, 2], "label": "layer"}
+
+    bundle_path = tmp_path / "extra_data.tl"
+    tl.save(model_log, bundle_path)
+    loaded = tl.load(bundle_path)
+    loaded_layer_pass = loaded.layer_list[0]
+    loaded_layer_log = loaded.layer_logs[loaded_layer_pass.layer_label_no_pass]
+
+    assert loaded.input_metadata == {"stimulus": {"word": "torchlens", "index": 7}}
+    assert loaded_layer_pass.extra_data["custom_metric"] == {
+        "values": [1.0, 2.0],
+        "label": "pass",
+    }
+    np.testing.assert_array_equal(loaded_layer_pass.extra_data["array"], array)
+    assert loaded_layer_log.extra_data == {"rdm": {"shape": [2, 2], "label": "layer"}}

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -932,6 +932,7 @@ def _log_output_tensor_info(
     fields_dict["activation"] = None
     fields_dict["has_saved_activations"] = False
     fields_dict["activation_postfunc"] = self.activation_postfunc
+    fields_dict["extra_data"] = {}
     fields_dict["args_captured"] = False
     fields_dict["captured_args"] = None
     fields_dict["captured_kwargs"] = None

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -223,6 +223,7 @@ def log_source_tensor_exhaustive(
         "activation": None,
         "has_saved_activations": False,
         "activation_postfunc": self.activation_postfunc,
+        "extra_data": {},
         "detach_saved_tensor": self.detach_saved_tensors,
         "output_device": self.output_device,
         "args_captured": False,

--- a/torchlens/constants.py
+++ b/torchlens/constants.py
@@ -58,6 +58,7 @@ MODEL_LOG_FIELD_ORDER = [
     "has_gradients",
     "activation_postfunc",
     "activation_postfunc_repr",
+    "input_metadata",
     "_source_code_blob",
     "_source_model_ref",
     "mark_input_output_distances",
@@ -165,6 +166,7 @@ LAYER_PASS_LOG_FIELD_ORDER = [
     "has_saved_activations",
     "output_device",
     "activation_postfunc",
+    "extra_data",
     "detach_saved_tensor",
     "args_captured",
     "captured_args",
@@ -316,6 +318,7 @@ LAYER_LOG_FIELD_ORDER = [
     # Config
     "output_device",
     "activation_postfunc",
+    "extra_data",
     "detach_saved_tensor",
     "save_gradients",
     # FLOPs

--- a/torchlens/data_classes/layer_log.py
+++ b/torchlens/data_classes/layer_log.py
@@ -86,6 +86,7 @@ class LayerLog:
         "tensor_memory": FieldPolicy.KEEP,
         "output_device": FieldPolicy.KEEP,
         "activation_postfunc": FieldPolicy.DROP,
+        "extra_data": FieldPolicy.KEEP,
         "detach_saved_tensor": FieldPolicy.KEEP,
         "save_gradients": FieldPolicy.KEEP,
         "flops_forward": FieldPolicy.KEEP,
@@ -173,6 +174,7 @@ class LayerLog:
         # Config
         self.output_device = first_pass.output_device
         self.activation_postfunc = first_pass.activation_postfunc
+        self.extra_data: Dict[str, Any] = {}
         self.detach_saved_tensor = first_pass.detach_saved_tensor
         self.save_gradients = first_pass.save_gradients
 
@@ -299,7 +301,7 @@ class LayerLog:
     def __setstate__(self, state: Dict[str, Any]) -> None:
         """Restore pickle state produced by ``__getstate__``."""
         read_io_format_version(state, cls_name=type(self).__name__)
-        default_fill_state(state, defaults={"_source_model_log_ref": None})
+        default_fill_state(state, defaults={"_source_model_log_ref": None, "extra_data": {}})
         self.__dict__.update(state)
 
     # ********************************************

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -117,6 +117,7 @@ class LayerPassLog:
         "has_saved_activations": FieldPolicy.KEEP,
         "output_device": FieldPolicy.KEEP,
         "activation_postfunc": FieldPolicy.DROP,
+        "extra_data": FieldPolicy.KEEP,
         "detach_saved_tensor": FieldPolicy.KEEP,
         "args_captured": FieldPolicy.KEEP,
         "captured_args": FieldPolicy.BLOB_RECURSIVE,
@@ -290,6 +291,7 @@ class LayerPassLog:
         self.has_saved_activations = fields_dict["has_saved_activations"]
         self.output_device = fields_dict["output_device"]
         self.activation_postfunc = fields_dict["activation_postfunc"]
+        self.extra_data: Dict[str, Any] = fields_dict["extra_data"]
         self.detach_saved_tensor = fields_dict["detach_saved_tensor"]
         self.args_captured = fields_dict["args_captured"]
         self.captured_args = fields_dict["captured_args"]
@@ -664,6 +666,7 @@ class LayerPassLog:
                 "gradient_ref": None,
                 "_pending_blob_id": None,
                 "_pending_gradient_blob_id": None,
+                "extra_data": {},
             },
         )
         self.__dict__.update(state)

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -152,6 +152,7 @@ class ModelLog:
         "keep_unsaved_layers": FieldPolicy.KEEP,
         "activation_postfunc": FieldPolicy.DROP,
         "activation_postfunc_repr": FieldPolicy.KEEP,
+        "input_metadata": FieldPolicy.KEEP,
         "_source_code_blob": FieldPolicy.KEEP,
         "_source_model_ref": FieldPolicy.DROP,
         "current_function_call_barcode": FieldPolicy.KEEP,
@@ -320,6 +321,7 @@ class ModelLog:
         self.activation_postfunc_repr = (
             repr(activation_postfunc) if activation_postfunc is not None else None
         )
+        self.input_metadata: Dict[str, Any] = {}
         self.gradient_postfunc = gradient_postfunc
         self.gradient_postfunc_repr = (
             repr(gradient_postfunc) if gradient_postfunc is not None else None
@@ -551,6 +553,7 @@ class ModelLog:
             defaults={
                 "io_format_version": IO_FORMAT_VERSION,
                 "activation_postfunc_repr": None,
+                "input_metadata": {},
                 "gradient_postfunc": None,
                 "gradient_postfunc_repr": None,
                 "gradients_to_save": "all",


### PR DESCRIPTION
## Summary
- Add `LayerLog.extra_data: Dict[str, Any]` for user-managed layer annotations.
- Add `LayerPassLog.extra_data: Dict[str, Any]` for user-managed per-pass annotations.
- Add `ModelLog.input_metadata: Dict[str, Any]` for user-managed input stimulus metadata.

No automatic population this sprint -- users mutate the dicts after the forward pass.

No visualization integration -- deferred to a later sprint.

FIELD_ORDER placement: the new fields sit next to `activation_postfunc`/saved-tensor config because they are user-facing annotation metadata on the same log surfaces.

## Tests
- `ruff format .`
- `ruff check . --fix`
- `mypy torchlens/`
- `pytest tests/ -m smoke -x --tb=short`
- `pytest tests/test_extra_data_plumbing.py -v`
