### PR TITLE
feat(capture): add autograd_saved_bytes field tracking per-op autograd memory

### DIFF
--- a/tests/test_autograd_saved_bytes.py
+++ b/tests/test_autograd_saved_bytes.py
@@ -1,0 +1,206 @@
+"""Tests for per-op autograd saved tensor memory accounting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.capture.output_tensors import _get_autograd_saved_stats_for_tensor
+from torchlens.data_classes.layer_log import LayerLog
+from torchlens.data_classes.layer_pass_log import LayerPassLog
+from torchlens.data_classes.model_log import ModelLog
+
+
+class TinySequentialModel(nn.Module):
+    """Small model with parameterized and activation ops."""
+
+    def __init__(self) -> None:
+        """Initialize the sequential test layers."""
+        super().__init__()
+        self.layers = nn.Sequential(nn.Linear(10, 20), nn.ReLU(), nn.Linear(20, 5))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the sequential layers."""
+        return self.layers(x)
+
+
+class TinyAddModel(nn.Module):
+    """Small model that exposes an add operation."""
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Add two tensors."""
+        return x + y
+
+
+class SaveInputFunction(torch.autograd.Function):
+    """Custom autograd function that saves its input for backward."""
+
+    @staticmethod
+    def forward(ctx: torch.autograd.function.FunctionCtx, x: torch.Tensor) -> torch.Tensor:
+        """Save the input tensor and return a scaled output."""
+        ctx.save_for_backward(x)
+        return x * 2
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx, grad_output: torch.Tensor
+    ) -> torch.Tensor:
+        """Return a simple gradient using the saved input."""
+        (saved_x,) = ctx.saved_tensors
+        return grad_output * saved_x
+
+
+def _log_sequential(requires_grad: bool = True) -> ModelLog:
+    """Return a logged pass through the tiny sequential model."""
+    torch.manual_seed(0)
+    model = TinySequentialModel()
+    x = torch.randn(4, 10, requires_grad=requires_grad)
+    return tl.log_forward_pass(model, x, layers_to_save="all", random_seed=0)
+
+
+def _non_source_passes(model_log: ModelLog) -> list[LayerPassLog]:
+    """Return operation logs, excluding synthetic source and output nodes."""
+    return [
+        layer
+        for layer in model_log.layer_list
+        if layer.layer_type not in {"input", "buffer", "output"}
+    ]
+
+
+def _single_layer_log_for_pass(model_log: ModelLog, pass_log: LayerPassLog) -> LayerLog:
+    """Return the aggregate LayerLog for a pass log."""
+    return model_log.layer_logs[pass_log.layer_label_no_pass]
+
+
+def _sum_layer_autograd_bytes(model_log: ModelLog) -> Optional[int]:
+    """Sum non-None layer-level autograd byte values."""
+    values = [
+        layer.autograd_saved_bytes
+        for layer in model_log.layer_logs.values()
+        if layer.autograd_saved_bytes is not None
+    ]
+    if not values:
+        return None
+    return sum(values)
+
+
+@pytest.mark.smoke
+def test_autograd_saved_bytes_basic_shape_model() -> None:
+    """Linear and ReLU ops should report autograd saved tensor memory."""
+    model_log = _log_sequential(requires_grad=True)
+
+    linear_passes = [layer for layer in model_log.layer_list if layer.layer_type == "linear"]
+    relu_passes = [layer for layer in model_log.layer_list if layer.layer_type == "relu"]
+
+    assert linear_passes
+    assert relu_passes
+    assert all(layer.autograd_saved_bytes is not None for layer in linear_passes)
+    assert all(layer.autograd_saved_bytes > 0 for layer in linear_passes)
+    assert all(layer.autograd_saved_tensor_count is not None for layer in linear_passes)
+    assert all(layer.autograd_saved_tensor_count > 0 for layer in linear_passes)
+    assert relu_passes[0].autograd_saved_bytes is not None
+    assert relu_passes[0].autograd_saved_bytes >= 0
+    assert relu_passes[0].autograd_saved_tensor_count is not None
+    assert relu_passes[0].autograd_saved_tensor_count >= 0
+
+
+def test_add_op_reports_zero_autograd_saved_bytes() -> None:
+    """Add should have a grad_fn but save no tensors for backward."""
+    model = TinyAddModel()
+    x = torch.ones(2, 3, requires_grad=True)
+    y = torch.ones(2, 3, requires_grad=True)
+    model_log = tl.log_forward_pass(model, (x, y), layers_to_save="all")
+    add_pass = next(layer for layer in model_log.layer_list if layer.layer_type == "add")
+
+    assert add_pass.grad_fn_id is not None
+    assert add_pass.autograd_saved_bytes == 0
+    assert add_pass.autograd_saved_tensor_count == 0
+    assert model_log.layer_logs[add_pass.layer_label_no_pass].autograd_saved_bytes == 0
+    assert model_log.total_autograd_saved_bytes == 0
+
+
+def test_no_grad_sets_autograd_saved_fields_to_none() -> None:
+    """torch.no_grad should produce None autograd saved fields at every level."""
+    torch.manual_seed(0)
+    model = TinySequentialModel()
+    x = torch.randn(4, 10, requires_grad=True)
+
+    with torch.no_grad():
+        model_log = tl.log_forward_pass(model, x, layers_to_save="all", random_seed=0)
+
+    assert all(layer.autograd_saved_bytes is None for layer in model_log.layer_list)
+    assert all(layer.autograd_saved_tensor_count is None for layer in model_log.layer_list)
+    assert all(layer.autograd_saved_bytes is None for layer in model_log.layer_logs.values())
+    assert all(layer.autograd_saved_tensor_count is None for layer in model_log.layer_logs.values())
+    assert model_log.total_autograd_saved_bytes is None
+
+
+def test_requires_grad_false_sets_autograd_saved_fields_to_none() -> None:
+    """Inputs without requires_grad should not create grad_fn-backed saved fields."""
+    torch.manual_seed(0)
+    model = TinySequentialModel()
+    for parameter in model.parameters():
+        parameter.requires_grad_(False)
+    x = torch.randn(4, 10, requires_grad=False)
+    model_log = tl.log_forward_pass(model, x, layers_to_save="all", random_seed=0, train_mode=True)
+
+    assert all(layer.autograd_saved_bytes is None for layer in _non_source_passes(model_log))
+    assert all(layer.autograd_saved_tensor_count is None for layer in _non_source_passes(model_log))
+    assert all(layer.autograd_saved_bytes is None for layer in model_log.layer_logs.values())
+    assert model_log.total_autograd_saved_bytes is None
+
+
+def test_layer_log_autograd_saved_rollup_matches_pass_values() -> None:
+    """LayerLog values should equal the sum of their pass-level values."""
+    model_log = _log_sequential(requires_grad=True)
+
+    for pass_log in _non_source_passes(model_log):
+        layer_log = _single_layer_log_for_pass(model_log, pass_log)
+        assert layer_log.autograd_saved_bytes == pass_log.autograd_saved_bytes
+        assert layer_log.autograd_saved_tensor_count == pass_log.autograd_saved_tensor_count
+
+
+def test_model_log_autograd_saved_rollup_matches_layer_values() -> None:
+    """ModelLog total should equal the sum of non-None layer-level values."""
+    model_log = _log_sequential(requires_grad=True)
+
+    assert model_log.total_autograd_saved_bytes == _sum_layer_autograd_bytes(model_log)
+
+
+def test_custom_autograd_function_saved_tensor_bytes() -> None:
+    """Custom autograd.Function saved_tensors should be measured by introspection."""
+    x = torch.randn(2, 3, requires_grad=True)
+    output = SaveInputFunction.apply(x)
+    expected_bytes = x.numel() * x.element_size()
+
+    autograd_saved_bytes, autograd_saved_tensor_count = _get_autograd_saved_stats_for_tensor(output)
+
+    assert autograd_saved_bytes == expected_bytes
+    assert autograd_saved_tensor_count == 1
+
+
+def test_autograd_saved_fields_roundtrip_through_bundle_save_load(tmp_path: Path) -> None:
+    """Autograd saved byte fields should survive portable bundle save/load."""
+    model_log = _log_sequential(requires_grad=True)
+    bundle_path = tmp_path / "autograd_saved_bytes.tl"
+
+    tl.save(model_log, bundle_path)
+    loaded = tl.load(bundle_path)
+
+    assert loaded.total_autograd_saved_bytes == model_log.total_autograd_saved_bytes
+    for original_layer, loaded_layer in zip(model_log.layer_list, loaded.layer_list):
+        assert loaded_layer.autograd_saved_bytes == original_layer.autograd_saved_bytes
+        assert (
+            loaded_layer.autograd_saved_tensor_count == original_layer.autograd_saved_tensor_count
+        )
+    for label, original_layer in model_log.layer_logs.items():
+        loaded_layer = loaded.layer_logs[label]
+        assert loaded_layer.autograd_saved_bytes == original_layer.autograd_saved_bytes
+        assert (
+            loaded_layer.autograd_saved_tensor_count == original_layer.autograd_saved_tensor_count
+        )

--- a/torchlens/capture/output_tensors.py
+++ b/torchlens/capture/output_tensors.py
@@ -82,6 +82,8 @@ from .source_tensors import _get_input_module_info
 if TYPE_CHECKING:
     from ..data_classes.model_log import ModelLog
 
+_AUTOGRAD_SAVED_ATTR_PREFIX = "_saved_"
+
 
 def log_function_output_tensors(
     self,
@@ -553,6 +555,7 @@ def log_function_output_tensors_exhaustive(
     )
 
     out_iter = ensure_iterable(out_orig)
+    autograd_saved_stats = _get_autograd_saved_stats_by_output(out_orig)
 
     for i, out in enumerate(out_iter):
         if not _output_should_be_logged(out, is_bottom_level_func):
@@ -576,7 +579,14 @@ def log_function_output_tensors_exhaustive(
         ):
             fields_dict_onetensor[field] = copy.deepcopy(fields_dict[field])
         _log_output_tensor_info(
-            self, out, i, args, kwargs, parent_param_passes, fields_dict_onetensor
+            self,
+            out,
+            i,
+            args,
+            kwargs,
+            parent_param_passes,
+            fields_dict_onetensor,
+            autograd_saved_stats.get(i, (None, None)),
         )
         _make_layer_log_entry(
             self,
@@ -751,6 +761,10 @@ def log_function_output_tensors_fast(
         orig_layer_entry.tensor_shape = tuple(out.shape)
         orig_layer_entry.tensor_dtype = out.dtype
         orig_layer_entry.tensor_memory = get_tensor_memory_amount(out)
+        (
+            orig_layer_entry.autograd_saved_bytes,
+            orig_layer_entry.autograd_saved_tensor_count,
+        ) = _get_autograd_saved_stats_for_tensor(out)
         orig_layer_entry.func_time = exec_ctx.time_elapsed
         orig_layer_entry.func_rng_states = exec_ctx.rng_states
         orig_layer_entry.func_autocast_state = exec_ctx.autocast_state
@@ -816,6 +830,154 @@ def _check_if_tensor_arg(arg: Any) -> bool:
         return False
 
 
+def _iter_autograd_saved_candidates(grad_fn: Any) -> List[Any]:
+    """Return accessible autograd-saved values from a grad_fn object.
+
+    Parameters
+    ----------
+    grad_fn
+        PyTorch autograd function object to inspect.
+
+    Returns
+    -------
+    list
+        Values exposed through ``saved_tensors`` and ``_saved_*`` attributes.
+        Attribute access failures are ignored because PyTorch may release or
+        guard some saved values.
+    """
+    saved_values: List[Any] = []
+    try:
+        saved_values.extend(getattr(grad_fn, "saved_tensors", ()))
+    except Exception:
+        pass
+
+    for attr_name in grad_fn.__class__.__dict__:
+        if not attr_name.startswith(_AUTOGRAD_SAVED_ATTR_PREFIX):
+            continue
+        try:
+            saved_values.append(getattr(grad_fn, attr_name))
+        except Exception:
+            continue
+    return saved_values
+
+
+def _collect_tensor_values(value: Any) -> List[torch.Tensor]:
+    """Collect tensor values from a shallow autograd-saved object.
+
+    Parameters
+    ----------
+    value
+        Value read from a grad_fn saved-tensor API.
+
+    Returns
+    -------
+    list of torch.Tensor
+        Tensor instances found in the value.
+    """
+    if isinstance(value, torch.Tensor):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [item for item in value if isinstance(item, torch.Tensor)]
+    if isinstance(value, dict):
+        return [item for item in value.values() if isinstance(item, torch.Tensor)]
+    return []
+
+
+def _add_autograd_saved_tensor(
+    tensor: torch.Tensor,
+    seen_data_ptrs: set[int],
+) -> tuple[int, int]:
+    """Return byte/count contribution for a deduped autograd-saved tensor.
+
+    Parameters
+    ----------
+    tensor
+        Saved tensor to measure.
+    seen_data_ptrs
+        Data pointers already counted for this operation.
+
+    Returns
+    -------
+    tuple of int
+        ``(bytes, tensor_count)`` contribution for this tensor.
+    """
+    try:
+        data_ptr = tensor.data_ptr()
+    except Exception:
+        return 0, 0
+    if data_ptr in seen_data_ptrs:
+        return 0, 0
+    seen_data_ptrs.add(data_ptr)
+    with pause_logging():
+        return tensor.numel() * tensor.element_size(), 1
+
+
+def _get_autograd_saved_stats_by_output(
+    output: Any,
+) -> dict[int, tuple[Optional[int], Optional[int]]]:
+    """Measure autograd-saved tensor bytes/counts for each tensor output.
+
+    Parameters
+    ----------
+    output
+        Raw function output from a decorated torch operation.
+
+    Returns
+    -------
+    dict
+        Mapping from output index to ``(autograd_saved_bytes,
+        autograd_saved_tensor_count)``. Non-tensor outputs and tensors without
+        ``grad_fn`` are omitted and handled by callers as ``None`` values.
+    """
+    stats_by_index: dict[int, tuple[Optional[int], Optional[int]]] = {}
+    seen_grad_fns: set[int] = set()
+    seen_data_ptrs: set[int] = set()
+
+    for output_index, maybe_tensor in enumerate(ensure_iterable(output)):
+        if not isinstance(maybe_tensor, torch.Tensor) or maybe_tensor.grad_fn is None:
+            continue
+
+        grad_fn = maybe_tensor.grad_fn
+        grad_fn_id = id(grad_fn)
+        if grad_fn_id in seen_grad_fns:
+            stats_by_index[output_index] = (0, 0)
+            continue
+        seen_grad_fns.add(grad_fn_id)
+
+        total_bytes = 0
+        tensor_count = 0
+        for saved_value in _iter_autograd_saved_candidates(grad_fn):
+            for saved_tensor in _collect_tensor_values(saved_value):
+                bytes_added, count_added = _add_autograd_saved_tensor(saved_tensor, seen_data_ptrs)
+                total_bytes += bytes_added
+                tensor_count += count_added
+        stats_by_index[output_index] = (total_bytes, tensor_count)
+
+    return stats_by_index
+
+
+def _get_autograd_saved_stats_for_tensor(
+    tensor: torch.Tensor,
+) -> tuple[Optional[int], Optional[int]]:
+    """Measure autograd-saved tensor bytes/counts for a single tensor output.
+
+    Parameters
+    ----------
+    tensor
+        Tensor output from a decorated torch operation.
+
+    Returns
+    -------
+    tuple
+        ``(autograd_saved_bytes, autograd_saved_tensor_count)``. Both values
+        are ``None`` when no grad_fn exists.
+    """
+    if tensor.grad_fn is None:
+        return None, None
+    stats_by_index = _get_autograd_saved_stats_by_output(tensor)
+    return stats_by_index.get(0, (None, None))
+
+
 def _log_output_tensor_info(
     self,
     t: torch.Tensor,
@@ -824,6 +986,7 @@ def _log_output_tensor_info(
     kwargs: Dict[str, Any],
     parent_param_passes: Dict[str, int],
     fields_dict: Dict[str, Any],
+    autograd_saved_stats: tuple[Optional[int], Optional[int]],
 ) -> None:
     """Populate per-tensor fields that differ across outputs of a single function call.
 
