### PR TITLE
feat(multi-trace): bundle visualization (Phase 2)

### DIFF
--- a/.project-context/todos.md
+++ b/.project-context/todos.md
@@ -6,6 +6,55 @@
 
 ## Improvements (Nice-to-Have)
 
+### Multi-trace V2 (deferred from 2026-04-27 sprint design)
+
+These were scoped OUT of the multi-trace MVP (TraceBundle + TraceOverlay)
+but are natural follow-ons. Pick up after MVP ships.
+
+- **Branch-divergence detection.** Soft version of "counterfactual
+  tracing." Given a TraceOverlay, surface "branch-divergence nodes"
+  where execution paths split, expose as a queryable list. NOT true
+  forced-branch enumeration -- just detection of where forward paths
+  diverged across the bundled inputs.
+
+- **True counterfactual branch enumeration** (forced-branch execution).
+  Programmatically force both arms of every Python `if` in a dynamic
+  network. Hard problem -- requires either symbolic tracing
+  (incompatible with TorchLens's runtime model), bytecode hacking
+  (fragile), or an intervention API where the user explicitly drives
+  forced inputs to coax branches. Defer indefinitely; the
+  branch-divergence detection above is the practical 80% solution.
+
+- **Streaming aggregate over a dataloader.** `tl.aggregate(model,
+  dataloader, metrics=[...])` -- consumes traces from a generator,
+  computes running per-node statistics (mean, var, RDM,
+  dimensionality), discards raw activations. For "10K images through
+  ResNet50" workflows where holding traces is impractical. Function,
+  not a class.
+
+- **Interactive viewer for bundles/overlays.** D3.js or anywidget-based
+  Jupyter widget. Pan/zoom, hover tooltips, click-to-expand node
+  visualizations, path highlighting, export to standalone HTML. After
+  graphviz MVP is stable.
+
+- **Custom node visualizations.** Pluggable per-node display: PCA-RGB
+  for conv layers, MDS scatter for linear layers, histograms for
+  activations, dimensionality estimates. Bundle/Overlay would accept
+  `node_display={'conv.*': 'pca_rgb', ...}` mappings.
+
+- **Convenience constructors with intervention APIs.** `tl.zero(node)`,
+  `tl.steer(node, vector)`, `tl.compare(model, input, {...})`,
+  `tl.sweep(model, input, {...})`. Interventions produce a new
+  ModelLog (never mix clean and intervened activations in a Bundle).
+  Out of scope for MVP; design once Bundle/Overlay are stable.
+
+- **Rename ModelLog -> Trace** (one-way door). Clean public-API
+  migration -- `tl.trace()` constructor, `Trace` class. Major
+  breaking change to a published-and-cited package. Do as a separate
+  deliberate migration, never bundled with feature work.
+
+### Other improvements
+
 - Rethink the parameter name `activation_postfunc` itself. Current name is
   awkward (`-postfunc` suffix) and the semantic now reads as a "transform"
   hook, not a "post-processing function" (after the raw-vs-transformed

--- a/tests/test_multi_trace_visualization.py
+++ b/tests/test_multi_trace_visualization.py
@@ -1,0 +1,361 @@
+"""Tests for the multi_trace visualization layer (show_bundle_graph).
+
+Covers the 15 cases from the Phase 2 spec. Fixtures are inlined rather
+than shared via conftest to keep this file self-contained -- it mirrors
+the pattern used in ``test_multi_trace.py``.
+
+Where the test only needs to verify that styling differs between modes
+we inspect the generated DOT source via the ``return_dot=True`` test
+hook on ``show_bundle_graph``. Where the test verifies actual file
+output, we render to a temp directory and check size + extension.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.multi_trace import TraceBundle, bundle, show_bundle_graph
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _LinearNet(nn.Module):
+    """Small static model used for shared-topology bundles."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(4, 4)
+        self.fc2 = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(self.fc2(torch.relu(self.fc1(x))))
+
+
+class _BranchNet(nn.Module):
+    """Conditionally branching model used for divergent-topology bundles."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.mean() > 0:
+            return torch.relu(x)
+        return torch.sigmoid(x)
+
+
+def _shared_bundle(n_traces: int = 3, batch: int = 2) -> TraceBundle:
+    """Build a shared-topology bundle from N forward passes of _LinearNet."""
+
+    model = _LinearNet()
+    traces = [tl.log_forward_pass(model, torch.rand(batch, 4)) for _ in range(n_traces)]
+    return TraceBundle(traces)
+
+
+def _divergent_bundle() -> TraceBundle:
+    """Build a divergent-topology bundle from a branching model."""
+
+    model = _BranchNet()
+    ml_pos = tl.log_forward_pass(model, torch.ones(2, 4))
+    ml_neg = tl.log_forward_pass(model, -torch.ones(2, 4))
+    return TraceBundle([ml_pos, ml_neg], names=["pos", "neg"])
+
+
+def _grouped_bundle() -> TraceBundle:
+    """Bundle with non-empty groups, suitable for group_color mode."""
+
+    model = _LinearNet()
+    traces = [tl.log_forward_pass(model, torch.rand(2, 4)) for _ in range(4)]
+    names = ["a1", "a2", "b1", "b2"]
+    groups = {"alphas": ["a1", "a2"], "betas": ["b1", "b2"]}
+    return TraceBundle(traces, names=names, groups=groups)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _file_nonempty(path: Path) -> bool:
+    """Return True if ``path`` exists and has size > 0."""
+
+    return path.exists() and path.stat().st_size > 0
+
+
+def _find_rendered(parent: Path, stem: str, ext: str) -> Path:
+    """Locate the rendered file by stem/extension under ``parent``."""
+
+    direct = parent / f"{stem}.{ext}"
+    if direct.exists():
+        return direct
+    matches: List[Path] = list(parent.glob(f"{stem}.{ext}"))
+    if matches:
+        return matches[0]
+    raise AssertionError(
+        f"No file matching '{stem}.{ext}' found under {parent}; "
+        f"contents: {sorted(p.name for p in parent.iterdir())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1-10: API behaviour + mode coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_show_bundle_graph_smoke(tmp_path: Path) -> None:
+    """Shared-topology bundle, mode='auto', writes a non-empty PDF."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle"
+    show_bundle_graph(b, vis_outpath=str(out), mode="auto", save_only=True)
+    rendered = _find_rendered(tmp_path, "bundle", "pdf")
+    assert _file_nonempty(rendered), f"expected non-empty file at {rendered}"
+
+
+def test_show_bundle_graph_divergence_mode(tmp_path: Path) -> None:
+    """Explicit mode='divergence' on a shared-topology bundle writes output."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle_div"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_div", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_swarm_mode(tmp_path: Path) -> None:
+    """Divergent-topology bundle in swarm mode writes output."""
+
+    b = _divergent_bundle()
+    out = tmp_path / "bundle_swarm"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="swarm",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_swarm", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_group_color_mode(tmp_path: Path) -> None:
+    """Bundle with groups + mode='group_color' writes output."""
+
+    b = _grouped_bundle()
+    out = tmp_path / "bundle_groups"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="group_color",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_groups", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_group_color_no_groups_errors() -> None:
+    """mode='group_color' on a bundle with no groups raises ValueError."""
+
+    b = _shared_bundle()
+    with pytest.raises(ValueError, match="bundle.groups"):
+        show_bundle_graph(b, mode="group_color", save_only=True, return_dot=True)
+
+
+def test_show_bundle_graph_auto_mode_picks_divergence() -> None:
+    """Shared-topology bundle + mode='auto' resolves to divergence styling.
+
+    Inspect the DOT caption (which records the resolved mode) plus a
+    palette colour cue: divergence uses the Reds palette, of which the
+    final stop ``#4a000a`` is a unique signature relative to viridis.
+    """
+
+    b = _shared_bundle()
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+    # Caption records the auto resolution.
+    assert "auto -&gt; divergence" in src or "auto -> divergence" in src
+    # Reds palette in use somewhere.
+    assert any(stop in src for stop in ("#fff5f0", "#fee0d2", "#fcbba1"))
+
+
+def test_show_bundle_graph_auto_mode_picks_swarm() -> None:
+    """Divergent-topology bundle + mode='auto' resolves to swarm styling."""
+
+    b = _divergent_bundle()
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+    assert "auto -&gt; swarm" in src or "auto -> swarm" in src
+    # Viridis palette signature -- ``#440154`` is unique to viridis stops.
+    assert "#440154" in src or "#fde725" in src
+
+
+def test_bundle_show_method(tmp_path: Path) -> None:
+    """``bundle.show()`` produces equivalent output to the top-level helper."""
+
+    b = _shared_bundle()
+    out_a = tmp_path / "via_method"
+    out_b = tmp_path / "via_func"
+
+    b.show(vis_outpath=str(out_a), mode="divergence", save_only=True)
+    show_bundle_graph(b, vis_outpath=str(out_b), mode="divergence", save_only=True)
+
+    file_a = _find_rendered(tmp_path, "via_method", "pdf")
+    file_b = _find_rendered(tmp_path, "via_func", "pdf")
+    assert _file_nonempty(file_a)
+    assert _file_nonempty(file_b)
+    # Both DOT sources should be identical -- the method is a thin wrapper.
+    src_a = b.show(vis_outpath=None, mode="divergence", return_dot=True)
+    src_b = show_bundle_graph(b, mode="divergence", return_dot=True)
+    assert src_a == src_b
+
+
+def test_show_bundle_graph_format_png(tmp_path: Path) -> None:
+    """vis_format='png' produces a .png file."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle_png"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        vis_format="png",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_png", "png")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_format_svg(tmp_path: Path) -> None:
+    """vis_format='svg' produces a .svg file."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle_svg"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        vis_format="svg",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_svg", "svg")
+    assert _file_nonempty(rendered)
+
+
+# ---------------------------------------------------------------------------
+# 11-15: regression + kwargs + IO
+# ---------------------------------------------------------------------------
+
+
+def test_show_model_graph_unchanged(tmp_path: Path) -> None:
+    """Regression: tl.show_model_graph(modellog) still produces a file."""
+
+    model = _LinearNet()
+    out = tmp_path / "single_trace"
+    tl.show_model_graph(
+        model,
+        torch.rand(2, 4),
+        vis_outpath=str(out),
+        vis_save_only=True,
+        vis_fileformat="pdf",
+    )
+    rendered = _find_rendered(tmp_path, "single_trace", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_swarm_show_coverage_kwarg() -> None:
+    """``show_coverage=True`` in swarm mode writes coverage labels into DOT."""
+
+    b = _divergent_bundle()
+    src_with = show_bundle_graph(b, mode="swarm", show_coverage=True, return_dot=True)
+    src_without = show_bundle_graph(b, mode="swarm", show_coverage=False, return_dot=True)
+    assert src_with is not None and src_without is not None
+    assert "coverage:" in src_with
+    assert "coverage:" not in src_without
+
+
+def test_metric_kwarg_for_divergence() -> None:
+    """metric='relative_l2' produces different DOT than the default cosine."""
+
+    b = _shared_bundle()
+    src_default = show_bundle_graph(b, mode="divergence", return_dot=True)
+    src_l2 = show_bundle_graph(b, mode="divergence", metric="relative_l2", return_dot=True)
+    assert src_default is not None and src_l2 is not None
+    # The per-node distance values flow into the rendered ``div: X.XX``
+    # rows, so swapping metrics SHOULD change the source unless the
+    # metrics happen to agree exactly (vanishingly unlikely on random
+    # initialisation).
+    assert src_default != src_l2
+
+
+def test_show_bundle_graph_with_default_outpath(tmp_path: Path) -> None:
+    """No vis_outpath -> writes to ``bundle_graph.<format>`` in cwd."""
+
+    import os
+
+    cwd = Path(os.getcwd())
+    saved = list(cwd.glob("bundle_graph.pdf"))
+    # Move to tmp_path so cleanup is automatic and we don't pollute repo.
+    os.chdir(tmp_path)
+    try:
+        b = _shared_bundle()
+        show_bundle_graph(b, mode="divergence", save_only=True)
+        rendered = tmp_path / "bundle_graph.pdf"
+        assert _file_nonempty(rendered)
+    finally:
+        os.chdir(cwd)
+    # Sanity: we haven't accidentally written into the repo root.
+    after = list(cwd.glob("bundle_graph.pdf"))
+    assert after == saved, f"unexpected new bundle_graph.pdf in cwd: {after} vs {saved}"
+
+
+def test_directory_creation(tmp_path: Path) -> None:
+    """vis_outpath='subdir/bundle.pdf' creates the subdir if needed."""
+
+    b = _shared_bundle()
+    nested = tmp_path / "deep" / "nest"
+    assert not nested.exists()
+    out = nested / "bundle"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        save_only=True,
+    )
+    rendered = _find_rendered(nested, "bundle", "pdf")
+    assert _file_nonempty(rendered)
+
+
+# ---------------------------------------------------------------------------
+# Bonus: a couple of internal-consistency checks discovered while writing
+# the spec'd 15 -- helpful for catching regressions later but cheap to run.
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_mode_raises() -> None:
+    """An unknown mode literal raises ValueError before doing any work."""
+
+    b = _shared_bundle()
+    with pytest.raises(ValueError, match="mode must be one of"):
+        show_bundle_graph(b, mode="rainbow", return_dot=True)  # type: ignore[arg-type]
+
+
+def test_too_many_groups_raises() -> None:
+    """More groups than the categorical palette supports raises ValueError."""
+
+    model = _LinearNet()
+    traces = [tl.log_forward_pass(model, torch.rand(2, 4)) for _ in range(11)]
+    names = [f"t{i}" for i in range(11)]
+    groups = {f"g{i}": [names[i]] for i in range(11)}
+    b = TraceBundle(traces, names=names, groups=groups)
+    with pytest.raises(ValueError, match="up to 10 groups"):
+        show_bundle_graph(b, mode="group_color", return_dot=True)

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -52,7 +52,7 @@ from .visualization import (
 
 # ---- Public API: multi-trace analysis ------------------------------------
 
-from .multi_trace import NodeView, TraceBundle, bundle
+from .multi_trace import NodeView, TraceBundle, bundle, show_bundle_graph
 
 # ---- Public API: decoration lifecycle ------------------------------------
 
@@ -118,6 +118,7 @@ __all__ = [
     "render_model_log_with_dagua",
     "save",
     "show_backward_graph",
+    "show_bundle_graph",
     "show_model_graph",
     "summary",
     "unwrap_torch",

--- a/torchlens/multi_trace/__init__.py
+++ b/torchlens/multi_trace/__init__.py
@@ -13,10 +13,11 @@ Public surface:
   structure produced by :func:`build_supergraph`.
 * Metric primitives (cosine_distance, relative_l2, pearson_correlation_distance,
   relative_l1_scalar) and :func:`resolve_metric`.
+* :func:`show_bundle_graph` -- Graphviz visualization with three styling
+  modes (divergence, swarm, group_color) plus an ``auto`` default.
 
-Visualization, counterfactual branch enumeration, intervention APIs, and
-streaming aggregate are deferred to a Phase 2 dispatch -- see
-``.project-context/todos.md``.
+Counterfactual branch enumeration, intervention APIs, and streaming
+aggregate remain deferred -- see ``.project-context/todos.md``.
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from .topology import (
     build_supergraph,
     compare_topology,
 )
+from .visualization import show_bundle_graph
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only
     from ..data_classes.model_log import ModelLog
@@ -75,4 +77,5 @@ __all__ = [
     "relative_l1_scalar",
     "relative_l2",
     "resolve_metric",
+    "show_bundle_graph",
 ]

--- a/torchlens/multi_trace/bundle.py
+++ b/torchlens/multi_trace/bundle.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     Iterator,
@@ -333,6 +334,31 @@ class TraceBundle:
         if not isinstance(view, NodeView):  # pragma: no cover - defensive
             raise TypeError("aggregate requires a node name (str), not a trace index")
         return view.aggregate(statistic=statistic, on=on)
+
+    # ------------------------------------------------------------------
+    # Visualization
+    # ------------------------------------------------------------------
+
+    def show(
+        self,
+        vis_outpath: Optional[str] = None,
+        mode: Literal["auto", "divergence", "swarm", "group_color"] = "auto",
+        **kwargs: Any,
+    ) -> Optional[str]:
+        """Render this bundle as a Graphviz graph.
+
+        Thin convenience wrapper around
+        :func:`torchlens.multi_trace.visualization.show_bundle_graph`.
+        See that function for full kwarg documentation; common options
+        are ``metric=`` (for ``mode='divergence'``), ``show_coverage=``
+        (for ``mode='swarm'``), ``vis_format=``, ``vis_orientation=``,
+        and ``save_only=``.
+        """
+
+        # Lazy import to dodge the bundle <-> visualization import cycle.
+        from .visualization import show_bundle_graph
+
+        return show_bundle_graph(self, vis_outpath=vis_outpath, mode=mode, **kwargs)
 
     # ------------------------------------------------------------------
     # Hard checks

--- a/torchlens/multi_trace/visualization.py
+++ b/torchlens/multi_trace/visualization.py
@@ -1,0 +1,779 @@
+"""Graphviz visualization for :class:`TraceBundle` objects.
+
+This module provides :func:`show_bundle_graph`, the canonical entry point
+for rendering a multi-trace bundle, plus three styling modes:
+
+* ``divergence`` -- per-node mean pairwise distance, sequential ``Reds``
+  colormap. Use when the bundle is shared-topology and the question is
+  "which nodes change the most across traces?".
+* ``swarm`` -- per-node coverage fraction, sequential ``viridis``
+  colormap. Use for divergent-topology bundles where the question is
+  "which nodes did most/all traces visit?".
+* ``group_color`` -- categorical colouring by trace-group membership
+  (``tab10`` palette). Requires ``bundle.groups`` to be non-empty;
+  multi-group nodes get a neutral light-grey shade rather than a blended
+  palette colour.
+
+The renderer is deliberately compact and self-contained -- it builds a
+fresh :class:`graphviz.Digraph` from the bundle's :class:`Supergraph`
+rather than reusing the ModelLog-coupled ``rendering.render_graph``
+machinery, which is too entangled with single-trace state to be safely
+re-pointed at a multi-trace input within the scope of this dispatch.
+What it DOES share with ``rendering.py`` is the file-format dispatch +
+view orchestration, factored into ``visualization/_render_utils.py``.
+
+Module clusters are derived from the supergraph's ``module_path`` strings
+(``"a.b.c"``-shaped), giving users the same hierarchical layout cue they
+get from ``show_model_graph`` even though the underlying ``ModuleLog``
+hierarchy is not first-class on a Supergraph.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+import graphviz
+import torch
+
+from ..utils.display import in_notebook
+from ..visualization._render_utils import (
+    render_dot_to_file,
+    strip_known_extension,
+)
+from .metrics import is_scalar_like, relative_l1_scalar, resolve_metric
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from .bundle import TraceBundle
+    from .topology import Supergraph, SupergraphNode
+
+
+# ---------------------------------------------------------------------------
+# Colormap definitions
+# ---------------------------------------------------------------------------
+#
+# All palettes are hardcoded as hex strings to avoid pulling matplotlib (or
+# any other plotting library) into torchlens's required dependency set.
+# Sampled at 10 stops for sequential maps; tab10 is the canonical
+# 10-category categorical palette. White / very light grey is reserved as
+# the "no-data / neutral" shade.
+
+# matplotlib's ``Reds`` colormap sampled at 10 evenly-spaced stops.
+# Light end is near-white so unchanged nodes fade into the background.
+_REDS_HEX: Tuple[str, ...] = (
+    "#fff5f0",
+    "#fee0d2",
+    "#fcbba1",
+    "#fc9272",
+    "#fb6a4a",
+    "#ef3b2c",
+    "#cb181d",
+    "#a50f15",
+    "#67000d",
+    "#4a000a",
+)
+
+# matplotlib's ``viridis`` colormap sampled at 10 evenly-spaced stops.
+# Monotonic luminance, colorblind-safe.
+_VIRIDIS_HEX: Tuple[str, ...] = (
+    "#440154",
+    "#482878",
+    "#3e4989",
+    "#31688e",
+    "#26828e",
+    "#1f9e89",
+    "#35b779",
+    "#6ece58",
+    "#b5de2b",
+    "#fde725",
+)
+
+# matplotlib's ``tab10`` categorical palette (RGB hex). Used for
+# group_color mode. Capacity is 10 distinct groups.
+_TAB10_HEX: Tuple[str, ...] = (
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+)
+
+# Designated neutral shade for nodes traversed by multiple groups in
+# group_color mode. Picked to read clearly against any tab10 colour.
+_NEUTRAL_GREY = "#d9d9d9"
+
+# Edge colour for divergence/swarm modes (faded so coloured nodes pop).
+_EDGE_COLOR_NEUTRAL = "#cccccc"
+
+# Default text colour for high-saturation node fills (improves contrast on
+# dark Reds / dark viridis stops). Heuristic: switch to white once the
+# fill darkens past ~halfway through the colormap.
+_LIGHT_TEXT = "#ffffff"
+_DARK_TEXT = "#000000"
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+ModeLiteral = Literal["auto", "divergence", "swarm", "group_color"]
+DirectionLiteral = Literal["bottomup", "topdown", "leftright"]
+FileFormatLiteral = Literal["pdf", "png", "svg", "jpg", "jpeg", "bmp", "tif", "tiff"]
+VisModeLiteral = Literal["unrolled", "rolled"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mode(bundle: "TraceBundle", mode: ModeLiteral) -> ModeLiteral:
+    """Resolve ``mode='auto'`` to a concrete styling mode.
+
+    Shared topology -> divergence (every node is universal so swarm would
+    paint everything the same colour). Divergent topology -> swarm
+    (coverage frequency carries information).
+    """
+
+    if mode != "auto":
+        return mode
+    return "divergence" if bundle.is_shared_topology else "swarm"
+
+
+def _direction_to_rankdir(direction: str) -> str:
+    """Translate a vis-direction literal into a Graphviz ``rankdir``."""
+
+    if direction == "bottomup":
+        return "BT"
+    if direction == "leftright":
+        return "LR"
+    if direction == "topdown":
+        return "TB"
+    raise ValueError(
+        f"vis_direction must be one of 'bottomup', 'topdown', or 'leftright'; got {direction!r}"
+    )
+
+
+def _sample_colormap(palette: Tuple[str, ...], frac: float) -> str:
+    """Return the palette colour closest to fractional position ``frac``.
+
+    ``frac`` is clamped to ``[0, 1]``; ``frac == 0`` -> first stop, ``frac
+    == 1`` -> last stop. Linear interpolation between stops would be more
+    accurate but adds zero perceptual benefit for rendered Graphviz
+    fills, so we round to the nearest stop.
+    """
+
+    if not palette:
+        return _NEUTRAL_GREY
+    if frac <= 0.0:
+        return palette[0]
+    if frac >= 1.0:
+        return palette[-1]
+    idx = int(round(frac * (len(palette) - 1)))
+    return palette[idx]
+
+
+def _is_dark_swatch(palette: Tuple[str, ...], frac: float) -> bool:
+    """Heuristic: is the colour at ``frac`` dark enough to need light text?"""
+
+    if not palette:
+        return False
+    if frac <= 0.0:
+        return False
+    # Past the midpoint of either palette the swatches are dark.
+    return frac >= 0.55
+
+
+def _per_node_distance(
+    bundle: "TraceBundle",
+    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]],
+) -> Dict[str, Optional[float]]:
+    """Compute mean pairwise distance per supergraph node.
+
+    Returns a dict ``{node_name: distance_or_None}``. Nodes traversed by
+    fewer than two traces, or missing stored activations, map to
+    ``None`` so the caller can render them with a neutral shade.
+    """
+
+    metric_fn = resolve_metric(metric)
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    out: Dict[str, Optional[float]] = {}
+
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        tensors: List[torch.Tensor] = []
+        for trace_name in node.traces:
+            layer = node.layer_refs[trace_name]
+            has = getattr(layer, "has_saved_activations", False)
+            value = getattr(layer, "activation", None) if has else None
+            if isinstance(value, torch.Tensor):
+                tensors.append(value)
+        if len(tensors) < 2:
+            out[name] = None
+            continue
+        distances: List[float] = []
+        # Pairwise mean: mirror the contract in TraceBundle.most_changed.
+        for i in range(len(tensors)):
+            for j in range(i + 1, len(tensors)):
+                ti, tj = tensors[i], tensors[j]
+                if is_scalar_like(ti) or is_scalar_like(tj):
+                    d = relative_l1_scalar(ti, tj)
+                else:
+                    try:
+                        d = metric_fn(ti, tj)
+                    except (RuntimeError, ValueError):
+                        # Shape disagreement etc. -- fall back to scalar
+                        # form so the mode still produces something
+                        # rather than crashing the entire render.
+                        d = relative_l1_scalar(ti, tj)
+                distances.append(float(d.detach().item()))
+        if not distances:
+            out[name] = None
+            continue
+        out[name] = sum(distances) / len(distances)
+    return out
+
+
+def _per_node_coverage(bundle: "TraceBundle") -> Dict[str, float]:
+    """Fraction of bundled traces that traversed each supergraph node."""
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    n = max(len(bundle.names), 1)
+    return {name: len(node.traces) / n for name, node in sg.nodes.items()}
+
+
+def _per_node_groups(
+    bundle: "TraceBundle",
+) -> Dict[str, frozenset]:
+    """Set of group names that traversed each supergraph node.
+
+    Returns ``frozenset`` so the values are hashable and easy to compare;
+    a node with no group memberships maps to the empty frozenset.
+    """
+
+    groups = bundle.groups
+    if not groups:
+        return {}
+
+    # Reverse the trace_name -> group(s) mapping so we can ask "which
+    # groups does this set of traces belong to?".
+    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
+    for group_name, members in groups.items():
+        for trace_name in members:
+            trace_to_groups[trace_name].add(group_name)
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    out: Dict[str, frozenset] = {}
+    for name, node in sg.nodes.items():
+        node_groups: Set[str] = set()
+        for trace_name in node.traces:
+            node_groups.update(trace_to_groups.get(trace_name, set()))
+        out[name] = frozenset(node_groups)
+    return out
+
+
+def _cluster_path(module_path: Optional[str]) -> List[str]:
+    """Split a dotted module path into the prefix chain used for clusters.
+
+    Trailing pass-suffixes (``"a.b:1"``) are dropped because Graphviz
+    cluster names need to be stable across traces.
+    """
+
+    if not module_path:
+        return []
+    # Strip any ``":N"`` suffix on the leaf (pass index).
+    head = module_path.split(":")[0]
+    parts = [p for p in head.split(".") if p]
+    return parts
+
+
+def _safe_dot_id(name: str) -> str:
+    """Return a Graphviz-safe identifier for arbitrary node/cluster names.
+
+    Graphviz allows fairly liberal node names but quotes characters like
+    ``:``/``.``/spaces in the DOT source. We rewrite to a pure
+    ``[A-Za-z0-9_]`` form so generated DOT is easy to inspect in tests.
+    """
+
+    return "".join(c if c.isalnum() or c == "_" else "_" for c in name)
+
+
+def _build_module_clusters(
+    bundle: "TraceBundle",
+) -> Dict[str, List[str]]:
+    """Map cluster path (dotted prefix) -> list of node names in it.
+
+    Empty-prefix nodes (no module path) live at the root and don't get
+    wrapped in a cluster.
+    """
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    clusters: Dict[str, List[str]] = defaultdict(list)
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        path = _cluster_path(node.module_path)
+        # We attach each node to its leaf cluster only; ancestor clusters
+        # are reconstructed lazily when laying out subgraph nesting.
+        cluster_key = ".".join(path)
+        clusters[cluster_key].append(name)
+    return clusters
+
+
+def _walk_clusters(
+    cluster_paths: List[str],
+) -> List[List[str]]:
+    """Return the list of dotted-prefix paths needed to render clusters.
+
+    For each leaf path we emit every ancestor (prefix) too, so deeply
+    nested clusters get their parents created. Ordering preserves the
+    first-seen order of leaves for stable DOT output.
+    """
+
+    seen: Set[str] = set()
+    ordered: List[List[str]] = []
+    for leaf in cluster_paths:
+        if not leaf:
+            continue
+        parts = leaf.split(".")
+        for depth in range(1, len(parts) + 1):
+            prefix = ".".join(parts[:depth])
+            if prefix in seen:
+                continue
+            seen.add(prefix)
+            ordered.append(parts[:depth])
+    return ordered
+
+
+def _node_label_lines(
+    name: str,
+    node: "SupergraphNode",
+    *,
+    coverage: Optional[float] = None,
+    distance: Optional[float] = None,
+    show_coverage: bool = False,
+) -> List[str]:
+    """Build the multi-line label for a supergraph node.
+
+    First line is the node name, second line is the op_type, and (when
+    requested) we append a coverage / divergence line. Kept text-only --
+    we let Graphviz draw it as an HTML-like table so it stays readable.
+    """
+
+    lines = [_html_escape(name)]
+    if node.op_type:
+        lines.append(f"<I>{_html_escape(node.op_type)}</I>")
+    if show_coverage and coverage is not None:
+        pct = int(round(coverage * 100))
+        lines.append(f"<FONT POINT-SIZE='10'>coverage: {pct}%</FONT>")
+    if distance is not None:
+        lines.append(f"<FONT POINT-SIZE='10'>div: {distance:.3g}</FONT>")
+    return lines
+
+
+def _html_escape(value: str) -> str:
+    """Escape the three Graphviz HTML-label specials."""
+
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _format_node_html(lines: List[str]) -> str:
+    """Wrap label lines into a Graphviz HTML-like label string."""
+
+    return "<" + "<BR/>".join(lines) + ">"
+
+
+# ---------------------------------------------------------------------------
+# Mode dispatch
+# ---------------------------------------------------------------------------
+
+
+def _style_node_divergence(
+    distances: Dict[str, Optional[float]],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in divergence mode."""
+
+    val = distances.get(name)
+    if val is None:
+        return _NEUTRAL_GREY, _DARK_TEXT
+    # Normalise to [0, 1] using the bundle-wide max so scales stay
+    # comparable. Skip nodes with None when computing the max.
+    valid = [v for v in distances.values() if v is not None]
+    max_val = max(valid) if valid else 0.0
+    frac = (val / max_val) if max_val > 0 else 0.0
+    fill = _sample_colormap(_REDS_HEX, frac)
+    font = _LIGHT_TEXT if _is_dark_swatch(_REDS_HEX, frac) else _DARK_TEXT
+    return fill, font
+
+
+def _style_node_swarm(
+    coverage_map: Dict[str, float],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in swarm mode."""
+
+    cov = coverage_map.get(name, 0.0)
+    fill = _sample_colormap(_VIRIDIS_HEX, cov)
+    font = _LIGHT_TEXT if _is_dark_swatch(_VIRIDIS_HEX, cov) else _DARK_TEXT
+    return fill, font
+
+
+def _style_node_group_color(
+    group_map: Dict[str, frozenset],
+    group_index: Dict[str, int],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in group_color mode."""
+
+    groups = group_map.get(name, frozenset())
+    if not groups:
+        return _NEUTRAL_GREY, _DARK_TEXT
+    if len(groups) > 1:
+        # Multi-group node -- neutral shade rather than blending.
+        return _NEUTRAL_GREY, _DARK_TEXT
+    only_group = next(iter(groups))
+    idx = group_index.get(only_group, 0)
+    fill = _TAB10_HEX[idx % len(_TAB10_HEX)]
+    return fill, _LIGHT_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def show_bundle_graph(
+    bundle: "TraceBundle",
+    vis_outpath: Optional[str] = None,
+    mode: ModeLiteral = "auto",
+    *,
+    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "cosine",
+    show_coverage: bool = False,
+    vis_opt: VisModeLiteral = "unrolled",
+    vis_format: FileFormatLiteral = "pdf",
+    vis_orientation: DirectionLiteral = "bottomup",
+    save_only: bool = False,
+    direction: Literal["forward", "backward", "both"] = "forward",
+    return_dot: bool = False,
+) -> Optional[str]:
+    """Render a :class:`TraceBundle` as a Graphviz graph.
+
+    Parameters
+    ----------
+    bundle:
+        The :class:`TraceBundle` to render.
+    vis_outpath:
+        Output path. Extension is inferred from ``vis_format`` and any
+        recognised extension on ``vis_outpath`` is stripped first. If
+        ``None`` (default), writes to ``"bundle_graph"`` in the current
+        working directory -- mirrors ``show_model_graph``'s default.
+    mode:
+        Styling mode: ``'auto'`` (picks divergence for shared topology,
+        swarm for divergent), ``'divergence'``, ``'swarm'``, or
+        ``'group_color'``.
+    metric:
+        Distance metric for divergence mode. Accepts the same strings as
+        :func:`torchlens.multi_trace.metrics.resolve_metric` (``cosine``,
+        ``relative_l2``, ``pearson``) or a callable
+        ``(Tensor, Tensor) -> Tensor``.
+    show_coverage:
+        For swarm mode, append a ``coverage: NN%`` row to each node's
+        label. Ignored in other modes.
+    vis_opt:
+        Layout flavour, ``'unrolled'`` (default) or ``'rolled'``.
+        Currently advisory -- the bundle renderer always treats each
+        supergraph node as a single rendered node; the kwarg is reserved
+        for future parity with ``show_model_graph``.
+    vis_format:
+        Output file format (``pdf``/``png``/``svg``/...).
+    vis_orientation:
+        Layout direction: ``'bottomup'`` (default), ``'topdown'``, or
+        ``'leftright'``. Mirrors ``show_model_graph``'s ``direction``.
+    save_only:
+        If ``True``, write the output file but skip opening a viewer.
+    direction:
+        Reserved for symmetry with ``show_model_graph``'s forward/backward
+        mode toggle. Bundle visualization currently only renders forward
+        graphs; ``'backward'`` raises ``ValueError``.
+    return_dot:
+        Internal/test hook -- if ``True``, return the generated DOT
+        source instead of writing to disk. Used by tests to inspect
+        styling without spawning Graphviz.
+
+    Returns
+    -------
+    str | None
+        The DOT source when ``return_dot=True``; otherwise ``None``.
+
+    Raises
+    ------
+    ValueError
+        If ``mode='group_color'`` and ``bundle.groups`` is empty, if the
+        mode literal is unknown, or if ``direction`` is anything other
+        than ``'forward'``.
+    """
+
+    # ----- arg validation -------------------------------------------------
+    if mode not in ("auto", "divergence", "swarm", "group_color"):
+        raise ValueError(
+            f"mode must be one of 'auto', 'divergence', 'swarm', or 'group_color'; got {mode!r}"
+        )
+    if vis_opt not in ("unrolled", "rolled"):
+        raise ValueError(f"vis_opt must be 'unrolled' or 'rolled'; got {vis_opt!r}")
+    if direction != "forward":
+        raise ValueError(
+            "show_bundle_graph currently only supports direction='forward'; "
+            "backward graph rendering is not part of the multi-trace "
+            "visualization phase."
+        )
+
+    if mode == "group_color" and not bundle.groups:
+        raise ValueError(
+            "mode='group_color' requires bundle.groups to be non-empty; "
+            "construct the bundle with `tl.bundle(traces, names=..., "
+            "groups={'a': ['n1'], 'b': ['n2']})`."
+        )
+    if mode == "group_color" and len(bundle.groups) > len(_TAB10_HEX):
+        raise ValueError(
+            f"mode='group_color' supports up to {len(_TAB10_HEX)} groups; "
+            f"got {len(bundle.groups)}. Reduce the group count or extend "
+            "the palette."
+        )
+
+    resolved_mode = _resolve_mode(bundle, mode)
+
+    # ----- per-node styling data -----------------------------------------
+    distances: Dict[str, Optional[float]] = {}
+    coverage_map: Dict[str, float] = {}
+    group_map: Dict[str, frozenset] = {}
+    group_index: Dict[str, int] = {}
+
+    if resolved_mode == "divergence":
+        distances = _per_node_distance(bundle, metric)
+    if resolved_mode == "swarm" or show_coverage:
+        coverage_map = _per_node_coverage(bundle)
+    if resolved_mode == "group_color":
+        group_map = _per_node_groups(bundle)
+        # Stable, dict-insertion-order indexing; bundle.groups is a copy
+        # but the underlying dict preserves insertion order in CPython.
+        group_index = {gname: i for i, gname in enumerate(bundle.groups)}
+
+    # ----- DOT graph build ------------------------------------------------
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    rankdir = _direction_to_rankdir(vis_orientation)
+
+    n_traces = len(bundle.names)
+    n_nodes = len(sg.nodes)
+    # HTML-style labels are bracketed by ``<>`` so any literal ``<``/``>``
+    # inside the body must be escaped or graphviz refuses to parse the
+    # label. The caption is the only place we historically embed an
+    # arrow ("auto -> swarm"); escape it via the standard HTML entities.
+    caption_lines = [
+        "<B>TraceBundle</B>",
+        f"{n_traces} traces, {n_nodes} supergraph nodes",
+        f"mode={_html_escape(resolved_mode)}",
+    ]
+    if mode == "auto" and resolved_mode != "auto":
+        caption_lines[-1] = f"mode=auto -&gt; {_html_escape(resolved_mode)}"
+    if resolved_mode == "group_color":
+        caption_lines.append("groups: " + _html_escape(", ".join(sorted(bundle.groups))))
+    graph_caption = "<" + "<BR ALIGN='LEFT'/>".join(caption_lines) + "<BR ALIGN='LEFT'/>>"
+
+    dot = graphviz.Digraph(
+        name="trace_bundle",
+        comment="Computational graph for a TorchLens TraceBundle",
+        format=vis_format,
+    )
+    dot.graph_attr.update(
+        {
+            "rankdir": rankdir,
+            "label": graph_caption,
+            "labelloc": "t",
+            "labeljust": "left",
+            "ordering": "out",
+            "compound": "true",
+        }
+    )
+    dot.node_attr.update({"ordering": "out", "shape": "box", "style": "filled"})
+
+    # Build cluster lookup (leaf cluster path -> node names).
+    leaf_cluster_to_nodes = _build_module_clusters(bundle)
+
+    # Pre-compute per-node fill / font colours so cluster nesting is the
+    # only remaining concern.
+    node_styles: Dict[str, Tuple[str, str]] = {}
+    node_labels: Dict[str, str] = {}
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        if resolved_mode == "divergence":
+            fill, font = _style_node_divergence(distances, name)
+        elif resolved_mode == "swarm":
+            fill, font = _style_node_swarm(coverage_map, name)
+        else:  # group_color
+            fill, font = _style_node_group_color(group_map, group_index, name)
+        node_styles[name] = (fill, font)
+        label_lines = _node_label_lines(
+            name,
+            node,
+            coverage=coverage_map.get(name) if coverage_map else None,
+            distance=distances.get(name) if distances else None,
+            show_coverage=show_coverage and resolved_mode == "swarm",
+        )
+        node_labels[name] = _format_node_html(label_lines)
+
+    # Build the cluster hierarchy lazily: for each cluster path we open a
+    # subgraph and emit its nodes; nested clusters open inside their
+    # parents. We do this by sorting leaves by depth and walking each
+    # ancestor chain.
+
+    # Map dotted-prefix -> set of direct child dotted-prefixes (one
+    # level deeper) and direct nodes that live in that prefix.
+    prefix_children: Dict[str, Set[str]] = defaultdict(set)
+    prefix_nodes: Dict[str, List[str]] = defaultdict(list)
+    for leaf, names_at_leaf in leaf_cluster_to_nodes.items():
+        prefix_nodes[leaf].extend(names_at_leaf)
+        if not leaf:
+            continue
+        parts = leaf.split(".")
+        for depth in range(1, len(parts) + 1):
+            child = ".".join(parts[:depth])
+            parent = ".".join(parts[: depth - 1])
+            prefix_children[parent].add(child)
+
+    # ROOT nodes: those whose leaf cluster is "" (no module path).
+    root_nodes = list(prefix_nodes.get("", []))
+    for name in root_nodes:
+        fill, font = node_styles[name]
+        dot.node(
+            _safe_dot_id(name),
+            label=node_labels[name],
+            fillcolor=fill,
+            fontcolor=font,
+            color=fill,
+        )
+
+    # Nested clusters: walk depth-first, attaching nodes to the right level.
+    def _emit_subgraph(parent_dot: graphviz.Digraph, prefix: str) -> None:
+        cluster_label = prefix.split(".")[-1] if prefix else ""
+        cluster_name = f"cluster_{_safe_dot_id(prefix)}"
+        with parent_dot.subgraph(name=cluster_name) as sub:
+            sub.attr(
+                label=f"<<B>@{_html_escape(cluster_label)}</B>>",
+                labelloc="b",
+                style="filled",
+                fillcolor="white",
+                color="#888888",
+                penwidth="2",
+            )
+            for child_prefix in sorted(prefix_children.get(prefix, set())):
+                _emit_subgraph(sub, child_prefix)
+            for node_name in prefix_nodes.get(prefix, []):
+                fill, font = node_styles[node_name]
+                sub.node(
+                    _safe_dot_id(node_name),
+                    label=node_labels[node_name],
+                    fillcolor=fill,
+                    fontcolor=font,
+                    color=fill,
+                )
+
+    for top_prefix in sorted(prefix_children.get("", set())):
+        _emit_subgraph(dot, top_prefix)
+
+    # Edges. In group_color mode we colour edges by the dominant group of
+    # the traces that traversed the edge; in other modes we use a faded
+    # neutral so coloured nodes pop.
+    for (parent, child), trace_set in sg.edges.items():
+        edge_color = _resolve_edge_color(
+            trace_set,
+            resolved_mode=resolved_mode,
+            bundle=bundle,
+            group_index=group_index,
+        )
+        dot.edge(
+            _safe_dot_id(parent),
+            _safe_dot_id(child),
+            color=edge_color,
+            penwidth="1.5",
+        )
+
+    if return_dot:
+        return dot.source
+
+    # ----- output ---------------------------------------------------------
+    outpath = vis_outpath if vis_outpath is not None else "bundle_graph"
+    outpath = strip_known_extension(outpath)
+
+    if in_notebook() and not save_only:  # pragma: no cover - env-dependent
+        from IPython.display import display
+
+        display(dot)
+
+    timeout_warning = (
+        f"Graphviz render timed out for TraceBundle graph "
+        f"({n_nodes} nodes). DOT source preserved on disk."
+    )
+    render_dot_to_file(
+        dot,
+        outpath,
+        vis_format,
+        save_only,
+        timeout_warning=timeout_warning,
+    )
+    return None
+
+
+def _resolve_edge_color(
+    trace_set: Set[str],
+    *,
+    resolved_mode: ModeLiteral,
+    bundle: "TraceBundle",
+    group_index: Dict[str, int],
+) -> str:
+    """Pick a stroke colour for a supergraph edge given the traversing traces.
+
+    In ``group_color`` mode an edge gets the colour of the group that
+    traversed it (or neutral grey if multiple groups did). In divergence
+    and swarm modes we keep edges neutral so the coloured nodes stay the
+    visual focus.
+    """
+
+    if resolved_mode != "group_color":
+        return _EDGE_COLOR_NEUTRAL
+
+    groups = bundle.groups
+    if not groups or not group_index:
+        return _EDGE_COLOR_NEUTRAL
+
+    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
+    for group_name, members in groups.items():
+        for trace_name in members:
+            trace_to_groups[trace_name].add(group_name)
+
+    edge_groups: Set[str] = set()
+    for trace_name in trace_set:
+        edge_groups.update(trace_to_groups.get(trace_name, set()))
+
+    if len(edge_groups) == 1:
+        only = next(iter(edge_groups))
+        return _TAB10_HEX[group_index.get(only, 0) % len(_TAB10_HEX)]
+    return _EDGE_COLOR_NEUTRAL
+
+
+__all__ = ["show_bundle_graph"]

--- a/torchlens/visualization/_render_utils.py
+++ b/torchlens/visualization/_render_utils.py
@@ -1,0 +1,99 @@
+"""Internal Graphviz rendering helpers shared across rendering paths.
+
+Private module: not part of the public API. Provides ModelLog-agnostic
+primitives that the single-trace ``rendering.py`` and the multi-trace
+``multi_trace/visualization.py`` both rely on, so we have one canonical
+implementation of file-format dispatch instead of two divergent copies.
+
+Keep this module narrow on purpose -- only primitives that take no
+ModelLog/Bundle context and can be reasoned about as pure utilities.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import warnings
+from typing import TYPE_CHECKING
+
+import graphviz
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    pass
+
+
+# Recognised file extensions that callers may include on ``vis_outpath``.
+# Mirrors the legacy list in ``rendering.render_graph`` (kept as a tuple
+# so it stays cheap and immutable).
+_KNOWN_EXTS = ("pdf", "png", "jpg", "svg", "jpeg", "bmp", "pic", "tif", "tiff")
+
+# Default subprocess timeout for the dot/sfdp render call. Mirrors the
+# legacy literal that lived inside ``rendering.render_graph``.
+RENDER_TIMEOUT_SECONDS = 120
+
+
+def strip_known_extension(outpath: str) -> str:
+    """Strip a recognised image extension off ``outpath`` if present.
+
+    The Graphviz Python binding wants the basename without an extension --
+    it adds the extension itself based on the requested ``format``. Users
+    who pass ``"out.pdf"`` should still get ``"out.pdf"`` rather than
+    ``"out.pdf.pdf"``, so we trim a trailing recognised extension.
+    """
+
+    parts = outpath.split(".")
+    if len(parts) > 1 and parts[-1].lower() in _KNOWN_EXTS:
+        return ".".join(parts[:-1])
+    return outpath
+
+
+def render_dot_to_file(
+    dot: "graphviz.Digraph",
+    outpath: str,
+    file_format: str,
+    save_only: bool,
+    *,
+    timeout_seconds: int = RENDER_TIMEOUT_SECONDS,
+    timeout_warning: str | None = None,
+) -> str:
+    """Render ``dot`` to ``outpath.<file_format>``, optionally previewing it.
+
+    Mirrors the dot/save/subprocess/view flow used internally by
+    ``rendering.render_graph`` and ``rendering.render_backward_graph``,
+    factored out so the multi-trace renderer can share the same plumbing.
+
+    Returns the DOT source string (``dot.source``) regardless of whether
+    the subprocess render succeeded -- failures are surfaced via
+    ``warnings.warn`` to match existing behaviour.
+    """
+
+    parent = os.path.dirname(os.path.abspath(outpath))
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, exist_ok=True)
+
+    source_path = dot.save(outpath)
+    try:
+        rendered_path = f"{outpath}.{file_format}"
+        cmd = [dot.engine, f"-T{file_format}", "-o", rendered_path, source_path]
+        subprocess.run(
+            cmd,
+            timeout=timeout_seconds,
+            check=True,
+            capture_output=True,
+        )
+        if not save_only:
+            graphviz.backend.viewing.view(rendered_path)
+    except subprocess.TimeoutExpired:
+        warnings.warn(
+            timeout_warning
+            or (
+                f"Graphviz render timed out ({timeout_seconds}s). "
+                f"DOT source saved to '{source_path}'."
+            )
+        )
+    except subprocess.CalledProcessError as exc:
+        warnings.warn(f"Graphviz render failed: {exc.stderr.decode()}")
+    finally:
+        if os.path.exists(source_path):
+            os.remove(source_path)
+    return dot.source


### PR DESCRIPTION
## Summary

Adds a Graphviz visualization layer for `TraceBundle` objects (Phase 2 of
the multi-trace sprint). Phase 1 (TraceBundle, Supergraph, NodeView,
topology, metrics) shipped in #170; this PR builds on that foundation.

### Public surface

* `tl.show_bundle_graph(bundle, ...)` -- canonical entry point.
* `bundle.show(...)` -- thin wrapper on `TraceBundle` for ergonomics.
* Re-exported from `torchlens.multi_trace` and the top-level `torchlens`
  package.

### Modes

| Mode | Colormap | When to use |
|------|----------|-------------|
| `divergence` | sequential Reds | Shared topology -- "which nodes change most?" |
| `swarm` | sequential viridis | Divergent topology -- "which nodes do most traces visit?" |
| `group_color` | tab10 categorical | When `bundle.groups` is non-empty |
| `auto` | (resolves) | shared -> divergence, divergent -> swarm |

In `group_color` mode, nodes traversed by multiple groups get a neutral
light-grey shade rather than a blended palette colour (per spec).

Output formats mirror `show_model_graph`: PDF, PNG, SVG, JPG, BMP, TIF.

### Usage

```python
import torchlens as tl

bundle = tl.bundle(
    [ml1, ml2, ml3],
    names=['cat_01', 'cat_02', 'dog_01'],
    groups={'cats': ['cat_01', 'cat_02'], 'dogs': ['dog_01']},
)

tl.show_bundle_graph(bundle, vis_outpath='out.pdf', mode='auto')
bundle.show('out.pdf', mode='group_color')
bundle.show('out.pdf', mode='divergence', metric='relative_l2')
bundle.show('out.pdf', mode='swarm', show_coverage=True)
```

## Refactor scope

Reused (extracted to `torchlens/visualization/_render_utils.py`, a private
helper module):

* `strip_known_extension(outpath)` -- canonical extension-stripping.
* `render_dot_to_file(dot, outpath, format, save_only, ...)` -- the
  `dot.save` / `subprocess.run` / `view` orchestration shared by both
  rendering paths.

Duplicated (intentionally, with rationale documented in
`torchlens/multi_trace/visualization.py`'s module docstring):

* The bundle renderer builds its own `graphviz.Digraph` rather than
  calling into `rendering.render_graph`. The single-trace orchestrator
  is ~340 lines wired into ~3500 lines of helpers, all assuming
  `ModelLog` state (`self.modules._pass_dict`, `self.layer_logs`,
  `self._all_layers_logged`, etc.). Re-pointing it at a `Supergraph`
  cleanly within this dispatch's risk budget was not feasible -- the
  existing `show_model_graph()` regression invariant from the spec was
  the priority.
* Colour palettes (Reds, viridis, tab10) are hardcoded as 10-stop hex
  arrays so torchlens does not gain a matplotlib dependency.
* Module clusters in the bundle renderer are derived from each
  supergraph node's `module_path` string (dotted prefix chain) rather
  than the `ModuleLog` hierarchy, which is not first-class on a
  `Supergraph`.

## Tests

`tests/test_multi_trace_visualization.py`: 17 tests (15 spec'd + 2
internal-consistency bonus), one marked `@pytest.mark.smoke`. All four
modes verified end-to-end via DOT-source inspection plus rendered file
size checks.

## Test plan

- [x] `pytest tests/test_multi_trace_visualization.py -v` (17 passed)
- [x] `pytest tests/test_multi_trace.py -v` (28 passed -- Phase 1
  regression)
- [x] `pytest tests/test_backward_visualization.py -v` (8 passed --
  forward graph regression check inside the file)
- [x] `pytest tests/test_output_aesthetics.py -v` (12 passed -- visual
  regression)
- [x] `pytest tests/ -m smoke -x` (90 passed)
- [x] `ruff check .` (clean)
- [x] `mypy torchlens/` (clean)
- [x] Manual eyeball of all four modes rendered as PNGs at 4-trace,
  10-node ResNet-style bundles.

## Notes

Phase 1's deferred V2 items in `.project-context/todos.md` remain parked
for future sprints (interactive viewer, custom node visualizations,
intervention APIs, ModelLog -> Trace rename, etc.). The committed
`todos.md` edit on this branch is the architect's pre-existing
working-tree update -- carried in this branch as instructed.