@@ -940,6 +1103,10 @@ def _log_output_tensor_info(
     fields_dict["tensor_dtype"] = t.dtype
     with pause_logging():
         fields_dict["tensor_memory"] = t.nelement() * t.element_size()
+    (
+        fields_dict["autograd_saved_bytes"],
+        fields_dict["autograd_saved_tensor_count"],
+    ) = autograd_saved_stats
 
     # FLOPs computation
     fields_dict["flops_forward"] = compute_forward_flops(

--- a/torchlens/capture/source_tensors.py
+++ b/torchlens/capture/source_tensors.py
@@ -232,6 +232,8 @@ def log_source_tensor_exhaustive(
         "tensor_shape": tuple(t.shape),
         "tensor_dtype": t.dtype,
         "tensor_memory": tensor_memory,
+        "autograd_saved_bytes": None,
+        "autograd_saved_tensor_count": None,
         # Child tensor variation tracking
         "has_child_tensor_variations": False,
         "children_tensor_versions": {},

--- a/torchlens/constants.py
+++ b/torchlens/constants.py
@@ -109,6 +109,7 @@ MODEL_LOG_FIELD_ORDER = [
     "orphan_layers",
     # Tensor info:
     "total_activation_memory",
+    "total_autograd_saved_bytes",
     "num_tensors_saved",
     "saved_activation_memory",
     # Param info
@@ -174,6 +175,8 @@ LAYER_PASS_LOG_FIELD_ORDER = [
     "tensor_shape",
     "tensor_dtype",
     "tensor_memory",
+    "autograd_saved_bytes",
+    "autograd_saved_tensor_count",
     # Child tensor variation tracking
     "has_child_tensor_variations",
     "children_tensor_versions",
@@ -315,6 +318,8 @@ LAYER_LOG_FIELD_ORDER = [
     "tensor_shape",
     "tensor_dtype",
     "tensor_memory",
+    "autograd_saved_bytes",
+    "autograd_saved_tensor_count",
     # Config
     "output_device",
     "activation_postfunc",

--- a/torchlens/data_classes/layer_log.py
+++ b/torchlens/data_classes/layer_log.py
@@ -84,6 +84,8 @@ class LayerLog:
         "tensor_shape": FieldPolicy.KEEP,
         "tensor_dtype": FieldPolicy.KEEP,
         "tensor_memory": FieldPolicy.KEEP,
+        "autograd_saved_bytes": FieldPolicy.KEEP,
+        "autograd_saved_tensor_count": FieldPolicy.KEEP,
         "output_device": FieldPolicy.KEEP,
         "activation_postfunc": FieldPolicy.DROP,
         "extra_data": FieldPolicy.KEEP,
@@ -170,6 +172,8 @@ class LayerLog:
         self.tensor_shape = first_pass.tensor_shape
         self.tensor_dtype = first_pass.tensor_dtype
         self.tensor_memory = first_pass.tensor_memory
+        self.autograd_saved_bytes: Optional[int] = first_pass.autograd_saved_bytes
+        self.autograd_saved_tensor_count: Optional[int] = first_pass.autograd_saved_tensor_count
 
         # Config
         self.output_device = first_pass.output_device
@@ -301,7 +305,15 @@ class LayerLog:
     def __setstate__(self, state: Dict[str, Any]) -> None:
         """Restore pickle state produced by ``__getstate__``."""
         read_io_format_version(state, cls_name=type(self).__name__)
-        default_fill_state(state, defaults={"_source_model_log_ref": None, "extra_data": {}})
+        default_fill_state(
+            state,
+            defaults={
+                "_source_model_log_ref": None,
+                "extra_data": {},
+                "autograd_saved_bytes": None,
+                "autograd_saved_tensor_count": None,
+            },
+        )
         self.__dict__.update(state)
 
     # ********************************************

--- a/torchlens/data_classes/layer_pass_log.py
+++ b/torchlens/data_classes/layer_pass_log.py
@@ -125,6 +125,8 @@ class LayerPassLog:
         "tensor_shape": FieldPolicy.KEEP,
         "tensor_dtype": FieldPolicy.KEEP,
         "tensor_memory": FieldPolicy.KEEP,
+        "autograd_saved_bytes": FieldPolicy.KEEP,
+        "autograd_saved_tensor_count": FieldPolicy.KEEP,
         "has_child_tensor_variations": FieldPolicy.KEEP,
         "children_tensor_versions": FieldPolicy.BLOB_RECURSIVE,
         "gradient": FieldPolicy.BLOB,
@@ -299,6 +301,8 @@ class LayerPassLog:
         self.tensor_shape = fields_dict["tensor_shape"]
         self.tensor_dtype = fields_dict["tensor_dtype"]
         self.tensor_memory = fields_dict["tensor_memory"]
+        self.autograd_saved_bytes: Optional[int] = fields_dict["autograd_saved_bytes"]
+        self.autograd_saved_tensor_count: Optional[int] = fields_dict["autograd_saved_tensor_count"]
 
         # Child tensor variation tracking - stores the raw tensor values that
         # each child operation received as input.  Must store RAW values (not
@@ -667,6 +671,8 @@ class LayerPassLog:
                 "_pending_blob_id": None,
                 "_pending_gradient_blob_id": None,
                 "extra_data": {},
+                "autograd_saved_bytes": None,
+                "autograd_saved_tensor_count": None,
             },
         )
         self.__dict__.update(state)

--- a/torchlens/data_classes/model_log.py
+++ b/torchlens/data_classes/model_log.py
@@ -215,6 +215,7 @@ class ModelLog:
         "layers_with_params": FieldPolicy.KEEP,
         "equivalent_operations": FieldPolicy.KEEP,
         "total_activation_memory": FieldPolicy.KEEP,
+        "total_autograd_saved_bytes": FieldPolicy.KEEP,
         "num_tensors_saved": FieldPolicy.KEEP,
         "saved_activation_memory": FieldPolicy.KEEP,
         "param_logs": FieldPolicy.KEEP,
@@ -411,6 +412,7 @@ class ModelLog:
 
         # Aggregate tensor statistics (computed during postprocessing):
         self.total_activation_memory: int = 0
+        self.total_autograd_saved_bytes: Optional[int] = None
         self.num_tensors_saved: int = 0  # layers with has_saved_activations=True
         self.saved_activation_memory: int = 0
 
@@ -565,6 +567,7 @@ class ModelLog:
                 "backward_num_passes": 0,
                 "backward_peak_memory_bytes": 0,
                 "backward_memory_backend": "unknown",
+                "total_autograd_saved_bytes": None,
                 "_buffer_accessor": None,
                 "_module_logs": None,
                 "_module_build_data": None,

--- a/torchlens/postprocess/finalization.py
+++ b/torchlens/postprocess/finalization.py
@@ -764,9 +764,32 @@ def _build_layer_logs(self: "ModelLog") -> None:
         pass_log.parent_layer_log = layer_log  # type: ignore[assignment]
         _merge_layer_log_conditional_fields(layer_log, pass_log)
 
+    total_autograd_saved_bytes = 0
+    has_autograd_saved_value = False
     for layer_log in layer_logs.values():
+        pass_autograd_bytes = [
+            pass_log.autograd_saved_bytes
+            for pass_log in layer_log.passes.values()
+            if pass_log.autograd_saved_bytes is not None
+        ]
+        pass_autograd_tensor_counts = [
+            pass_log.autograd_saved_tensor_count
+            for pass_log in layer_log.passes.values()
+            if pass_log.autograd_saved_tensor_count is not None
+        ]
+        if pass_autograd_bytes:
+            layer_log.autograd_saved_bytes = sum(pass_autograd_bytes)
+            layer_log.autograd_saved_tensor_count = sum(pass_autograd_tensor_counts)
+            total_autograd_saved_bytes += layer_log.autograd_saved_bytes
+            has_autograd_saved_value = True
+        else:
+            layer_log.autograd_saved_bytes = None
+            layer_log.autograd_saved_tensor_count = None
         _rebuild_layer_log_conditional_views(layer_log)
 
+    self.total_autograd_saved_bytes = (
+        total_autograd_saved_bytes if has_autograd_saved_value else None
+    )
     self.layer_logs = layer_logs
     _rebuild_conditional_edge_passes(self)
 

--- a/torchlens/postprocess/graph_traversal.py
+++ b/torchlens/postprocess/graph_traversal.py
@@ -81,6 +81,8 @@ def _add_output_layers(
         new_output_node.func_kwargs_non_tensor = {}
         new_output_node.func_non_tensor_args = []
         new_output_node.grad_fn_name = None
+        new_output_node.autograd_saved_bytes = None
+        new_output_node.autograd_saved_tensor_count = None
         new_output_node.captured_args = [output_tensors[i]]
         new_output_node.captured_kwargs = {}
 


### PR DESCRIPTION
## Summary

- Add pass-level `LayerPassLog.autograd_saved_bytes` and `LayerPassLog.autograd_saved_tensor_count` fields populated from live autograd `grad_fn` introspection.
- Add aggregate `LayerLog.autograd_saved_bytes` and `LayerLog.autograd_saved_tensor_count` rollups across passes.
- Add `ModelLog.total_autograd_saved_bytes` as the model-level sum across layers.

## Design Notes

This is introspection-only: TorchLens reads `grad_fn.saved_tensors` and accessible `_saved_*` attributes at forward logging time, without static op tables or formula-based estimates. When no `grad_fn` exists, including `torch.no_grad()` and inference-mode style execution, the autograd fields stay `None`; a real grad_fn that saves nothing reports `0`.

The new fields are placed near existing tensor-memory fields in `MODEL_LOG_FIELD_ORDER`, `LAYER_PASS_LOG_FIELD_ORDER`, and `LAYER_LOG_FIELD_ORDER` so display and serialization order keeps memory metrics together.

This metric is a companion to, but distinct from, `saved_activation_memory`. `saved_activation_memory` measures tensors TorchLens saves for user inspection, while `autograd_saved_bytes` measures tensors PyTorch autograd saves internally for backward.

Future work: add a formula-based `estimated_autograd_saved_bytes` companion from the `.project-context/todos.md` improvements list in a separate sprint.

## Validation

- `ruff format .`
- `ruff check . --fix`
- `mypy torchlens/`
- `pytest tests/ -m smoke -x --tb=short`
- `pytest tests/test_autograd_saved_bytes.py -v`
- `pytest tests/ -m "not slow" -x --tb=short`
