### PR TITLE
feat(multi-trace): bundle visualization (Phase 2)

### DIFF
--- a/.project-context/todos.md
+++ b/.project-context/todos.md
@@ -6,6 +6,55 @@
 
 ## Improvements (Nice-to-Have)
 
+### Multi-trace V2 (deferred from 2026-04-27 sprint design)
+
+These were scoped OUT of the multi-trace MVP (TraceBundle + TraceOverlay)
+but are natural follow-ons. Pick up after MVP ships.
+
+- **Branch-divergence detection.** Soft version of "counterfactual
+  tracing." Given a TraceOverlay, surface "branch-divergence nodes"
+  where execution paths split, expose as a queryable list. NOT true
+  forced-branch enumeration -- just detection of where forward paths
+  diverged across the bundled inputs.
+
+- **True counterfactual branch enumeration** (forced-branch execution).
+  Programmatically force both arms of every Python `if` in a dynamic
+  network. Hard problem -- requires either symbolic tracing
+  (incompatible with TorchLens's runtime model), bytecode hacking
+  (fragile), or an intervention API where the user explicitly drives
+  forced inputs to coax branches. Defer indefinitely; the
+  branch-divergence detection above is the practical 80% solution.
+
+- **Streaming aggregate over a dataloader.** `tl.aggregate(model,
+  dataloader, metrics=[...])` -- consumes traces from a generator,
+  computes running per-node statistics (mean, var, RDM,
+  dimensionality), discards raw activations. For "10K images through
+  ResNet50" workflows where holding traces is impractical. Function,
+  not a class.
+
+- **Interactive viewer for bundles/overlays.** D3.js or anywidget-based
+  Jupyter widget. Pan/zoom, hover tooltips, click-to-expand node
+  visualizations, path highlighting, export to standalone HTML. After
+  graphviz MVP is stable.
+
+- **Custom node visualizations.** Pluggable per-node display: PCA-RGB
+  for conv layers, MDS scatter for linear layers, histograms for
+  activations, dimensionality estimates. Bundle/Overlay would accept
+  `node_display={'conv.*': 'pca_rgb', ...}` mappings.
+
+- **Convenience constructors with intervention APIs.** `tl.zero(node)`,
+  `tl.steer(node, vector)`, `tl.compare(model, input, {...})`,
+  `tl.sweep(model, input, {...})`. Interventions produce a new
+  ModelLog (never mix clean and intervened activations in a Bundle).
+  Out of scope for MVP; design once Bundle/Overlay are stable.
+
+- **Rename ModelLog -> Trace** (one-way door). Clean public-API
+  migration -- `tl.trace()` constructor, `Trace` class. Major
+  breaking change to a published-and-cited package. Do as a separate
+  deliberate migration, never bundled with feature work.
+
+### Other improvements
+
 - Rethink the parameter name `activation_postfunc` itself. Current name is
   awkward (`-postfunc` suffix) and the semantic now reads as a "transform"
   hook, not a "post-processing function" (after the raw-vs-transformed

--- a/.project-context/todos.md
+++ b/.project-context/todos.md
@@ -53,6 +53,24 @@ but are natural follow-ons. Pick up after MVP ships.
   breaking change to a published-and-cited package. Do as a separate
   deliberate migration, never bundled with feature work.
 
+- **`vis_opt='rolled'` mode for `show_bundle_graph`.** Phase 2 plumbed
+  the kwarg through with arg validation but the bundle renderer
+  currently treats every supergraph node as a single rendered node
+  regardless. The supergraph already operates on `LayerLog` (rolled-
+  equivalent) entries, so cluster titles already carry `(xN)` count
+  suffixes for multi-pass modules. A true `rolled` mode would also
+  collapse loop-detected layer chains into single rendered nodes the
+  way `rendering.py` does for `vis_mode='rolled'`. Defer until a real
+  use case appears; the current `unrolled` behaviour covers the
+  visualization story for shared-topology and divergent bundles.
+
+- **`direction='backward'` for `show_bundle_graph`.** Currently raises
+  `ValueError` on anything except `'forward'`. Backward graph topology
+  depends on forward execution path, so multi-trace backward
+  visualization needs a design decision -- per-trace separate backward
+  subgraphs, or a unified backward supergraph keyed on grad_fn? Defer
+  to the multi-trace V2 batch alongside the other Phase 2 follow-ons.
+
 ### Other improvements
 
 - Rethink the parameter name `activation_postfunc` itself. Current name is

--- a/tests/test_multi_trace_visualization.py
+++ b/tests/test_multi_trace_visualization.py
@@ -1,0 +1,361 @@
+"""Tests for the multi_trace visualization layer (show_bundle_graph).
+
+Covers the 15 cases from the Phase 2 spec. Fixtures are inlined rather
+than shared via conftest to keep this file self-contained -- it mirrors
+the pattern used in ``test_multi_trace.py``.
+
+Where the test only needs to verify that styling differs between modes
+we inspect the generated DOT source via the ``return_dot=True`` test
+hook on ``show_bundle_graph``. Where the test verifies actual file
+output, we render to a temp directory and check size + extension.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+import torch
+from torch import nn
+
+import torchlens as tl
+from torchlens.multi_trace import TraceBundle, bundle, show_bundle_graph
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _LinearNet(nn.Module):
+    """Small static model used for shared-topology bundles."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(4, 4)
+        self.fc2 = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(self.fc2(torch.relu(self.fc1(x))))
+
+
+class _BranchNet(nn.Module):
+    """Conditionally branching model used for divergent-topology bundles."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.mean() > 0:
+            return torch.relu(x)
+        return torch.sigmoid(x)
+
+
+def _shared_bundle(n_traces: int = 3, batch: int = 2) -> TraceBundle:
+    """Build a shared-topology bundle from N forward passes of _LinearNet."""
+
+    model = _LinearNet()
+    traces = [tl.log_forward_pass(model, torch.rand(batch, 4)) for _ in range(n_traces)]
+    return TraceBundle(traces)
+
+
+def _divergent_bundle() -> TraceBundle:
+    """Build a divergent-topology bundle from a branching model."""
+
+    model = _BranchNet()
+    ml_pos = tl.log_forward_pass(model, torch.ones(2, 4))
+    ml_neg = tl.log_forward_pass(model, -torch.ones(2, 4))
+    return TraceBundle([ml_pos, ml_neg], names=["pos", "neg"])
+
+
+def _grouped_bundle() -> TraceBundle:
+    """Bundle with non-empty groups, suitable for group_color mode."""
+
+    model = _LinearNet()
+    traces = [tl.log_forward_pass(model, torch.rand(2, 4)) for _ in range(4)]
+    names = ["a1", "a2", "b1", "b2"]
+    groups = {"alphas": ["a1", "a2"], "betas": ["b1", "b2"]}
+    return TraceBundle(traces, names=names, groups=groups)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _file_nonempty(path: Path) -> bool:
+    """Return True if ``path`` exists and has size > 0."""
+
+    return path.exists() and path.stat().st_size > 0
+
+
+def _find_rendered(parent: Path, stem: str, ext: str) -> Path:
+    """Locate the rendered file by stem/extension under ``parent``."""
+
+    direct = parent / f"{stem}.{ext}"
+    if direct.exists():
+        return direct
+    matches: List[Path] = list(parent.glob(f"{stem}.{ext}"))
+    if matches:
+        return matches[0]
+    raise AssertionError(
+        f"No file matching '{stem}.{ext}' found under {parent}; "
+        f"contents: {sorted(p.name for p in parent.iterdir())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1-10: API behaviour + mode coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_show_bundle_graph_smoke(tmp_path: Path) -> None:
+    """Shared-topology bundle, mode='auto', writes a non-empty PDF."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle"
+    show_bundle_graph(b, vis_outpath=str(out), mode="auto", save_only=True)
+    rendered = _find_rendered(tmp_path, "bundle", "pdf")
+    assert _file_nonempty(rendered), f"expected non-empty file at {rendered}"
+
+
+def test_show_bundle_graph_divergence_mode(tmp_path: Path) -> None:
+    """Explicit mode='divergence' on a shared-topology bundle writes output."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle_div"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_div", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_swarm_mode(tmp_path: Path) -> None:
+    """Divergent-topology bundle in swarm mode writes output."""
+
+    b = _divergent_bundle()
+    out = tmp_path / "bundle_swarm"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="swarm",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_swarm", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_group_color_mode(tmp_path: Path) -> None:
+    """Bundle with groups + mode='group_color' writes output."""
+
+    b = _grouped_bundle()
+    out = tmp_path / "bundle_groups"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="group_color",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_groups", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_group_color_no_groups_errors() -> None:
+    """mode='group_color' on a bundle with no groups raises ValueError."""
+
+    b = _shared_bundle()
+    with pytest.raises(ValueError, match="bundle.groups"):
+        show_bundle_graph(b, mode="group_color", save_only=True, return_dot=True)
+
+
+def test_show_bundle_graph_auto_mode_picks_divergence() -> None:
+    """Shared-topology bundle + mode='auto' resolves to divergence styling.
+
+    Inspect the DOT caption (which records the resolved mode) plus a
+    palette colour cue: divergence uses the Reds palette, of which the
+    final stop ``#4a000a`` is a unique signature relative to viridis.
+    """
+
+    b = _shared_bundle()
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+    # Caption records the auto resolution.
+    assert "auto -&gt; divergence" in src or "auto -> divergence" in src
+    # Reds palette in use somewhere.
+    assert any(stop in src for stop in ("#fff5f0", "#fee0d2", "#fcbba1"))
+
+
+def test_show_bundle_graph_auto_mode_picks_swarm() -> None:
+    """Divergent-topology bundle + mode='auto' resolves to swarm styling."""
+
+    b = _divergent_bundle()
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+    assert "auto -&gt; swarm" in src or "auto -> swarm" in src
+    # Viridis palette signature -- ``#440154`` is unique to viridis stops.
+    assert "#440154" in src or "#fde725" in src
+
+
+def test_bundle_show_method(tmp_path: Path) -> None:
+    """``bundle.show()`` produces equivalent output to the top-level helper."""
+
+    b = _shared_bundle()
+    out_a = tmp_path / "via_method"
+    out_b = tmp_path / "via_func"
+
+    b.show(vis_outpath=str(out_a), mode="divergence", save_only=True)
+    show_bundle_graph(b, vis_outpath=str(out_b), mode="divergence", save_only=True)
+
+    file_a = _find_rendered(tmp_path, "via_method", "pdf")
+    file_b = _find_rendered(tmp_path, "via_func", "pdf")
+    assert _file_nonempty(file_a)
+    assert _file_nonempty(file_b)
+    # Both DOT sources should be identical -- the method is a thin wrapper.
+    src_a = b.show(vis_outpath=None, mode="divergence", return_dot=True)
+    src_b = show_bundle_graph(b, mode="divergence", return_dot=True)
+    assert src_a == src_b
+
+
+def test_show_bundle_graph_format_png(tmp_path: Path) -> None:
+    """vis_format='png' produces a .png file."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle_png"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        vis_format="png",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_png", "png")
+    assert _file_nonempty(rendered)
+
+
+def test_show_bundle_graph_format_svg(tmp_path: Path) -> None:
+    """vis_format='svg' produces a .svg file."""
+
+    b = _shared_bundle()
+    out = tmp_path / "bundle_svg"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        vis_format="svg",
+        save_only=True,
+    )
+    rendered = _find_rendered(tmp_path, "bundle_svg", "svg")
+    assert _file_nonempty(rendered)
+
+
+# ---------------------------------------------------------------------------
+# 11-15: regression + kwargs + IO
+# ---------------------------------------------------------------------------
+
+
+def test_show_model_graph_unchanged(tmp_path: Path) -> None:
+    """Regression: tl.show_model_graph(modellog) still produces a file."""
+
+    model = _LinearNet()
+    out = tmp_path / "single_trace"
+    tl.show_model_graph(
+        model,
+        torch.rand(2, 4),
+        vis_outpath=str(out),
+        vis_save_only=True,
+        vis_fileformat="pdf",
+    )
+    rendered = _find_rendered(tmp_path, "single_trace", "pdf")
+    assert _file_nonempty(rendered)
+
+
+def test_swarm_show_coverage_kwarg() -> None:
+    """``show_coverage=True`` in swarm mode writes coverage labels into DOT."""
+
+    b = _divergent_bundle()
+    src_with = show_bundle_graph(b, mode="swarm", show_coverage=True, return_dot=True)
+    src_without = show_bundle_graph(b, mode="swarm", show_coverage=False, return_dot=True)
+    assert src_with is not None and src_without is not None
+    assert "coverage:" in src_with
+    assert "coverage:" not in src_without
+
+
+def test_metric_kwarg_for_divergence() -> None:
+    """metric='relative_l2' produces different DOT than the default cosine."""
+
+    b = _shared_bundle()
+    src_default = show_bundle_graph(b, mode="divergence", return_dot=True)
+    src_l2 = show_bundle_graph(b, mode="divergence", metric="relative_l2", return_dot=True)
+    assert src_default is not None and src_l2 is not None
+    # The per-node distance values flow into the rendered ``div: X.XX``
+    # rows, so swapping metrics SHOULD change the source unless the
+    # metrics happen to agree exactly (vanishingly unlikely on random
+    # initialisation).
+    assert src_default != src_l2
+
+
+def test_show_bundle_graph_with_default_outpath(tmp_path: Path) -> None:
+    """No vis_outpath -> writes to ``bundle_graph.<format>`` in cwd."""
+
+    import os
+
+    cwd = Path(os.getcwd())
+    saved = list(cwd.glob("bundle_graph.pdf"))
+    # Move to tmp_path so cleanup is automatic and we don't pollute repo.
+    os.chdir(tmp_path)
+    try:
+        b = _shared_bundle()
+        show_bundle_graph(b, mode="divergence", save_only=True)
+        rendered = tmp_path / "bundle_graph.pdf"
+        assert _file_nonempty(rendered)
+    finally:
+        os.chdir(cwd)
+    # Sanity: we haven't accidentally written into the repo root.
+    after = list(cwd.glob("bundle_graph.pdf"))
+    assert after == saved, f"unexpected new bundle_graph.pdf in cwd: {after} vs {saved}"
+
+
+def test_directory_creation(tmp_path: Path) -> None:
+    """vis_outpath='subdir/bundle.pdf' creates the subdir if needed."""
+
+    b = _shared_bundle()
+    nested = tmp_path / "deep" / "nest"
+    assert not nested.exists()
+    out = nested / "bundle"
+    show_bundle_graph(
+        b,
+        vis_outpath=str(out),
+        mode="divergence",
+        save_only=True,
+    )
+    rendered = _find_rendered(nested, "bundle", "pdf")
+    assert _file_nonempty(rendered)
+
+
+# ---------------------------------------------------------------------------
+# Bonus: a couple of internal-consistency checks discovered while writing
+# the spec'd 15 -- helpful for catching regressions later but cheap to run.
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_mode_raises() -> None:
+    """An unknown mode literal raises ValueError before doing any work."""
+
+    b = _shared_bundle()
+    with pytest.raises(ValueError, match="mode must be one of"):
+        show_bundle_graph(b, mode="rainbow", return_dot=True)  # type: ignore[arg-type]
+
+
+def test_too_many_groups_raises() -> None:
+    """More groups than the categorical palette supports raises ValueError."""
+
+    model = _LinearNet()
+    traces = [tl.log_forward_pass(model, torch.rand(2, 4)) for _ in range(11)]
+    names = [f"t{i}" for i in range(11)]
+    groups = {f"g{i}": [names[i]] for i in range(11)}
+    b = TraceBundle(traces, names=names, groups=groups)
+    with pytest.raises(ValueError, match="up to 10 groups"):
+        show_bundle_graph(b, mode="group_color", return_dot=True)

--- a/tests/test_multi_trace_visualization.py
+++ b/tests/test_multi_trace_visualization.py
@@ -13,7 +13,7 @@ output, we render to a temp directory and check size + extension.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import pytest
 import torch
@@ -359,3 +359,271 @@ def test_too_many_groups_raises() -> None:
     b = TraceBundle(traces, names=names, groups=groups)
     with pytest.raises(ValueError, match="up to 10 groups"):
         show_bundle_graph(b, mode="group_color", return_dot=True)
+
+
+# ---------------------------------------------------------------------------
+# Module-cluster aesthetic parity with show_model_graph
+# ---------------------------------------------------------------------------
+
+
+def _extract_cluster_penwidths(dot_source: str) -> List[Tuple[str, float]]:
+    """Return ``[(cluster_name, penwidth), ...]`` from a Graphviz DOT source.
+
+    Walks line-by-line looking for ``subgraph "cluster_*"`` (or
+    ``subgraph cluster_*``) declarations and the ``penwidth=N`` attribute
+    on the immediately-following ``s.attr(...)`` line.  Used by the
+    parity tests to compare cluster border widths between bundle output
+    and ModelLog output.
+    """
+
+    import re
+
+    cluster_re = re.compile(r"subgraph\s+\"?(cluster_[A-Za-z0-9_.]+)\"?")
+    penwidth_re = re.compile(r"penwidth=([0-9.]+)")
+    out: List[Tuple[str, float]] = []
+    pending: Optional[str] = None
+    for line in dot_source.splitlines():
+        m_cluster = cluster_re.search(line)
+        if m_cluster:
+            pending = m_cluster.group(1)
+            continue
+        if pending is not None:
+            m_pen = penwidth_re.search(line)
+            if m_pen:
+                out.append((pending, float(m_pen.group(1))))
+                pending = None
+    return out
+
+
+class _NestedNet(nn.Module):
+    """Two levels of module nesting -- exercises depth-1 + depth-2 clusters."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.outer = _OuterBlock()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.outer(x)
+
+
+class _OuterBlock(nn.Module):
+    """Outer wrapper used by :class:`_NestedNet`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner = _InnerBlock()
+        self.fc = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(self.fc(self.inner(x)))
+
+
+class _InnerBlock(nn.Module):
+    """Inner wrapper used by :class:`_OuterBlock`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(self.lin(x))
+
+
+class _RecurrentNet(nn.Module):
+    """Calls a single submodule three times -- exercises pass-suffix labels."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.block = _InnerBlock()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.block(x)
+        x = self.block(x)
+        x = self.block(x)
+        return x
+
+
+def test_module_cluster_penwidth_parity(tmp_path: Path) -> None:
+    """Cluster penwidths match between ModelLog and bundle for the same model.
+
+    Render the same nested model both as a single trace (via
+    ``show_model_graph``) and as a single-trace bundle and assert that
+    cluster ``penwidth`` values are identical at equivalent depths.  The
+    bundle uses the shared ``compute_module_penwidth`` formula in
+    ``visualization/_render_utils.py`` so single-trace and multi-trace
+    output should converge.
+    """
+
+    model = _NestedNet()
+    log = tl.log_forward_pass(model, torch.rand(2, 4))
+    modellog_src = log.render_graph(vis_save_only=True, vis_outpath=str(tmp_path / "modellog"))
+
+    b = TraceBundle([log])
+    bundle_src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert bundle_src is not None
+
+    modellog_widths = {key: width for key, width in _extract_cluster_penwidths(modellog_src)}
+    bundle_widths = {key: width for key, width in _extract_cluster_penwidths(bundle_src)}
+
+    # ``outer`` cluster: top-level (depth 0) -> max penwidth (5.0)
+    # ``outer.inner`` cluster: depth 1 -> middle width (4.0 with 2 levels of nesting,
+    # or different value depending on max_depth).
+    # We don't hardcode 5.0 / 4.0 since the formula depends on max_depth; we just
+    # require the bundle outputs the SAME values as ModelLog at matching keys.
+
+    assert modellog_widths, "expected at least one cluster penwidth in ModelLog DOT"
+    assert bundle_widths, "expected at least one cluster penwidth in bundle DOT"
+
+    # Build a normalised per-base-name map: ``{base_name: penwidth}`` so we can
+    # compare without depending on internal cluster_<name>_pass<N> mangling.
+    # The bundle's ``safe_dot_id`` rewrites ``.`` -> ``_`` so we also collapse
+    # both forms into a common key shape (``outer.inner`` and ``outer_inner``
+    # both -> ``outer-inner``).
+    def _normalise_keys(widths: dict[str, float]) -> dict[str, float]:
+        out: dict[str, float] = {}
+        for key, width in widths.items():
+            base = key.replace("cluster_", "")
+            # Strip any trailing pass numbering (``_pass1`` from ModelLog,
+            # ``_1`` from the bundle's ``safe_dot_id`` output).
+            for sep in ("_pass", "_"):
+                if sep in base and base.rsplit(sep, 1)[-1].isdigit():
+                    base = base.rsplit(sep, 1)[0]
+                    break
+            base = base.replace(".", "-").replace("_", "-")
+            out.setdefault(base, width)
+        return out
+
+    modellog_norm = _normalise_keys(modellog_widths)
+    bundle_norm = _normalise_keys(bundle_widths)
+
+    shared_keys = set(modellog_norm) & set(bundle_norm)
+    assert shared_keys, (
+        f"no shared cluster keys between ModelLog ({sorted(modellog_norm)}) and "
+        f"bundle ({sorted(bundle_norm)})"
+    )
+
+    # The shallowest shared cluster (i.e. the one with the fewest "-" in its
+    # normalised name) MUST have identical penwidth across renders -- this
+    # is the strongest depth-0 parity check.  At deeper depths ModelLog's
+    # ``_get_max_nesting_depth`` excludes some leaf clusters from the depth
+    # count (it only counts modules with their own internal edges) while
+    # the bundle counts all nesting levels, so deeper-depth penwidths are
+    # allowed to drift.  We assert that at least the depth-0 cluster matches
+    # exactly, and at deeper depths just require both renderers to be
+    # monotonically scaling.
+    shallowest = sorted(shared_keys, key=lambda k: k.count("-"))[0]
+    assert modellog_norm[shallowest] == bundle_norm[shallowest], (
+        f"penwidth mismatch at shallowest cluster {shallowest!r}: "
+        f"ModelLog={modellog_norm[shallowest]} vs bundle={bundle_norm[shallowest]}"
+    )
+
+    # Both ModelLog and the bundle must produce monotonically non-increasing
+    # penwidths as depth increases (deeper clusters get thinner borders).
+    def _by_depth(widths: dict[str, float]) -> List[Tuple[int, float]]:
+        return sorted([(k.count("-"), w) for k, w in widths.items()])
+
+    for series, name in [
+        (_by_depth(modellog_norm), "ModelLog"),
+        (_by_depth(bundle_norm), "bundle"),
+    ]:
+        prev_w = None
+        prev_d = None
+        for depth, w in series:
+            if prev_d is not None and depth > prev_d:
+                assert w <= prev_w, (
+                    f"{name} penwidth not monotonic: depth {prev_d}={prev_w}, depth {depth}={w}"
+                )
+            prev_d, prev_w = depth, w
+
+    # Sanity: at least one cluster carries a non-default (>2) width so the
+    # parity check actually exercised the depth scaling formula.
+    assert any(w > 2.0 for w in bundle_norm.values()), (
+        f"expected at least one cluster with depth-scaled penwidth > 2.0; got {bundle_norm}"
+    )
+    # Both renderers should produce strictly decreasing penwidths from depth
+    # 0 to the deepest cluster.  Without this, the formula isn't actually
+    # being exercised.
+    bundle_widths_only = sorted({w for w in bundle_norm.values()}, reverse=True)
+    assert len(bundle_widths_only) >= 2, (
+        f"bundle should produce more than one distinct penwidth; got {bundle_norm}"
+    )
+
+
+def test_module_cluster_pass_labels(tmp_path: Path) -> None:
+    """Multi-pass module clusters carry ``(xN)`` count or ``:N`` pass suffixes.
+
+    The bundle operates on rolled-equivalent supergraph nodes (one
+    canonical entry per fingerprint+occurrence-index), so a recurrent
+    model that calls ``self.block(...)`` three times produces a single
+    ``@block`` cluster whose label carries the rolled-style count
+    ``(x3)`` -- mirroring ``show_model_graph(vis_mode='rolled')``.
+
+    For models where the supergraph genuinely contains multiple distinct
+    pass occurrences (covered separately in
+    :func:`test_module_cluster_unrolled_pass_labels`) each pass becomes
+    its own cluster with a ``:N`` suffix in the title.  Both signals are
+    pass-aware bundle parity for ``show_model_graph``'s aesthetics.
+    """
+
+    # Recurrent: same submodule called 3 times -> rolled-style ``(x3)``.
+    model = _RecurrentNet()
+    log = tl.log_forward_pass(model, torch.rand(2, 4))
+    b = TraceBundle([log])
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+    assert "@block (x3)" in src, (
+        f"expected rolled-style '@block (x3)' label in bundle DOT; got:\n{src}"
+    )
+    assert "@block.lin (x3)" in src, (
+        f"expected nested rolled-style '@block.lin (x3)' label; got:\n{src}"
+    )
+
+
+def test_module_cluster_unrolled_pass_labels(tmp_path: Path) -> None:
+    """Genuinely multi-occurrence supergraph clusters carry ``:N`` suffixes.
+
+    When a model has distinct call-site occurrences of the same module
+    (e.g. ``NestedModules``' ``level21`` called from three positions in
+    ``forward()``), the supergraph produces one canonical cluster per
+    occurrence and each cluster's title includes the ``:N`` pass suffix.
+    """
+
+    import sys
+    from pathlib import Path as _Path
+
+    # Reuse the example_models fixtures alongside the test suite.
+    repo_root = _Path(__file__).resolve().parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    import example_models  # type: ignore[import-not-found]
+
+    model = example_models.NestedModules()
+    log = tl.log_forward_pass(model, torch.rand(5, 5))
+    b = TraceBundle([log])
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+
+    # ``level21`` is called 3 times via distinct forward-statement positions;
+    # the supergraph emits three pass-tagged clusters.
+    for n in (1, 2, 3):
+        assert f"@level21:{n}" in src, f"expected unrolled pass cluster '@level21:{n}'; got:\n{src}"
+
+
+def test_module_cluster_single_pass_label_no_suffix(tmp_path: Path) -> None:
+    """Single-pass modules drop the ``:N`` suffix even though the data carries it.
+
+    Mirrors ``rendering._setup_subgraphs_recurse``'s ``num_passes == 1``
+    branch.  Without this the bundle would always print ``@fc1:1`` style
+    labels even for single-call modules, which would diverge visually
+    from ``show_model_graph``.
+    """
+
+    model = _LinearNet()
+    log = tl.log_forward_pass(model, torch.rand(2, 4))
+    b = TraceBundle([log])
+    src = show_bundle_graph(b, mode="auto", return_dot=True)
+    assert src is not None
+
+    # ``fc1`` and ``fc2`` are each called once -- bundle drops the suffix.
+    assert "@fc1<" in src, f"expected single-pass module label '@fc1' in bundle DOT; got:\n{src}"
+    assert "@fc1:1" not in src, f"single-pass module should not carry ':1' suffix; got:\n{src}"

--- a/torchlens/__init__.py
+++ b/torchlens/__init__.py
@@ -52,7 +52,7 @@ from .visualization import (
 
 # ---- Public API: multi-trace analysis ------------------------------------
 
-from .multi_trace import NodeView, TraceBundle, bundle
+from .multi_trace import NodeView, TraceBundle, bundle, show_bundle_graph
 
 # ---- Public API: decoration lifecycle ------------------------------------
 
@@ -118,6 +118,7 @@ __all__ = [
     "render_model_log_with_dagua",
     "save",
     "show_backward_graph",
+    "show_bundle_graph",
     "show_model_graph",
     "summary",
     "unwrap_torch",

--- a/torchlens/multi_trace/__init__.py
+++ b/torchlens/multi_trace/__init__.py
@@ -13,10 +13,11 @@ Public surface:
   structure produced by :func:`build_supergraph`.
 * Metric primitives (cosine_distance, relative_l2, pearson_correlation_distance,
   relative_l1_scalar) and :func:`resolve_metric`.
+* :func:`show_bundle_graph` -- Graphviz visualization with three styling
+  modes (divergence, swarm, group_color) plus an ``auto`` default.
 
-Visualization, counterfactual branch enumeration, intervention APIs, and
-streaming aggregate are deferred to a Phase 2 dispatch -- see
-``.project-context/todos.md``.
+Counterfactual branch enumeration, intervention APIs, and streaming
+aggregate remain deferred -- see ``.project-context/todos.md``.
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from .topology import (
     build_supergraph,
     compare_topology,
 )
+from .visualization import show_bundle_graph
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only
     from ..data_classes.model_log import ModelLog
@@ -75,4 +77,5 @@ __all__ = [
     "relative_l1_scalar",
     "relative_l2",
     "resolve_metric",
+    "show_bundle_graph",
 ]

--- a/torchlens/multi_trace/_bundle_clusters.py
+++ b/torchlens/multi_trace/_bundle_clusters.py
@@ -1,0 +1,222 @@
+"""Cluster construction helpers for the multi-trace bundle renderer.
+
+Private helper module: not part of the public API. Kept separate from
+``multi_trace/visualization.py`` because the cluster code is the largest
+self-contained chunk of bundle-specific orchestration and the renderer
+is easier to read when these helpers live in their own file.
+
+These helpers convert a :class:`TraceBundle`'s supergraph into the data
+the cluster emitter needs:
+
+* a per-cluster list of supergraph nodes
+* a parent->child cluster map for nesting
+* a display title per cluster (with ModelLog-equivalent
+  ``@<module>:N`` pass suffixes when the underlying module is multi-pass)
+* a "cluster has any traversal" flag per cluster
+* the max nesting depth (1-based, matches
+  ``rendering._get_max_nesting_depth``)
+
+The actual Graphviz emission stays in ``visualization.py`` so the
+renderer can keep all rendering decisions in one place.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from .bundle import TraceBundle
+    from .topology import SupergraphNode
+
+
+def _split_leaf_pass(component: str) -> Tuple[str, Optional[str]]:
+    """Split ``"name:pass"`` into ``(name, pass)``; ``"name"`` -> ``(name, None)``."""
+
+    if ":" in component:
+        base, _, suffix = component.rpartition(":")
+        return base, suffix or None
+    return component, None
+
+
+def safe_dot_id(name: str) -> str:
+    """Return a Graphviz-safe identifier for arbitrary node/cluster names.
+
+    Graphviz allows fairly liberal node names but quotes characters like
+    ``:``/``.``/spaces in the DOT source.  We rewrite to a pure
+    ``[A-Za-z0-9_]`` form so generated DOT is easy to inspect in tests.
+    """
+
+    return "".join(c if c.isalnum() or c == "_" else "_" for c in name)
+
+
+def _supergraph_node_module_chain(node: "SupergraphNode") -> List[str]:
+    """Return the cluster-path chain for a supergraph node.
+
+    Reads ``containing_modules`` from the first contributing trace's
+    ``LayerLog`` -- the same source the supergraph uses to populate
+    ``module_path``.  Falls back to a single-element chain derived from
+    ``module_path`` if ``containing_modules`` is unavailable for any
+    reason (e.g. a synthetic LayerLog from a test fixture).
+
+    The returned list elements are full module-pass addresses (e.g.
+    ``"level21:1"``, ``"level21.level11:1"``).  Each element is used
+    verbatim as a cluster key so two passes of the same module live in
+    distinct clusters, matching ``rendering.py``'s unrolled-mode
+    behaviour.
+    """
+
+    if not node.layer_refs:
+        return []
+    first_trace = node.traces[0] if node.traces else next(iter(node.layer_refs))
+    layer = node.layer_refs[first_trace]
+    chain = getattr(layer, "containing_modules", None)
+    if isinstance(chain, list) and chain:
+        return [str(item) for item in chain if item is not None]
+    if node.module_path:
+        return [str(node.module_path)]
+    return []
+
+
+def _consensus_num_passes(bundle: "TraceBundle", node_names: List[str]) -> Optional[int]:
+    """Return the consensus ``num_passes`` for a cluster, or ``None`` if mixed.
+
+    For each direct supergraph node in the cluster, sample
+    ``num_passes`` from every traversing trace's LayerLog.  If every
+    sample agrees on a single value > 1 we return it -- the cluster is
+    consistently multi-pass and merits an ``(xN)`` suffix in the
+    rolled-mode title.  Anything else (single-pass everywhere, divergent
+    across traces, or accessor-missing) returns ``None`` so the caller
+    falls back to the plain title.
+    """
+
+    if not node_names:
+        return None
+
+    sg = bundle._supergraph  # type: ignore[attr-defined]
+    seen: Set[int] = set()
+    for node_name in node_names:
+        node = sg.nodes.get(node_name)
+        if node is None:
+            continue
+        for layer in node.layer_refs.values():
+            np_attr = getattr(layer, "num_passes", None)
+            if not isinstance(np_attr, int) or np_attr <= 0:
+                return None
+            seen.add(np_attr)
+    if len(seen) != 1:
+        return None
+    consensus = next(iter(seen))
+    if consensus <= 1:
+        return None
+    return consensus
+
+
+def collect_cluster_metadata(
+    bundle: "TraceBundle",
+) -> Tuple[
+    Dict[str, List[str]],  # cluster key -> direct nodes
+    Dict[str, Set[str]],  # cluster key -> direct child cluster keys
+    Dict[str, str],  # cluster key -> display title
+    Dict[str, bool],  # cluster key -> traversed by any trace
+    int,  # 1-based max nesting depth
+]:
+    """Walk the supergraph and gather everything the cluster renderer needs.
+
+    Returns a tuple of:
+
+    * ``cluster_nodes`` -- map cluster key -> list of supergraph node
+      names that live directly inside that leaf cluster.  ``""`` collects
+      root nodes (no module).
+    * ``cluster_children`` -- map cluster key -> set of direct-child
+      cluster keys.  ``""`` maps to the set of top-level clusters.
+    * ``cluster_title`` -- map cluster key -> display title used in the
+      ``@<title>`` cluster label.  Mirrors ``rendering.py`` rolled-mode
+      conventions: single-pass modules drop the ``:N`` suffix (so ``fc1``
+      not ``fc1:1``); multi-pass modules show ``base (xN)`` when every
+      traversing trace agrees on the pass count, falling back to the
+      plain base name when traces diverge.
+    * ``cluster_has_traversal`` -- map cluster key -> True iff any trace
+      populated a node inside the cluster.  Bundle clusters always have
+      traversal because the supergraph wouldn't have created an empty
+      cluster, but the dict is exposed for parity with
+      ``rendering._setup_subgraphs_recurse`` and to leave room for
+      future "skip empty branches" behaviour.
+    * ``max_nesting_depth`` -- 1-based depth of the deepest cluster
+      (i.e. the number of levels in the deepest chain).  Mirrors the
+      value returned by ``rendering._get_max_nesting_depth`` so the
+      shared ``compute_module_penwidth`` formula produces matching
+      values for ModelLog and bundle clusters at the same depth.
+    """
+
+    sg = bundle._supergraph  # type: ignore[attr-defined]
+
+    cluster_nodes: Dict[str, List[str]] = defaultdict(list)
+    cluster_children: Dict[str, Set[str]] = defaultdict(set)
+    cluster_has_traversal: Dict[str, bool] = defaultdict(bool)
+
+    # Track how many distinct pass-suffixes appear for each base module
+    # address.  ModelLog shows ``@fc1`` for single-pass modules and
+    # ``@fc1:N`` for unrolled-mode multi-pass.  The bundle operates on
+    # rolled-equivalent supergraph nodes so it primarily emits ``@fc1``
+    # or ``@fc1 (xN)``; the suffix-set is still tracked because divergent
+    # topologies can put different passes of the same module in distinct
+    # supergraph clusters (cf. NestedModules' level21 called 3x).
+    base_to_passes: Dict[str, Set[Optional[str]]] = defaultdict(set)
+    cluster_keys: Set[str] = set()
+
+    max_depth = 1  # mirrors ``rendering._get_max_nesting_depth`` floor
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        chain = _supergraph_node_module_chain(node)
+        if not chain:
+            cluster_nodes[""].append(name)
+            continue
+        leaf_key = chain[-1]
+        cluster_nodes[leaf_key].append(name)
+
+        # Walk the chain registering each level's parent->child relation
+        # and collecting pass info to drive the title format.
+        prev_key = ""
+        for depth, key in enumerate(chain):
+            cluster_has_traversal[key] = True
+            cluster_keys.add(key)
+            base_addr, pass_suffix = _split_leaf_pass(key)
+            base_to_passes[base_addr].add(pass_suffix)
+            cluster_children[prev_key].add(key)
+            prev_key = key
+            max_depth = max(max_depth, depth + 1)
+
+    cluster_title: Dict[str, str] = {}
+    for key in cluster_keys:
+        base_addr, pass_suffix = _split_leaf_pass(key)
+        # Decide on ``base`` vs ``base:N`` first (the "is it multi-pass at
+        # the unrolled level" question), then decorate with ``(xN)`` if the
+        # cluster's underlying LayerLogs are themselves multi-pass.
+        if pass_suffix is None:
+            title_base = key
+        else:
+            distinct_pass_suffixes = {p for p in base_to_passes[base_addr] if p is not None}
+            if len(distinct_pass_suffixes) > 1:
+                # Multiple passes show up at the supergraph level
+                # (rolled-style equivalent of unrolled per-pass clusters).
+                title_base = key
+            else:
+                title_base = base_addr
+
+        # Append a ``(xN)`` suffix when every traversing LayerLog agrees
+        # on the same pass count > 1 -- the rolled-mode signal that the
+        # cluster represents N invocations of the same module.
+        consensus = _consensus_num_passes(bundle, cluster_nodes.get(key, []))
+        if consensus is not None:
+            title_base = f"{title_base} (x{consensus})"
+
+        cluster_title[key] = title_base
+
+    return (
+        dict(cluster_nodes),
+        dict(cluster_children),
+        cluster_title,
+        dict(cluster_has_traversal),
+        max_depth,
+    )

--- a/torchlens/multi_trace/_bundle_styling.py
+++ b/torchlens/multi_trace/_bundle_styling.py
@@ -1,0 +1,459 @@
+"""Per-node styling helpers for the multi-trace bundle renderer.
+
+Private helper module: not part of the public API. Holds the colormap
+tables and per-node aggregation/styling logic so
+``multi_trace/visualization.py`` can stay focused on Graphviz orchestration.
+
+The public entry point :func:`compute_node_styles` returns the per-node
+fill colour, font colour, and label-line list for a given mode -- a clean
+seam between bundle-aware aggregation (here) and Graphviz emission (in
+``visualization.py``).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+import torch
+
+from ..visualization._render_utils import format_node_html, html_escape
+from .metrics import is_scalar_like, relative_l1_scalar, resolve_metric
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from .bundle import TraceBundle
+    from .topology import Supergraph, SupergraphNode
+
+
+# ---------------------------------------------------------------------------
+# Colormap definitions
+# ---------------------------------------------------------------------------
+#
+# All palettes are hardcoded as hex strings to avoid pulling matplotlib (or
+# any other plotting library) into torchlens's required dependency set.
+# Sampled at 10 stops for sequential maps; tab10 is the canonical
+# 10-category categorical palette. White / very light grey is reserved as
+# the "no-data / neutral" shade.
+
+# matplotlib's ``Reds`` colormap sampled at 10 evenly-spaced stops.
+# Light end is near-white so unchanged nodes fade into the background.
+REDS_HEX: Tuple[str, ...] = (
+    "#fff5f0",
+    "#fee0d2",
+    "#fcbba1",
+    "#fc9272",
+    "#fb6a4a",
+    "#ef3b2c",
+    "#cb181d",
+    "#a50f15",
+    "#67000d",
+    "#4a000a",
+)
+
+# matplotlib's ``viridis`` colormap sampled at 10 evenly-spaced stops.
+# Monotonic luminance, colorblind-safe.
+VIRIDIS_HEX: Tuple[str, ...] = (
+    "#440154",
+    "#482878",
+    "#3e4989",
+    "#31688e",
+    "#26828e",
+    "#1f9e89",
+    "#35b779",
+    "#6ece58",
+    "#b5de2b",
+    "#fde725",
+)
+
+# matplotlib's ``tab10`` categorical palette (RGB hex). Used for
+# group_color mode. Capacity is 10 distinct groups.
+TAB10_HEX: Tuple[str, ...] = (
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+)
+
+# Designated neutral shade for nodes traversed by multiple groups in
+# group_color mode. Picked to read clearly against any tab10 colour.
+NEUTRAL_GREY = "#d9d9d9"
+
+# Edge colour for divergence/swarm modes (faded so coloured nodes pop).
+EDGE_COLOR_NEUTRAL = "#cccccc"
+
+# Default text colour for high-saturation node fills (improves contrast on
+# dark Reds / dark viridis stops). Heuristic: switch to white once the
+# fill darkens past ~halfway through the colormap.
+LIGHT_TEXT = "#ffffff"
+DARK_TEXT = "#000000"
+
+
+ModeLiteral = Literal["auto", "divergence", "swarm", "group_color"]
+
+
+# ---------------------------------------------------------------------------
+# Colormap sampling
+# ---------------------------------------------------------------------------
+
+
+def sample_colormap(palette: Tuple[str, ...], frac: float) -> str:
+    """Return the palette colour closest to fractional position ``frac``.
+
+    ``frac`` is clamped to ``[0, 1]``; ``frac == 0`` -> first stop, ``frac
+    == 1`` -> last stop. Linear interpolation between stops would be more
+    accurate but adds zero perceptual benefit for rendered Graphviz
+    fills, so we round to the nearest stop.
+    """
+
+    if not palette:
+        return NEUTRAL_GREY
+    if frac <= 0.0:
+        return palette[0]
+    if frac >= 1.0:
+        return palette[-1]
+    idx = int(round(frac * (len(palette) - 1)))
+    return palette[idx]
+
+
+def is_dark_swatch(palette: Tuple[str, ...], frac: float) -> bool:
+    """Heuristic: is the colour at ``frac`` dark enough to need light text?"""
+
+    if not palette:
+        return False
+    if frac <= 0.0:
+        return False
+    # Past the midpoint of either palette the swatches are dark.
+    return frac >= 0.55
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution + per-node aggregation
+# ---------------------------------------------------------------------------
+
+
+def resolve_mode(bundle: "TraceBundle", mode: ModeLiteral) -> ModeLiteral:
+    """Resolve ``mode='auto'`` to a concrete styling mode.
+
+    Shared topology -> divergence (every node is universal so swarm would
+    paint everything the same colour). Divergent topology -> swarm
+    (coverage frequency carries information).
+    """
+
+    if mode != "auto":
+        return mode
+    return "divergence" if bundle.is_shared_topology else "swarm"
+
+
+def _layer_tensor(
+    layer: Any,
+    *,
+    field: str,
+    has_field: str,
+) -> Optional[torch.Tensor]:
+    """Pull a tensor off a single-pass LayerLog without crashing on multi-pass.
+
+    LayerLog raises ``ValueError`` rather than ``AttributeError`` for fields
+    that depend on a specific pass number; multi-pass LayerLogs reach us via
+    ``SupergraphNode.layer_refs`` and we treat them as "no tensor available"
+    rather than letting the divergence/swarm pipeline crash. Multi-pass
+    activation rendering is tracked in todos.md (Multi-trace V2).
+    """
+
+    try:
+        has = getattr(layer, has_field, False)
+    except (ValueError, AttributeError):
+        return None
+    if not has:
+        return None
+    try:
+        value = getattr(layer, field, None)
+    except (ValueError, AttributeError):
+        return None
+    if isinstance(value, torch.Tensor):
+        return value
+    return None
+
+
+def per_node_distance(
+    bundle: "TraceBundle",
+    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]],
+) -> Dict[str, Optional[float]]:
+    """Compute mean pairwise distance per supergraph node.
+
+    Returns a dict ``{node_name: distance_or_None}``.  Nodes traversed by
+    fewer than two traces, or missing stored activations (including
+    multi-pass layers whose activations live on per-pass ``passes[k]``
+    accessors), map to ``None`` so the caller can render them with a
+    neutral shade.
+    """
+
+    metric_fn = resolve_metric(metric)
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    out: Dict[str, Optional[float]] = {}
+
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        tensors: List[torch.Tensor] = []
+        for trace_name in node.traces:
+            tensor = _layer_tensor(
+                node.layer_refs[trace_name],
+                field="activation",
+                has_field="has_saved_activations",
+            )
+            if tensor is not None:
+                tensors.append(tensor)
+        if len(tensors) < 2:
+            out[name] = None
+            continue
+        distances: List[float] = []
+        # Pairwise mean: mirror the contract in TraceBundle.most_changed.
+        for i in range(len(tensors)):
+            for j in range(i + 1, len(tensors)):
+                ti, tj = tensors[i], tensors[j]
+                if is_scalar_like(ti) or is_scalar_like(tj):
+                    d = relative_l1_scalar(ti, tj)
+                else:
+                    try:
+                        d = metric_fn(ti, tj)
+                    except (RuntimeError, ValueError):
+                        # Shape disagreement etc. -- fall back to scalar
+                        # form so the mode still produces something
+                        # rather than crashing the entire render.
+                        d = relative_l1_scalar(ti, tj)
+                distances.append(float(d.detach().item()))
+        if not distances:
+            out[name] = None
+            continue
+        out[name] = sum(distances) / len(distances)
+    return out
+
+
+def per_node_coverage(bundle: "TraceBundle") -> Dict[str, float]:
+    """Fraction of bundled traces that traversed each supergraph node."""
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    n = max(len(bundle.names), 1)
+    return {name: len(node.traces) / n for name, node in sg.nodes.items()}
+
+
+def per_node_groups(bundle: "TraceBundle") -> Dict[str, frozenset]:
+    """Set of group names that traversed each supergraph node.
+
+    Returns ``frozenset`` so the values are hashable and easy to compare;
+    a node with no group memberships maps to the empty frozenset.
+    """
+
+    groups = bundle.groups
+    if not groups:
+        return {}
+
+    # Reverse the trace_name -> group(s) mapping so we can ask "which
+    # groups does this set of traces belong to?".
+    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
+    for group_name, members in groups.items():
+        for trace_name in members:
+            trace_to_groups[trace_name].add(group_name)
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    out: Dict[str, frozenset] = {}
+    for name, node in sg.nodes.items():
+        node_groups: Set[str] = set()
+        for trace_name in node.traces:
+            node_groups.update(trace_to_groups.get(trace_name, set()))
+        out[name] = frozenset(node_groups)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-node styling
+# ---------------------------------------------------------------------------
+
+
+def _style_node_divergence(
+    distances: Dict[str, Optional[float]],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in divergence mode."""
+
+    val = distances.get(name)
+    if val is None:
+        return NEUTRAL_GREY, DARK_TEXT
+    valid = [v for v in distances.values() if v is not None]
+    max_val = max(valid) if valid else 0.0
+    frac = (val / max_val) if max_val > 0 else 0.0
+    fill = sample_colormap(REDS_HEX, frac)
+    font = LIGHT_TEXT if is_dark_swatch(REDS_HEX, frac) else DARK_TEXT
+    return fill, font
+
+
+def _style_node_swarm(
+    coverage_map: Dict[str, float],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in swarm mode."""
+
+    cov = coverage_map.get(name, 0.0)
+    fill = sample_colormap(VIRIDIS_HEX, cov)
+    font = LIGHT_TEXT if is_dark_swatch(VIRIDIS_HEX, cov) else DARK_TEXT
+    return fill, font
+
+
+def _style_node_group_color(
+    group_map: Dict[str, frozenset],
+    group_index: Dict[str, int],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in group_color mode."""
+
+    groups = group_map.get(name, frozenset())
+    if not groups:
+        return NEUTRAL_GREY, DARK_TEXT
+    if len(groups) > 1:
+        # Multi-group node -- neutral shade rather than blending.
+        return NEUTRAL_GREY, DARK_TEXT
+    only_group = next(iter(groups))
+    idx = group_index.get(only_group, 0)
+    fill = TAB10_HEX[idx % len(TAB10_HEX)]
+    return fill, LIGHT_TEXT
+
+
+def _node_label_lines(
+    name: str,
+    node: "SupergraphNode",
+    *,
+    coverage: Optional[float] = None,
+    distance: Optional[float] = None,
+    show_coverage: bool = False,
+) -> List[str]:
+    """Build the multi-line label for a supergraph node.
+
+    First line is the node name, second line is the op_type, and (when
+    requested) we append a coverage / divergence line. Kept text-only --
+    we let Graphviz draw it as an HTML-like table so it stays readable.
+    """
+
+    lines = [html_escape(name)]
+    if node.op_type:
+        lines.append(f"<I>{html_escape(node.op_type)}</I>")
+    if show_coverage and coverage is not None:
+        pct = int(round(coverage * 100))
+        lines.append(f"<FONT POINT-SIZE='10'>coverage: {pct}%</FONT>")
+    if distance is not None:
+        lines.append(f"<FONT POINT-SIZE='10'>div: {distance:.3g}</FONT>")
+    return lines
+
+
+def compute_node_styles(
+    bundle: "TraceBundle",
+    *,
+    resolved_mode: ModeLiteral,
+    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]],
+    show_coverage: bool,
+    group_index: Dict[str, int],
+) -> Tuple[
+    Dict[str, Tuple[str, str]],  # node name -> (fill, font)
+    Dict[str, str],  # node name -> HTML label string
+    Dict[str, Optional[float]],  # raw distances (divergence) for caption use
+    Dict[str, float],  # coverage map (swarm + show_coverage)
+    Dict[str, frozenset],  # group memberships (group_color)
+]:
+    """Compute per-node Graphviz fill/font colours and HTML labels.
+
+    Returns the resolved node styling along with the raw mode-specific
+    aggregations -- they're kept available so the caller can wire any
+    of them into legend/caption strings later if needed.
+    """
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+
+    distances: Dict[str, Optional[float]] = {}
+    coverage_map: Dict[str, float] = {}
+    group_map: Dict[str, frozenset] = {}
+
+    if resolved_mode == "divergence":
+        distances = per_node_distance(bundle, metric)
+    if resolved_mode == "swarm" or show_coverage:
+        coverage_map = per_node_coverage(bundle)
+    if resolved_mode == "group_color":
+        group_map = per_node_groups(bundle)
+
+    node_styles: Dict[str, Tuple[str, str]] = {}
+    node_labels: Dict[str, str] = {}
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        if resolved_mode == "divergence":
+            fill, font = _style_node_divergence(distances, name)
+        elif resolved_mode == "swarm":
+            fill, font = _style_node_swarm(coverage_map, name)
+        else:  # group_color
+            fill, font = _style_node_group_color(group_map, group_index, name)
+        node_styles[name] = (fill, font)
+        label_lines = _node_label_lines(
+            name,
+            node,
+            coverage=coverage_map.get(name) if coverage_map else None,
+            distance=distances.get(name) if distances else None,
+            show_coverage=show_coverage and resolved_mode == "swarm",
+        )
+        node_labels[name] = format_node_html(label_lines)
+
+    return node_styles, node_labels, distances, coverage_map, group_map
+
+
+# ---------------------------------------------------------------------------
+# Edge styling
+# ---------------------------------------------------------------------------
+
+
+def resolve_edge_color(
+    trace_set: Set[str],
+    *,
+    resolved_mode: ModeLiteral,
+    bundle: "TraceBundle",
+    group_index: Dict[str, int],
+) -> str:
+    """Pick a stroke colour for a supergraph edge given the traversing traces.
+
+    In ``group_color`` mode an edge gets the colour of the group that
+    traversed it (or neutral grey if multiple groups did).  In divergence
+    and swarm modes we keep edges neutral so the coloured nodes stay the
+    visual focus.
+    """
+
+    if resolved_mode != "group_color":
+        return EDGE_COLOR_NEUTRAL
+
+    groups = bundle.groups
+    if not groups or not group_index:
+        return EDGE_COLOR_NEUTRAL
+
+    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
+    for group_name, members in groups.items():
+        for trace_name in members:
+            trace_to_groups[trace_name].add(group_name)
+
+    edge_groups: Set[str] = set()
+    for trace_name in trace_set:
+        edge_groups.update(trace_to_groups.get(trace_name, set()))
+
+    if len(edge_groups) == 1:
+        only = next(iter(edge_groups))
+        return TAB10_HEX[group_index.get(only, 0) % len(TAB10_HEX)]
+    return EDGE_COLOR_NEUTRAL

--- a/torchlens/multi_trace/bundle.py
+++ b/torchlens/multi_trace/bundle.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     Iterator,
@@ -333,6 +334,31 @@ class TraceBundle:
         if not isinstance(view, NodeView):  # pragma: no cover - defensive
             raise TypeError("aggregate requires a node name (str), not a trace index")
         return view.aggregate(statistic=statistic, on=on)
+
+    # ------------------------------------------------------------------
+    # Visualization
+    # ------------------------------------------------------------------
+
+    def show(
+        self,
+        vis_outpath: Optional[str] = None,
+        mode: Literal["auto", "divergence", "swarm", "group_color"] = "auto",
+        **kwargs: Any,
+    ) -> Optional[str]:
+        """Render this bundle as a Graphviz graph.
+
+        Thin convenience wrapper around
+        :func:`torchlens.multi_trace.visualization.show_bundle_graph`.
+        See that function for full kwarg documentation; common options
+        are ``metric=`` (for ``mode='divergence'``), ``show_coverage=``
+        (for ``mode='swarm'``), ``vis_format=``, ``vis_orientation=``,
+        and ``save_only=``.
+        """
+
+        # Lazy import to dodge the bundle <-> visualization import cycle.
+        from .visualization import show_bundle_graph
+
+        return show_bundle_graph(self, vis_outpath=vis_outpath, mode=mode, **kwargs)
 
     # ------------------------------------------------------------------
     # Hard checks

--- a/torchlens/multi_trace/visualization.py
+++ b/torchlens/multi_trace/visualization.py
@@ -1,0 +1,779 @@
+"""Graphviz visualization for :class:`TraceBundle` objects.
+
+This module provides :func:`show_bundle_graph`, the canonical entry point
+for rendering a multi-trace bundle, plus three styling modes:
+
+* ``divergence`` -- per-node mean pairwise distance, sequential ``Reds``
+  colormap. Use when the bundle is shared-topology and the question is
+  "which nodes change the most across traces?".
+* ``swarm`` -- per-node coverage fraction, sequential ``viridis``
+  colormap. Use for divergent-topology bundles where the question is
+  "which nodes did most/all traces visit?".
+* ``group_color`` -- categorical colouring by trace-group membership
+  (``tab10`` palette). Requires ``bundle.groups`` to be non-empty;
+  multi-group nodes get a neutral light-grey shade rather than a blended
+  palette colour.
+
+The renderer is deliberately compact and self-contained -- it builds a
+fresh :class:`graphviz.Digraph` from the bundle's :class:`Supergraph`
+rather than reusing the ModelLog-coupled ``rendering.render_graph``
+machinery, which is too entangled with single-trace state to be safely
+re-pointed at a multi-trace input within the scope of this dispatch.
+What it DOES share with ``rendering.py`` is the file-format dispatch +
+view orchestration, factored into ``visualization/_render_utils.py``.
+
+Module clusters are derived from the supergraph's ``module_path`` strings
+(``"a.b.c"``-shaped), giving users the same hierarchical layout cue they
+get from ``show_model_graph`` even though the underlying ``ModuleLog``
+hierarchy is not first-class on a Supergraph.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+import graphviz
+import torch
+
+from ..utils.display import in_notebook
+from ..visualization._render_utils import (
+    render_dot_to_file,
+    strip_known_extension,
+)
+from .metrics import is_scalar_like, relative_l1_scalar, resolve_metric
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from .bundle import TraceBundle
+    from .topology import Supergraph, SupergraphNode
+
+
+# ---------------------------------------------------------------------------
+# Colormap definitions
+# ---------------------------------------------------------------------------
+#
+# All palettes are hardcoded as hex strings to avoid pulling matplotlib (or
+# any other plotting library) into torchlens's required dependency set.
+# Sampled at 10 stops for sequential maps; tab10 is the canonical
+# 10-category categorical palette. White / very light grey is reserved as
+# the "no-data / neutral" shade.
+
+# matplotlib's ``Reds`` colormap sampled at 10 evenly-spaced stops.
+# Light end is near-white so unchanged nodes fade into the background.
+_REDS_HEX: Tuple[str, ...] = (
+    "#fff5f0",
+    "#fee0d2",
+    "#fcbba1",
+    "#fc9272",
+    "#fb6a4a",
+    "#ef3b2c",
+    "#cb181d",
+    "#a50f15",
+    "#67000d",
+    "#4a000a",
+)
+
+# matplotlib's ``viridis`` colormap sampled at 10 evenly-spaced stops.
+# Monotonic luminance, colorblind-safe.
+_VIRIDIS_HEX: Tuple[str, ...] = (
+    "#440154",
+    "#482878",
+    "#3e4989",
+    "#31688e",
+    "#26828e",
+    "#1f9e89",
+    "#35b779",
+    "#6ece58",
+    "#b5de2b",
+    "#fde725",
+)
+
+# matplotlib's ``tab10`` categorical palette (RGB hex). Used for
+# group_color mode. Capacity is 10 distinct groups.
+_TAB10_HEX: Tuple[str, ...] = (
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+)
+
+# Designated neutral shade for nodes traversed by multiple groups in
+# group_color mode. Picked to read clearly against any tab10 colour.
+_NEUTRAL_GREY = "#d9d9d9"
+
+# Edge colour for divergence/swarm modes (faded so coloured nodes pop).
+_EDGE_COLOR_NEUTRAL = "#cccccc"
+
+# Default text colour for high-saturation node fills (improves contrast on
+# dark Reds / dark viridis stops). Heuristic: switch to white once the
+# fill darkens past ~halfway through the colormap.
+_LIGHT_TEXT = "#ffffff"
+_DARK_TEXT = "#000000"
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+ModeLiteral = Literal["auto", "divergence", "swarm", "group_color"]
+DirectionLiteral = Literal["bottomup", "topdown", "leftright"]
+FileFormatLiteral = Literal["pdf", "png", "svg", "jpg", "jpeg", "bmp", "tif", "tiff"]
+VisModeLiteral = Literal["unrolled", "rolled"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mode(bundle: "TraceBundle", mode: ModeLiteral) -> ModeLiteral:
+    """Resolve ``mode='auto'`` to a concrete styling mode.
+
+    Shared topology -> divergence (every node is universal so swarm would
+    paint everything the same colour). Divergent topology -> swarm
+    (coverage frequency carries information).
+    """
+
+    if mode != "auto":
+        return mode
+    return "divergence" if bundle.is_shared_topology else "swarm"
+
+
+def _direction_to_rankdir(direction: str) -> str:
+    """Translate a vis-direction literal into a Graphviz ``rankdir``."""
+
+    if direction == "bottomup":
+        return "BT"
+    if direction == "leftright":
+        return "LR"
+    if direction == "topdown":
+        return "TB"
+    raise ValueError(
+        f"vis_direction must be one of 'bottomup', 'topdown', or 'leftright'; got {direction!r}"
+    )
+
+
+def _sample_colormap(palette: Tuple[str, ...], frac: float) -> str:
+    """Return the palette colour closest to fractional position ``frac``.
+
+    ``frac`` is clamped to ``[0, 1]``; ``frac == 0`` -> first stop, ``frac
+    == 1`` -> last stop. Linear interpolation between stops would be more
+    accurate but adds zero perceptual benefit for rendered Graphviz
+    fills, so we round to the nearest stop.
+    """
+
+    if not palette:
+        return _NEUTRAL_GREY
+    if frac <= 0.0:
+        return palette[0]
+    if frac >= 1.0:
+        return palette[-1]
+    idx = int(round(frac * (len(palette) - 1)))
+    return palette[idx]
+
+
+def _is_dark_swatch(palette: Tuple[str, ...], frac: float) -> bool:
+    """Heuristic: is the colour at ``frac`` dark enough to need light text?"""
+
+    if not palette:
+        return False
+    if frac <= 0.0:
+        return False
+    # Past the midpoint of either palette the swatches are dark.
+    return frac >= 0.55
+
+
+def _per_node_distance(
+    bundle: "TraceBundle",
+    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]],
+) -> Dict[str, Optional[float]]:
+    """Compute mean pairwise distance per supergraph node.
+
+    Returns a dict ``{node_name: distance_or_None}``. Nodes traversed by
+    fewer than two traces, or missing stored activations, map to
+    ``None`` so the caller can render them with a neutral shade.
+    """
+
+    metric_fn = resolve_metric(metric)
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    out: Dict[str, Optional[float]] = {}
+
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        tensors: List[torch.Tensor] = []
+        for trace_name in node.traces:
+            layer = node.layer_refs[trace_name]
+            has = getattr(layer, "has_saved_activations", False)
+            value = getattr(layer, "activation", None) if has else None
+            if isinstance(value, torch.Tensor):
+                tensors.append(value)
+        if len(tensors) < 2:
+            out[name] = None
+            continue
+        distances: List[float] = []
+        # Pairwise mean: mirror the contract in TraceBundle.most_changed.
+        for i in range(len(tensors)):
+            for j in range(i + 1, len(tensors)):
+                ti, tj = tensors[i], tensors[j]
+                if is_scalar_like(ti) or is_scalar_like(tj):
+                    d = relative_l1_scalar(ti, tj)
+                else:
+                    try:
+                        d = metric_fn(ti, tj)
+                    except (RuntimeError, ValueError):
+                        # Shape disagreement etc. -- fall back to scalar
+                        # form so the mode still produces something
+                        # rather than crashing the entire render.
+                        d = relative_l1_scalar(ti, tj)
+                distances.append(float(d.detach().item()))
+        if not distances:
+            out[name] = None
+            continue
+        out[name] = sum(distances) / len(distances)
+    return out
+
+
+def _per_node_coverage(bundle: "TraceBundle") -> Dict[str, float]:
+    """Fraction of bundled traces that traversed each supergraph node."""
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    n = max(len(bundle.names), 1)
+    return {name: len(node.traces) / n for name, node in sg.nodes.items()}
+
+
+def _per_node_groups(
+    bundle: "TraceBundle",
+) -> Dict[str, frozenset]:
+    """Set of group names that traversed each supergraph node.
+
+    Returns ``frozenset`` so the values are hashable and easy to compare;
+    a node with no group memberships maps to the empty frozenset.
+    """
+
+    groups = bundle.groups
+    if not groups:
+        return {}
+
+    # Reverse the trace_name -> group(s) mapping so we can ask "which
+    # groups does this set of traces belong to?".
+    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
+    for group_name, members in groups.items():
+        for trace_name in members:
+            trace_to_groups[trace_name].add(group_name)
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    out: Dict[str, frozenset] = {}
+    for name, node in sg.nodes.items():
+        node_groups: Set[str] = set()
+        for trace_name in node.traces:
+            node_groups.update(trace_to_groups.get(trace_name, set()))
+        out[name] = frozenset(node_groups)
+    return out
+
+
+def _cluster_path(module_path: Optional[str]) -> List[str]:
+    """Split a dotted module path into the prefix chain used for clusters.
+
+    Trailing pass-suffixes (``"a.b:1"``) are dropped because Graphviz
+    cluster names need to be stable across traces.
+    """
+
+    if not module_path:
+        return []
+    # Strip any ``":N"`` suffix on the leaf (pass index).
+    head = module_path.split(":")[0]
+    parts = [p for p in head.split(".") if p]
+    return parts
+
+
+def _safe_dot_id(name: str) -> str:
+    """Return a Graphviz-safe identifier for arbitrary node/cluster names.
+
+    Graphviz allows fairly liberal node names but quotes characters like
+    ``:``/``.``/spaces in the DOT source. We rewrite to a pure
+    ``[A-Za-z0-9_]`` form so generated DOT is easy to inspect in tests.
+    """
+
+    return "".join(c if c.isalnum() or c == "_" else "_" for c in name)
+
+
+def _build_module_clusters(
+    bundle: "TraceBundle",
+) -> Dict[str, List[str]]:
+    """Map cluster path (dotted prefix) -> list of node names in it.
+
+    Empty-prefix nodes (no module path) live at the root and don't get
+    wrapped in a cluster.
+    """
+
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    clusters: Dict[str, List[str]] = defaultdict(list)
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        path = _cluster_path(node.module_path)
+        # We attach each node to its leaf cluster only; ancestor clusters
+        # are reconstructed lazily when laying out subgraph nesting.
+        cluster_key = ".".join(path)
+        clusters[cluster_key].append(name)
+    return clusters
+
+
+def _walk_clusters(
+    cluster_paths: List[str],
+) -> List[List[str]]:
+    """Return the list of dotted-prefix paths needed to render clusters.
+
+    For each leaf path we emit every ancestor (prefix) too, so deeply
+    nested clusters get their parents created. Ordering preserves the
+    first-seen order of leaves for stable DOT output.
+    """
+
+    seen: Set[str] = set()
+    ordered: List[List[str]] = []
+    for leaf in cluster_paths:
+        if not leaf:
+            continue
+        parts = leaf.split(".")
+        for depth in range(1, len(parts) + 1):
+            prefix = ".".join(parts[:depth])
+            if prefix in seen:
+                continue
+            seen.add(prefix)
+            ordered.append(parts[:depth])
+    return ordered
+
+
+def _node_label_lines(
+    name: str,
+    node: "SupergraphNode",
+    *,
+    coverage: Optional[float] = None,
+    distance: Optional[float] = None,
+    show_coverage: bool = False,
+) -> List[str]:
+    """Build the multi-line label for a supergraph node.
+
+    First line is the node name, second line is the op_type, and (when
+    requested) we append a coverage / divergence line. Kept text-only --
+    we let Graphviz draw it as an HTML-like table so it stays readable.
+    """
+
+    lines = [_html_escape(name)]
+    if node.op_type:
+        lines.append(f"<I>{_html_escape(node.op_type)}</I>")
+    if show_coverage and coverage is not None:
+        pct = int(round(coverage * 100))
+        lines.append(f"<FONT POINT-SIZE='10'>coverage: {pct}%</FONT>")
+    if distance is not None:
+        lines.append(f"<FONT POINT-SIZE='10'>div: {distance:.3g}</FONT>")
+    return lines
+
+
+def _html_escape(value: str) -> str:
+    """Escape the three Graphviz HTML-label specials."""
+
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _format_node_html(lines: List[str]) -> str:
+    """Wrap label lines into a Graphviz HTML-like label string."""
+
+    return "<" + "<BR/>".join(lines) + ">"
+
+
+# ---------------------------------------------------------------------------
+# Mode dispatch
+# ---------------------------------------------------------------------------
+
+
+def _style_node_divergence(
+    distances: Dict[str, Optional[float]],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in divergence mode."""
+
+    val = distances.get(name)
+    if val is None:
+        return _NEUTRAL_GREY, _DARK_TEXT
+    # Normalise to [0, 1] using the bundle-wide max so scales stay
+    # comparable. Skip nodes with None when computing the max.
+    valid = [v for v in distances.values() if v is not None]
+    max_val = max(valid) if valid else 0.0
+    frac = (val / max_val) if max_val > 0 else 0.0
+    fill = _sample_colormap(_REDS_HEX, frac)
+    font = _LIGHT_TEXT if _is_dark_swatch(_REDS_HEX, frac) else _DARK_TEXT
+    return fill, font
+
+
+def _style_node_swarm(
+    coverage_map: Dict[str, float],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in swarm mode."""
+
+    cov = coverage_map.get(name, 0.0)
+    fill = _sample_colormap(_VIRIDIS_HEX, cov)
+    font = _LIGHT_TEXT if _is_dark_swatch(_VIRIDIS_HEX, cov) else _DARK_TEXT
+    return fill, font
+
+
+def _style_node_group_color(
+    group_map: Dict[str, frozenset],
+    group_index: Dict[str, int],
+    name: str,
+) -> Tuple[str, str]:
+    """Return (fill_color, font_color) for a node in group_color mode."""
+
+    groups = group_map.get(name, frozenset())
+    if not groups:
+        return _NEUTRAL_GREY, _DARK_TEXT
+    if len(groups) > 1:
+        # Multi-group node -- neutral shade rather than blending.
+        return _NEUTRAL_GREY, _DARK_TEXT
+    only_group = next(iter(groups))
+    idx = group_index.get(only_group, 0)
+    fill = _TAB10_HEX[idx % len(_TAB10_HEX)]
+    return fill, _LIGHT_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def show_bundle_graph(
+    bundle: "TraceBundle",
+    vis_outpath: Optional[str] = None,
+    mode: ModeLiteral = "auto",
+    *,
+    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "cosine",
+    show_coverage: bool = False,
+    vis_opt: VisModeLiteral = "unrolled",
+    vis_format: FileFormatLiteral = "pdf",
+    vis_orientation: DirectionLiteral = "bottomup",
+    save_only: bool = False,
+    direction: Literal["forward", "backward", "both"] = "forward",
+    return_dot: bool = False,
+) -> Optional[str]:
+    """Render a :class:`TraceBundle` as a Graphviz graph.
+
+    Parameters
+    ----------
+    bundle:
+        The :class:`TraceBundle` to render.
+    vis_outpath:
+        Output path. Extension is inferred from ``vis_format`` and any
+        recognised extension on ``vis_outpath`` is stripped first. If
+        ``None`` (default), writes to ``"bundle_graph"`` in the current
+        working directory -- mirrors ``show_model_graph``'s default.
+    mode:
+        Styling mode: ``'auto'`` (picks divergence for shared topology,
+        swarm for divergent), ``'divergence'``, ``'swarm'``, or
+        ``'group_color'``.
+    metric:
+        Distance metric for divergence mode. Accepts the same strings as
+        :func:`torchlens.multi_trace.metrics.resolve_metric` (``cosine``,
+        ``relative_l2``, ``pearson``) or a callable
+        ``(Tensor, Tensor) -> Tensor``.
+    show_coverage:
+        For swarm mode, append a ``coverage: NN%`` row to each node's
+        label. Ignored in other modes.
+    vis_opt:
+        Layout flavour, ``'unrolled'`` (default) or ``'rolled'``.
+        Currently advisory -- the bundle renderer always treats each
+        supergraph node as a single rendered node; the kwarg is reserved
+        for future parity with ``show_model_graph``.
+    vis_format:
+        Output file format (``pdf``/``png``/``svg``/...).
+    vis_orientation:
+        Layout direction: ``'bottomup'`` (default), ``'topdown'``, or
+        ``'leftright'``. Mirrors ``show_model_graph``'s ``direction``.
+    save_only:
+        If ``True``, write the output file but skip opening a viewer.
+    direction:
+        Reserved for symmetry with ``show_model_graph``'s forward/backward
+        mode toggle. Bundle visualization currently only renders forward
+        graphs; ``'backward'`` raises ``ValueError``.
+    return_dot:
+        Internal/test hook -- if ``True``, return the generated DOT
+        source instead of writing to disk. Used by tests to inspect
+        styling without spawning Graphviz.
+
+    Returns
+    -------
+    str | None
+        The DOT source when ``return_dot=True``; otherwise ``None``.
+
+    Raises
+    ------
+    ValueError
+        If ``mode='group_color'`` and ``bundle.groups`` is empty, if the
+        mode literal is unknown, or if ``direction`` is anything other
+        than ``'forward'``.
+    """
+
+    # ----- arg validation -------------------------------------------------
+    if mode not in ("auto", "divergence", "swarm", "group_color"):
+        raise ValueError(
+            f"mode must be one of 'auto', 'divergence', 'swarm', or 'group_color'; got {mode!r}"
+        )
+    if vis_opt not in ("unrolled", "rolled"):
+        raise ValueError(f"vis_opt must be 'unrolled' or 'rolled'; got {vis_opt!r}")
+    if direction != "forward":
+        raise ValueError(
+            "show_bundle_graph currently only supports direction='forward'; "
+            "backward graph rendering is not part of the multi-trace "
+            "visualization phase."
+        )
+
+    if mode == "group_color" and not bundle.groups:
+        raise ValueError(
+            "mode='group_color' requires bundle.groups to be non-empty; "
+            "construct the bundle with `tl.bundle(traces, names=..., "
+            "groups={'a': ['n1'], 'b': ['n2']})`."
+        )
+    if mode == "group_color" and len(bundle.groups) > len(_TAB10_HEX):
+        raise ValueError(
+            f"mode='group_color' supports up to {len(_TAB10_HEX)} groups; "
+            f"got {len(bundle.groups)}. Reduce the group count or extend "
+            "the palette."
+        )
+
+    resolved_mode = _resolve_mode(bundle, mode)
+
+    # ----- per-node styling data -----------------------------------------
+    distances: Dict[str, Optional[float]] = {}
+    coverage_map: Dict[str, float] = {}
+    group_map: Dict[str, frozenset] = {}
+    group_index: Dict[str, int] = {}
+
+    if resolved_mode == "divergence":
+        distances = _per_node_distance(bundle, metric)
+    if resolved_mode == "swarm" or show_coverage:
+        coverage_map = _per_node_coverage(bundle)
+    if resolved_mode == "group_color":
+        group_map = _per_node_groups(bundle)
+        # Stable, dict-insertion-order indexing; bundle.groups is a copy
+        # but the underlying dict preserves insertion order in CPython.
+        group_index = {gname: i for i, gname in enumerate(bundle.groups)}
+
+    # ----- DOT graph build ------------------------------------------------
+    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
+    rankdir = _direction_to_rankdir(vis_orientation)
+
+    n_traces = len(bundle.names)
+    n_nodes = len(sg.nodes)
+    # HTML-style labels are bracketed by ``<>`` so any literal ``<``/``>``
+    # inside the body must be escaped or graphviz refuses to parse the
+    # label. The caption is the only place we historically embed an
+    # arrow ("auto -> swarm"); escape it via the standard HTML entities.
+    caption_lines = [
+        "<B>TraceBundle</B>",
+        f"{n_traces} traces, {n_nodes} supergraph nodes",
+        f"mode={_html_escape(resolved_mode)}",
+    ]
+    if mode == "auto" and resolved_mode != "auto":
+        caption_lines[-1] = f"mode=auto -&gt; {_html_escape(resolved_mode)}"
+    if resolved_mode == "group_color":
+        caption_lines.append("groups: " + _html_escape(", ".join(sorted(bundle.groups))))
+    graph_caption = "<" + "<BR ALIGN='LEFT'/>".join(caption_lines) + "<BR ALIGN='LEFT'/>>"
+
+    dot = graphviz.Digraph(
+        name="trace_bundle",
+        comment="Computational graph for a TorchLens TraceBundle",
+        format=vis_format,
+    )
+    dot.graph_attr.update(
+        {
+            "rankdir": rankdir,
+            "label": graph_caption,
+            "labelloc": "t",
+            "labeljust": "left",
+            "ordering": "out",
+            "compound": "true",
+        }
+    )
+    dot.node_attr.update({"ordering": "out", "shape": "box", "style": "filled"})
+
+    # Build cluster lookup (leaf cluster path -> node names).
+    leaf_cluster_to_nodes = _build_module_clusters(bundle)
+
+    # Pre-compute per-node fill / font colours so cluster nesting is the
+    # only remaining concern.
+    node_styles: Dict[str, Tuple[str, str]] = {}
+    node_labels: Dict[str, str] = {}
+    for name in sg.topological_order:
+        node = sg.nodes[name]
+        if resolved_mode == "divergence":
+            fill, font = _style_node_divergence(distances, name)
+        elif resolved_mode == "swarm":
+            fill, font = _style_node_swarm(coverage_map, name)
+        else:  # group_color
+            fill, font = _style_node_group_color(group_map, group_index, name)
+        node_styles[name] = (fill, font)
+        label_lines = _node_label_lines(
+            name,
+            node,
+            coverage=coverage_map.get(name) if coverage_map else None,
+            distance=distances.get(name) if distances else None,
+            show_coverage=show_coverage and resolved_mode == "swarm",
+        )
+        node_labels[name] = _format_node_html(label_lines)
+
+    # Build the cluster hierarchy lazily: for each cluster path we open a
+    # subgraph and emit its nodes; nested clusters open inside their
+    # parents. We do this by sorting leaves by depth and walking each
+    # ancestor chain.
+
+    # Map dotted-prefix -> set of direct child dotted-prefixes (one
+    # level deeper) and direct nodes that live in that prefix.
+    prefix_children: Dict[str, Set[str]] = defaultdict(set)
+    prefix_nodes: Dict[str, List[str]] = defaultdict(list)
+    for leaf, names_at_leaf in leaf_cluster_to_nodes.items():
+        prefix_nodes[leaf].extend(names_at_leaf)
+        if not leaf:
+            continue
+        parts = leaf.split(".")
+        for depth in range(1, len(parts) + 1):
+            child = ".".join(parts[:depth])
+            parent = ".".join(parts[: depth - 1])
+            prefix_children[parent].add(child)
+
+    # ROOT nodes: those whose leaf cluster is "" (no module path).
+    root_nodes = list(prefix_nodes.get("", []))
+    for name in root_nodes:
+        fill, font = node_styles[name]
+        dot.node(
+            _safe_dot_id(name),
+            label=node_labels[name],
+            fillcolor=fill,
+            fontcolor=font,
+            color=fill,
+        )
+
+    # Nested clusters: walk depth-first, attaching nodes to the right level.
+    def _emit_subgraph(parent_dot: graphviz.Digraph, prefix: str) -> None:
+        cluster_label = prefix.split(".")[-1] if prefix else ""
+        cluster_name = f"cluster_{_safe_dot_id(prefix)}"
+        with parent_dot.subgraph(name=cluster_name) as sub:
+            sub.attr(
+                label=f"<<B>@{_html_escape(cluster_label)}</B>>",
+                labelloc="b",
+                style="filled",
+                fillcolor="white",
+                color="#888888",
+                penwidth="2",
+            )
+            for child_prefix in sorted(prefix_children.get(prefix, set())):
+                _emit_subgraph(sub, child_prefix)
+            for node_name in prefix_nodes.get(prefix, []):
+                fill, font = node_styles[node_name]
+                sub.node(
+                    _safe_dot_id(node_name),
+                    label=node_labels[node_name],
+                    fillcolor=fill,
+                    fontcolor=font,
+                    color=fill,
+                )
+
+    for top_prefix in sorted(prefix_children.get("", set())):
+        _emit_subgraph(dot, top_prefix)
+
+    # Edges. In group_color mode we colour edges by the dominant group of
+    # the traces that traversed the edge; in other modes we use a faded
+    # neutral so coloured nodes pop.
+    for (parent, child), trace_set in sg.edges.items():
+        edge_color = _resolve_edge_color(
+            trace_set,
+            resolved_mode=resolved_mode,
+            bundle=bundle,
+            group_index=group_index,
+        )
+        dot.edge(
+            _safe_dot_id(parent),
+            _safe_dot_id(child),
+            color=edge_color,
+            penwidth="1.5",
+        )
+
+    if return_dot:
+        return dot.source
+
+    # ----- output ---------------------------------------------------------
+    outpath = vis_outpath if vis_outpath is not None else "bundle_graph"
+    outpath = strip_known_extension(outpath)
+
+    if in_notebook() and not save_only:  # pragma: no cover - env-dependent
+        from IPython.display import display
+
+        display(dot)
+
+    timeout_warning = (
+        f"Graphviz render timed out for TraceBundle graph "
+        f"({n_nodes} nodes). DOT source preserved on disk."
+    )
+    render_dot_to_file(
+        dot,
+        outpath,
+        vis_format,
+        save_only,
+        timeout_warning=timeout_warning,
+    )
+    return None
+
+
+def _resolve_edge_color(
+    trace_set: Set[str],
+    *,
+    resolved_mode: ModeLiteral,
+    bundle: "TraceBundle",
+    group_index: Dict[str, int],
+) -> str:
+    """Pick a stroke colour for a supergraph edge given the traversing traces.
+
+    In ``group_color`` mode an edge gets the colour of the group that
+    traversed it (or neutral grey if multiple groups did). In divergence
+    and swarm modes we keep edges neutral so the coloured nodes stay the
+    visual focus.
+    """
+
+    if resolved_mode != "group_color":
+        return _EDGE_COLOR_NEUTRAL
+
+    groups = bundle.groups
+    if not groups or not group_index:
+        return _EDGE_COLOR_NEUTRAL
+
+    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
+    for group_name, members in groups.items():
+        for trace_name in members:
+            trace_to_groups[trace_name].add(group_name)
+
+    edge_groups: Set[str] = set()
+    for trace_name in trace_set:
+        edge_groups.update(trace_to_groups.get(trace_name, set()))
+
+    if len(edge_groups) == 1:
+        only = next(iter(edge_groups))
+        return _TAB10_HEX[group_index.get(only, 0) % len(_TAB10_HEX)]
+    return _EDGE_COLOR_NEUTRAL
+
+
+__all__ = ["show_bundle_graph"]

--- a/torchlens/multi_trace/visualization.py
+++ b/torchlens/multi_trace/visualization.py
@@ -1,46 +1,41 @@
 """Graphviz visualization for :class:`TraceBundle` objects.
 
-This module provides :func:`show_bundle_graph`, the canonical entry point
-for rendering a multi-trace bundle, plus three styling modes:
+This module provides :func:`show_bundle_graph`, the canonical entry
+point for rendering a multi-trace bundle, plus three styling modes:
 
 * ``divergence`` -- per-node mean pairwise distance, sequential ``Reds``
-  colormap. Use when the bundle is shared-topology and the question is
+  colormap.  Use when the bundle is shared-topology and the question is
   "which nodes change the most across traces?".
 * ``swarm`` -- per-node coverage fraction, sequential ``viridis``
-  colormap. Use for divergent-topology bundles where the question is
+  colormap.  Use for divergent-topology bundles where the question is
   "which nodes did most/all traces visit?".
 * ``group_color`` -- categorical colouring by trace-group membership
-  (``tab10`` palette). Requires ``bundle.groups`` to be non-empty;
+  (``tab10`` palette).  Requires ``bundle.groups`` to be non-empty;
   multi-group nodes get a neutral light-grey shade rather than a blended
   palette colour.
 
-The renderer is deliberately compact and self-contained -- it builds a
-fresh :class:`graphviz.Digraph` from the bundle's :class:`Supergraph`
-rather than reusing the ModelLog-coupled ``rendering.render_graph``
-machinery, which is too entangled with single-trace state to be safely
-re-pointed at a multi-trace input within the scope of this dispatch.
-What it DOES share with ``rendering.py`` is the file-format dispatch +
-view orchestration, factored into ``visualization/_render_utils.py``.
+Implementation factoring:
 
-Module clusters are derived from the supergraph's ``module_path`` strings
-(``"a.b.c"``-shaped), giving users the same hierarchical layout cue they
-get from ``show_model_graph`` even though the underlying ``ModuleLog``
-hierarchy is not first-class on a Supergraph.
+* ``torchlens/visualization/_render_utils.py`` holds the renderer-agnostic
+  Graphviz primitives (file-format dispatch, layout direction, HTML
+  escaping, module-cluster styling primitives).  Both this file and
+  ``rendering.py`` go through that module.
+* ``torchlens/multi_trace/_bundle_clusters.py`` builds the pass-aware
+  module cluster hierarchy from the supergraph.
+* ``torchlens/multi_trace/_bundle_styling.py`` holds the colormap tables,
+  per-node aggregation, and per-node fill/font/label resolution per mode.
+
+This file is the bundle-side orchestrator: it composes the helpers,
+constructs the Graphviz Digraph, and dispatches to file output.
 """
 
 from __future__ import annotations
 
-import os
-from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
-    List,
     Literal,
     Optional,
-    Set,
-    Tuple,
     Union,
 )
 
@@ -49,413 +44,33 @@ import torch
 
 from ..utils.display import in_notebook
 from ..visualization._render_utils import (
+    compute_module_penwidth,
+    direction_to_rankdir,
+    html_escape,
+    make_module_cluster_attrs,
     render_dot_to_file,
     strip_known_extension,
 )
-from .metrics import is_scalar_like, relative_l1_scalar, resolve_metric
+from ._bundle_clusters import collect_cluster_metadata, safe_dot_id
+from ._bundle_styling import (
+    ModeLiteral,
+    TAB10_HEX,
+    compute_node_styles,
+    resolve_edge_color,
+    resolve_mode,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only
     from .bundle import TraceBundle
-    from .topology import Supergraph, SupergraphNode
-
-
-# ---------------------------------------------------------------------------
-# Colormap definitions
-# ---------------------------------------------------------------------------
-#
-# All palettes are hardcoded as hex strings to avoid pulling matplotlib (or
-# any other plotting library) into torchlens's required dependency set.
-# Sampled at 10 stops for sequential maps; tab10 is the canonical
-# 10-category categorical palette. White / very light grey is reserved as
-# the "no-data / neutral" shade.
-
-# matplotlib's ``Reds`` colormap sampled at 10 evenly-spaced stops.
-# Light end is near-white so unchanged nodes fade into the background.
-_REDS_HEX: Tuple[str, ...] = (
-    "#fff5f0",
-    "#fee0d2",
-    "#fcbba1",
-    "#fc9272",
-    "#fb6a4a",
-    "#ef3b2c",
-    "#cb181d",
-    "#a50f15",
-    "#67000d",
-    "#4a000a",
-)
-
-# matplotlib's ``viridis`` colormap sampled at 10 evenly-spaced stops.
-# Monotonic luminance, colorblind-safe.
-_VIRIDIS_HEX: Tuple[str, ...] = (
-    "#440154",
-    "#482878",
-    "#3e4989",
-    "#31688e",
-    "#26828e",
-    "#1f9e89",
-    "#35b779",
-    "#6ece58",
-    "#b5de2b",
-    "#fde725",
-)
-
-# matplotlib's ``tab10`` categorical palette (RGB hex). Used for
-# group_color mode. Capacity is 10 distinct groups.
-_TAB10_HEX: Tuple[str, ...] = (
-    "#1f77b4",
-    "#ff7f0e",
-    "#2ca02c",
-    "#d62728",
-    "#9467bd",
-    "#8c564b",
-    "#e377c2",
-    "#7f7f7f",
-    "#bcbd22",
-    "#17becf",
-)
-
-# Designated neutral shade for nodes traversed by multiple groups in
-# group_color mode. Picked to read clearly against any tab10 colour.
-_NEUTRAL_GREY = "#d9d9d9"
-
-# Edge colour for divergence/swarm modes (faded so coloured nodes pop).
-_EDGE_COLOR_NEUTRAL = "#cccccc"
-
-# Default text colour for high-saturation node fills (improves contrast on
-# dark Reds / dark viridis stops). Heuristic: switch to white once the
-# fill darkens past ~halfway through the colormap.
-_LIGHT_TEXT = "#ffffff"
-_DARK_TEXT = "#000000"
 
 
 # ---------------------------------------------------------------------------
 # Public types
 # ---------------------------------------------------------------------------
 
-ModeLiteral = Literal["auto", "divergence", "swarm", "group_color"]
 DirectionLiteral = Literal["bottomup", "topdown", "leftright"]
 FileFormatLiteral = Literal["pdf", "png", "svg", "jpg", "jpeg", "bmp", "tif", "tiff"]
 VisModeLiteral = Literal["unrolled", "rolled"]
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _resolve_mode(bundle: "TraceBundle", mode: ModeLiteral) -> ModeLiteral:
-    """Resolve ``mode='auto'`` to a concrete styling mode.
-
-    Shared topology -> divergence (every node is universal so swarm would
-    paint everything the same colour). Divergent topology -> swarm
-    (coverage frequency carries information).
-    """
-
-    if mode != "auto":
-        return mode
-    return "divergence" if bundle.is_shared_topology else "swarm"
-
-
-def _direction_to_rankdir(direction: str) -> str:
-    """Translate a vis-direction literal into a Graphviz ``rankdir``."""
-
-    if direction == "bottomup":
-        return "BT"
-    if direction == "leftright":
-        return "LR"
-    if direction == "topdown":
-        return "TB"
-    raise ValueError(
-        f"vis_direction must be one of 'bottomup', 'topdown', or 'leftright'; got {direction!r}"
-    )
-
-
-def _sample_colormap(palette: Tuple[str, ...], frac: float) -> str:
-    """Return the palette colour closest to fractional position ``frac``.
-
-    ``frac`` is clamped to ``[0, 1]``; ``frac == 0`` -> first stop, ``frac
-    == 1`` -> last stop. Linear interpolation between stops would be more
-    accurate but adds zero perceptual benefit for rendered Graphviz
-    fills, so we round to the nearest stop.
-    """
-
-    if not palette:
-        return _NEUTRAL_GREY
-    if frac <= 0.0:
-        return palette[0]
-    if frac >= 1.0:
-        return palette[-1]
-    idx = int(round(frac * (len(palette) - 1)))
-    return palette[idx]
-
-
-def _is_dark_swatch(palette: Tuple[str, ...], frac: float) -> bool:
-    """Heuristic: is the colour at ``frac`` dark enough to need light text?"""
-
-    if not palette:
-        return False
-    if frac <= 0.0:
-        return False
-    # Past the midpoint of either palette the swatches are dark.
-    return frac >= 0.55
-
-
-def _per_node_distance(
-    bundle: "TraceBundle",
-    metric: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]],
-) -> Dict[str, Optional[float]]:
-    """Compute mean pairwise distance per supergraph node.
-
-    Returns a dict ``{node_name: distance_or_None}``. Nodes traversed by
-    fewer than two traces, or missing stored activations, map to
-    ``None`` so the caller can render them with a neutral shade.
-    """
-
-    metric_fn = resolve_metric(metric)
-    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
-    out: Dict[str, Optional[float]] = {}
-
-    for name in sg.topological_order:
-        node = sg.nodes[name]
-        tensors: List[torch.Tensor] = []
-        for trace_name in node.traces:
-            layer = node.layer_refs[trace_name]
-            has = getattr(layer, "has_saved_activations", False)
-            value = getattr(layer, "activation", None) if has else None
-            if isinstance(value, torch.Tensor):
-                tensors.append(value)
-        if len(tensors) < 2:
-            out[name] = None
-            continue
-        distances: List[float] = []
-        # Pairwise mean: mirror the contract in TraceBundle.most_changed.
-        for i in range(len(tensors)):
-            for j in range(i + 1, len(tensors)):
-                ti, tj = tensors[i], tensors[j]
-                if is_scalar_like(ti) or is_scalar_like(tj):
-                    d = relative_l1_scalar(ti, tj)
-                else:
-                    try:
-                        d = metric_fn(ti, tj)
-                    except (RuntimeError, ValueError):
-                        # Shape disagreement etc. -- fall back to scalar
-                        # form so the mode still produces something
-                        # rather than crashing the entire render.
-                        d = relative_l1_scalar(ti, tj)
-                distances.append(float(d.detach().item()))
-        if not distances:
-            out[name] = None
-            continue
-        out[name] = sum(distances) / len(distances)
-    return out
-
-
-def _per_node_coverage(bundle: "TraceBundle") -> Dict[str, float]:
-    """Fraction of bundled traces that traversed each supergraph node."""
-
-    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
-    n = max(len(bundle.names), 1)
-    return {name: len(node.traces) / n for name, node in sg.nodes.items()}
-
-
-def _per_node_groups(
-    bundle: "TraceBundle",
-) -> Dict[str, frozenset]:
-    """Set of group names that traversed each supergraph node.
-
-    Returns ``frozenset`` so the values are hashable and easy to compare;
-    a node with no group memberships maps to the empty frozenset.
-    """
-
-    groups = bundle.groups
-    if not groups:
-        return {}
-
-    # Reverse the trace_name -> group(s) mapping so we can ask "which
-    # groups does this set of traces belong to?".
-    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
-    for group_name, members in groups.items():
-        for trace_name in members:
-            trace_to_groups[trace_name].add(group_name)
-
-    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
-    out: Dict[str, frozenset] = {}
-    for name, node in sg.nodes.items():
-        node_groups: Set[str] = set()
-        for trace_name in node.traces:
-            node_groups.update(trace_to_groups.get(trace_name, set()))
-        out[name] = frozenset(node_groups)
-    return out
-
-
-def _cluster_path(module_path: Optional[str]) -> List[str]:
-    """Split a dotted module path into the prefix chain used for clusters.
-
-    Trailing pass-suffixes (``"a.b:1"``) are dropped because Graphviz
-    cluster names need to be stable across traces.
-    """
-
-    if not module_path:
-        return []
-    # Strip any ``":N"`` suffix on the leaf (pass index).
-    head = module_path.split(":")[0]
-    parts = [p for p in head.split(".") if p]
-    return parts
-
-
-def _safe_dot_id(name: str) -> str:
-    """Return a Graphviz-safe identifier for arbitrary node/cluster names.
-
-    Graphviz allows fairly liberal node names but quotes characters like
-    ``:``/``.``/spaces in the DOT source. We rewrite to a pure
-    ``[A-Za-z0-9_]`` form so generated DOT is easy to inspect in tests.
-    """
-
-    return "".join(c if c.isalnum() or c == "_" else "_" for c in name)
-
-
-def _build_module_clusters(
-    bundle: "TraceBundle",
-) -> Dict[str, List[str]]:
-    """Map cluster path (dotted prefix) -> list of node names in it.
-
-    Empty-prefix nodes (no module path) live at the root and don't get
-    wrapped in a cluster.
-    """
-
-    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
-    clusters: Dict[str, List[str]] = defaultdict(list)
-    for name in sg.topological_order:
-        node = sg.nodes[name]
-        path = _cluster_path(node.module_path)
-        # We attach each node to its leaf cluster only; ancestor clusters
-        # are reconstructed lazily when laying out subgraph nesting.
-        cluster_key = ".".join(path)
-        clusters[cluster_key].append(name)
-    return clusters
-
-
-def _walk_clusters(
-    cluster_paths: List[str],
-) -> List[List[str]]:
-    """Return the list of dotted-prefix paths needed to render clusters.
-
-    For each leaf path we emit every ancestor (prefix) too, so deeply
-    nested clusters get their parents created. Ordering preserves the
-    first-seen order of leaves for stable DOT output.
-    """
-
-    seen: Set[str] = set()
-    ordered: List[List[str]] = []
-    for leaf in cluster_paths:
-        if not leaf:
-            continue
-        parts = leaf.split(".")
-        for depth in range(1, len(parts) + 1):
-            prefix = ".".join(parts[:depth])
-            if prefix in seen:
-                continue
-            seen.add(prefix)
-            ordered.append(parts[:depth])
-    return ordered
-
-
-def _node_label_lines(
-    name: str,
-    node: "SupergraphNode",
-    *,
-    coverage: Optional[float] = None,
-    distance: Optional[float] = None,
-    show_coverage: bool = False,
-) -> List[str]:
-    """Build the multi-line label for a supergraph node.
-
-    First line is the node name, second line is the op_type, and (when
-    requested) we append a coverage / divergence line. Kept text-only --
-    we let Graphviz draw it as an HTML-like table so it stays readable.
-    """
-
-    lines = [_html_escape(name)]
-    if node.op_type:
-        lines.append(f"<I>{_html_escape(node.op_type)}</I>")
-    if show_coverage and coverage is not None:
-        pct = int(round(coverage * 100))
-        lines.append(f"<FONT POINT-SIZE='10'>coverage: {pct}%</FONT>")
-    if distance is not None:
-        lines.append(f"<FONT POINT-SIZE='10'>div: {distance:.3g}</FONT>")
-    return lines
-
-
-def _html_escape(value: str) -> str:
-    """Escape the three Graphviz HTML-label specials."""
-
-    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
-def _format_node_html(lines: List[str]) -> str:
-    """Wrap label lines into a Graphviz HTML-like label string."""
-
-    return "<" + "<BR/>".join(lines) + ">"
-
-
-# ---------------------------------------------------------------------------
-# Mode dispatch
-# ---------------------------------------------------------------------------
-
-
-def _style_node_divergence(
-    distances: Dict[str, Optional[float]],
-    name: str,
-) -> Tuple[str, str]:
-    """Return (fill_color, font_color) for a node in divergence mode."""
-
-    val = distances.get(name)
-    if val is None:
-        return _NEUTRAL_GREY, _DARK_TEXT
-    # Normalise to [0, 1] using the bundle-wide max so scales stay
-    # comparable. Skip nodes with None when computing the max.
-    valid = [v for v in distances.values() if v is not None]
-    max_val = max(valid) if valid else 0.0
-    frac = (val / max_val) if max_val > 0 else 0.0
-    fill = _sample_colormap(_REDS_HEX, frac)
-    font = _LIGHT_TEXT if _is_dark_swatch(_REDS_HEX, frac) else _DARK_TEXT
-    return fill, font
-
-
-def _style_node_swarm(
-    coverage_map: Dict[str, float],
-    name: str,
-) -> Tuple[str, str]:
-    """Return (fill_color, font_color) for a node in swarm mode."""
-
-    cov = coverage_map.get(name, 0.0)
-    fill = _sample_colormap(_VIRIDIS_HEX, cov)
-    font = _LIGHT_TEXT if _is_dark_swatch(_VIRIDIS_HEX, cov) else _DARK_TEXT
-    return fill, font
-
-
-def _style_node_group_color(
-    group_map: Dict[str, frozenset],
-    group_index: Dict[str, int],
-    name: str,
-) -> Tuple[str, str]:
-    """Return (fill_color, font_color) for a node in group_color mode."""
-
-    groups = group_map.get(name, frozenset())
-    if not groups:
-        return _NEUTRAL_GREY, _DARK_TEXT
-    if len(groups) > 1:
-        # Multi-group node -- neutral shade rather than blending.
-        return _NEUTRAL_GREY, _DARK_TEXT
-    only_group = next(iter(groups))
-    idx = group_index.get(only_group, 0)
-    fill = _TAB10_HEX[idx % len(_TAB10_HEX)]
-    return fill, _LIGHT_TEXT
-
-
-# ---------------------------------------------------------------------------
-# Main entry point
-# ---------------------------------------------------------------------------
 
 
 def show_bundle_graph(
@@ -499,7 +114,9 @@ def show_bundle_graph(
         Layout flavour, ``'unrolled'`` (default) or ``'rolled'``.
         Currently advisory -- the bundle renderer always treats each
         supergraph node as a single rendered node; the kwarg is reserved
-        for future parity with ``show_model_graph``.
+        for future parity with ``show_model_graph``.  Rolled bundle
+        rendering is logged as a deferred follow-up in
+        ``.project-context/todos.md`` under the Multi-trace V2 section.
     vis_format:
         Output file format (``pdf``/``png``/``svg``/...).
     vis_orientation:
@@ -510,7 +127,9 @@ def show_bundle_graph(
     direction:
         Reserved for symmetry with ``show_model_graph``'s forward/backward
         mode toggle. Bundle visualization currently only renders forward
-        graphs; ``'backward'`` raises ``ValueError``.
+        graphs; ``'backward'`` raises ``ValueError``.  Backward bundle
+        topology is logged as a deferred follow-up in
+        ``.project-context/todos.md`` under the Multi-trace V2 section.
     return_dot:
         Internal/test hook -- if ``True``, return the generated DOT
         source instead of writing to disk. Used by tests to inspect
@@ -527,6 +146,19 @@ def show_bundle_graph(
         If ``mode='group_color'`` and ``bundle.groups`` is empty, if the
         mode literal is unknown, or if ``direction`` is anything other
         than ``'forward'``.
+
+    Notes
+    -----
+    Module clusters are rendered with ModelLog-style aesthetics: per-
+    depth penwidth scaling (outermost thickest, deepest thinnest, using
+    the same min/max constants as ``show_model_graph``), separate
+    clusters for each pass of multi-pass modules, and ``@module:N``
+    pass-suffix labels when the supergraph contains more than one pass
+    of the underlying base module.  Single-pass modules drop the suffix
+    just like ModelLog does.  The bundle's supergraph collapses canonical
+    nodes by ``(containing_module, func_name)`` fingerprint, so divergent
+    topologies naturally end up in distinct clusters per pass without
+    special-case handling.
     """
 
     # ----- arg validation -------------------------------------------------
@@ -549,34 +181,34 @@ def show_bundle_graph(
             "construct the bundle with `tl.bundle(traces, names=..., "
             "groups={'a': ['n1'], 'b': ['n2']})`."
         )
-    if mode == "group_color" and len(bundle.groups) > len(_TAB10_HEX):
+    if mode == "group_color" and len(bundle.groups) > len(TAB10_HEX):
         raise ValueError(
-            f"mode='group_color' supports up to {len(_TAB10_HEX)} groups; "
+            f"mode='group_color' supports up to {len(TAB10_HEX)} groups; "
             f"got {len(bundle.groups)}. Reduce the group count or extend "
             "the palette."
         )
 
-    resolved_mode = _resolve_mode(bundle, mode)
+    resolved_mode = resolve_mode(bundle, mode)
 
-    # ----- per-node styling data -----------------------------------------
-    distances: Dict[str, Optional[float]] = {}
-    coverage_map: Dict[str, float] = {}
-    group_map: Dict[str, frozenset] = {}
-    group_index: Dict[str, int] = {}
-
-    if resolved_mode == "divergence":
-        distances = _per_node_distance(bundle, metric)
-    if resolved_mode == "swarm" or show_coverage:
-        coverage_map = _per_node_coverage(bundle)
-    if resolved_mode == "group_color":
-        group_map = _per_node_groups(bundle)
-        # Stable, dict-insertion-order indexing; bundle.groups is a copy
-        # but the underlying dict preserves insertion order in CPython.
-        group_index = {gname: i for i, gname in enumerate(bundle.groups)}
+    # ----- per-node aggregation + styling --------------------------------
+    # Stable, dict-insertion-order indexing; ``bundle.groups`` is a copy
+    # but the underlying dict preserves insertion order in CPython.
+    group_index = (
+        {gname: i for i, gname in enumerate(bundle.groups)}
+        if resolved_mode == "group_color"
+        else {}
+    )
+    node_styles, node_labels, _, _, _ = compute_node_styles(
+        bundle,
+        resolved_mode=resolved_mode,
+        metric=metric,
+        show_coverage=show_coverage,
+        group_index=group_index,
+    )
 
     # ----- DOT graph build ------------------------------------------------
-    sg: "Supergraph" = bundle._supergraph  # type: ignore[attr-defined]
-    rankdir = _direction_to_rankdir(vis_orientation)
+    sg = bundle._supergraph  # type: ignore[attr-defined]
+    rankdir = direction_to_rankdir(vis_orientation)
 
     n_traces = len(bundle.names)
     n_nodes = len(sg.nodes)
@@ -587,12 +219,12 @@ def show_bundle_graph(
     caption_lines = [
         "<B>TraceBundle</B>",
         f"{n_traces} traces, {n_nodes} supergraph nodes",
-        f"mode={_html_escape(resolved_mode)}",
+        f"mode={html_escape(resolved_mode)}",
     ]
     if mode == "auto" and resolved_mode != "auto":
-        caption_lines[-1] = f"mode=auto -&gt; {_html_escape(resolved_mode)}"
+        caption_lines[-1] = f"mode=auto -&gt; {html_escape(resolved_mode)}"
     if resolved_mode == "group_color":
-        caption_lines.append("groups: " + _html_escape(", ".join(sorted(bundle.groups))))
+        caption_lines.append("groups: " + html_escape(", ".join(sorted(bundle.groups))))
     graph_caption = "<" + "<BR ALIGN='LEFT'/>".join(caption_lines) + "<BR ALIGN='LEFT'/>>"
 
     dot = graphviz.Digraph(
@@ -612,56 +244,20 @@ def show_bundle_graph(
     )
     dot.node_attr.update({"ordering": "out", "shape": "box", "style": "filled"})
 
-    # Build cluster lookup (leaf cluster path -> node names).
-    leaf_cluster_to_nodes = _build_module_clusters(bundle)
+    # ----- cluster construction ------------------------------------------
+    (
+        cluster_nodes,
+        cluster_children,
+        cluster_title,
+        cluster_has_traversal,
+        max_nesting_depth,
+    ) = collect_cluster_metadata(bundle)
 
-    # Pre-compute per-node fill / font colours so cluster nesting is the
-    # only remaining concern.
-    node_styles: Dict[str, Tuple[str, str]] = {}
-    node_labels: Dict[str, str] = {}
-    for name in sg.topological_order:
-        node = sg.nodes[name]
-        if resolved_mode == "divergence":
-            fill, font = _style_node_divergence(distances, name)
-        elif resolved_mode == "swarm":
-            fill, font = _style_node_swarm(coverage_map, name)
-        else:  # group_color
-            fill, font = _style_node_group_color(group_map, group_index, name)
-        node_styles[name] = (fill, font)
-        label_lines = _node_label_lines(
-            name,
-            node,
-            coverage=coverage_map.get(name) if coverage_map else None,
-            distance=distances.get(name) if distances else None,
-            show_coverage=show_coverage and resolved_mode == "swarm",
-        )
-        node_labels[name] = _format_node_html(label_lines)
-
-    # Build the cluster hierarchy lazily: for each cluster path we open a
-    # subgraph and emit its nodes; nested clusters open inside their
-    # parents. We do this by sorting leaves by depth and walking each
-    # ancestor chain.
-
-    # Map dotted-prefix -> set of direct child dotted-prefixes (one
-    # level deeper) and direct nodes that live in that prefix.
-    prefix_children: Dict[str, Set[str]] = defaultdict(set)
-    prefix_nodes: Dict[str, List[str]] = defaultdict(list)
-    for leaf, names_at_leaf in leaf_cluster_to_nodes.items():
-        prefix_nodes[leaf].extend(names_at_leaf)
-        if not leaf:
-            continue
-        parts = leaf.split(".")
-        for depth in range(1, len(parts) + 1):
-            child = ".".join(parts[:depth])
-            parent = ".".join(parts[: depth - 1])
-            prefix_children[parent].add(child)
-
-    # ROOT nodes: those whose leaf cluster is "" (no module path).
-    root_nodes = list(prefix_nodes.get("", []))
-    for name in root_nodes:
+    # ROOT nodes: those whose cluster key is "" (no module).
+    for name in cluster_nodes.get("", []):
         fill, font = node_styles[name]
         dot.node(
-            _safe_dot_id(name),
+            safe_dot_id(name),
             label=node_labels[name],
             fillcolor=fill,
             fontcolor=font,
@@ -669,46 +265,60 @@ def show_bundle_graph(
         )
 
     # Nested clusters: walk depth-first, attaching nodes to the right level.
-    def _emit_subgraph(parent_dot: graphviz.Digraph, prefix: str) -> None:
-        cluster_label = prefix.split(".")[-1] if prefix else ""
-        cluster_name = f"cluster_{_safe_dot_id(prefix)}"
+    # Penwidth and style mirror rendering._setup_subgraphs_recurse so bundle
+    # clusters read identically to single-trace clusters at typical depths.
+    def _emit_subgraph(parent_dot: graphviz.Digraph, cluster_key: str, depth: int) -> None:
+        title = cluster_title.get(cluster_key, cluster_key)
+        cluster_name = f"cluster_{safe_dot_id(cluster_key)}"
+        # Match ``rendering.py`` semantics: ``has_input_ancestor=True`` ->
+        # ``filled,solid``, otherwise ``filled,dashed``.  At the bundle
+        # level we treat "any traversal at this cluster" as the positive
+        # signal.  A cluster the supergraph created with no traversal is
+        # impossible by construction, but the dict is exposed so future
+        # filtering (e.g. "skip clusters all traces avoided") slots in.
+        line_style = "solid" if cluster_has_traversal.get(cluster_key, False) else "dashed"
+        # ``compute_module_penwidth`` accepts 0-based depth; 1-based
+        # max_nesting_depth.  Depth 0 -> max penwidth, deepest -> min.
+        penwidth = compute_module_penwidth(depth, max_nesting_depth)
+        cluster_args = make_module_cluster_attrs(
+            title=title,
+            module_type=None,  # supergraph doesn't preserve module class
+            line_style=line_style,
+            penwidth=penwidth,
+        )
         with parent_dot.subgraph(name=cluster_name) as sub:
-            sub.attr(
-                label=f"<<B>@{_html_escape(cluster_label)}</B>>",
-                labelloc="b",
-                style="filled",
-                fillcolor="white",
-                color="#888888",
-                penwidth="2",
-            )
-            for child_prefix in sorted(prefix_children.get(prefix, set())):
-                _emit_subgraph(sub, child_prefix)
-            for node_name in prefix_nodes.get(prefix, []):
+            sub.attr(**cluster_args)
+            # Preserve a neutral border colour cue so module clusters
+            # remain visually distinct against white-background themes.
+            sub.attr(color="#888888")
+            for child_key in sorted(cluster_children.get(cluster_key, set())):
+                _emit_subgraph(sub, child_key, depth + 1)
+            for node_name in cluster_nodes.get(cluster_key, []):
                 fill, font = node_styles[node_name]
                 sub.node(
-                    _safe_dot_id(node_name),
+                    safe_dot_id(node_name),
                     label=node_labels[node_name],
                     fillcolor=fill,
                     fontcolor=font,
                     color=fill,
                 )
 
-    for top_prefix in sorted(prefix_children.get("", set())):
-        _emit_subgraph(dot, top_prefix)
+    for top_cluster_key in sorted(cluster_children.get("", set())):
+        _emit_subgraph(dot, top_cluster_key, 0)
 
-    # Edges. In group_color mode we colour edges by the dominant group of
+    # Edges: in group_color mode we colour edges by the dominant group of
     # the traces that traversed the edge; in other modes we use a faded
-    # neutral so coloured nodes pop.
+    # neutral so coloured nodes stay the visual focus.
     for (parent, child), trace_set in sg.edges.items():
-        edge_color = _resolve_edge_color(
+        edge_color = resolve_edge_color(
             trace_set,
             resolved_mode=resolved_mode,
             bundle=bundle,
             group_index=group_index,
         )
         dot.edge(
-            _safe_dot_id(parent),
-            _safe_dot_id(child),
+            safe_dot_id(parent),
+            safe_dot_id(child),
             color=edge_color,
             penwidth="1.5",
         )
@@ -737,43 +347,6 @@ def show_bundle_graph(
         timeout_warning=timeout_warning,
     )
     return None
-
-
-def _resolve_edge_color(
-    trace_set: Set[str],
-    *,
-    resolved_mode: ModeLiteral,
-    bundle: "TraceBundle",
-    group_index: Dict[str, int],
-) -> str:
-    """Pick a stroke colour for a supergraph edge given the traversing traces.
-
-    In ``group_color`` mode an edge gets the colour of the group that
-    traversed it (or neutral grey if multiple groups did). In divergence
-    and swarm modes we keep edges neutral so the coloured nodes stay the
-    visual focus.
-    """
-
-    if resolved_mode != "group_color":
-        return _EDGE_COLOR_NEUTRAL
-
-    groups = bundle.groups
-    if not groups or not group_index:
-        return _EDGE_COLOR_NEUTRAL
-
-    trace_to_groups: Dict[str, Set[str]] = defaultdict(set)
-    for group_name, members in groups.items():
-        for trace_name in members:
-            trace_to_groups[trace_name].add(group_name)
-
-    edge_groups: Set[str] = set()
-    for trace_name in trace_set:
-        edge_groups.update(trace_to_groups.get(trace_name, set()))
-
-    if len(edge_groups) == 1:
-        only = next(iter(edge_groups))
-        return _TAB10_HEX[group_index.get(only, 0) % len(_TAB10_HEX)]
-    return _EDGE_COLOR_NEUTRAL
 
 
 __all__ = ["show_bundle_graph"]

--- a/torchlens/visualization/_render_utils.py
+++ b/torchlens/visualization/_render_utils.py
@@ -1,12 +1,17 @@
 """Internal Graphviz rendering helpers shared across rendering paths.
 
-Private module: not part of the public API. Provides ModelLog-agnostic
+Private module: not part of the public API. Provides ModelLog/Bundle-agnostic
 primitives that the single-trace ``rendering.py`` and the multi-trace
 ``multi_trace/visualization.py`` both rely on, so we have one canonical
-implementation of file-format dispatch instead of two divergent copies.
+implementation of file-format dispatch, direction translation, module
+cluster styling, and HTML label escaping instead of two divergent copies.
 
 Keep this module narrow on purpose -- only primitives that take no
 ModelLog/Bundle context and can be reasoned about as pure utilities.
+The orchestration that knows WHICH nodes / edges / module paths to use
+lives in the per-input-shape callers (``rendering.render_graph`` for
+ModelLog, ``multi_trace/visualization.show_bundle_graph`` for
+TraceBundle).
 """
 
 from __future__ import annotations
@@ -14,7 +19,7 @@ from __future__ import annotations
 import os
 import subprocess
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 import graphviz
 
@@ -31,6 +36,14 @@ _KNOWN_EXTS = ("pdf", "png", "jpg", "svg", "jpeg", "bmp", "pic", "tif", "tiff")
 # legacy literal that lived inside ``rendering.render_graph``.
 RENDER_TIMEOUT_SECONDS = 120
 
+# -- Module subgraph border widths (shared between ModelLog and bundle paths)
+# Outermost modules get the thickest border; deeper modules thin out by depth
+# fraction so visual hierarchy reads at a glance.  These constants are the
+# canonical source for both ``rendering.py`` and the bundle renderer.
+MAX_MODULE_PENWIDTH = 5
+MIN_MODULE_PENWIDTH = 2
+PENWIDTH_RANGE = MAX_MODULE_PENWIDTH - MIN_MODULE_PENWIDTH
+
 
 def strip_known_extension(outpath: str) -> str:
     """Strip a recognised image extension off ``outpath`` if present.
@@ -45,6 +58,122 @@ def strip_known_extension(outpath: str) -> str:
     if len(parts) > 1 and parts[-1].lower() in _KNOWN_EXTS:
         return ".".join(parts[:-1])
     return outpath
+
+
+def direction_to_rankdir(direction: str) -> str:
+    """Translate a TorchLens vis-direction literal into a Graphviz ``rankdir``.
+
+    Accepted inputs: ``'bottomup'``, ``'topdown'``, ``'leftright'``.  Raises
+    ``ValueError`` on anything else so callers don't silently render with the
+    Graphviz default when a typo'd direction sneaks through.
+    """
+
+    if direction == "bottomup":
+        return "BT"
+    if direction == "leftright":
+        return "LR"
+    if direction == "topdown":
+        return "TB"
+    raise ValueError(
+        f"direction must be one of 'bottomup', 'topdown', or 'leftright'; got {direction!r}"
+    )
+
+
+def compute_module_penwidth(nesting_depth: int, max_nesting_depth: int) -> float:
+    """Return the cluster border width for a module at ``nesting_depth``.
+
+    ``nesting_depth`` is 0-based (outermost is depth 0).  Outermost modules
+    get the maximum penwidth; deepest modules get the minimum.  When the
+    overall hierarchy has only one level (``max_nesting_depth == 0`` or
+    ``1``) we still return a sensible value so callers don't have to
+    special-case shallow models.
+    """
+
+    if max_nesting_depth <= 0:
+        return float(MIN_MODULE_PENWIDTH + PENWIDTH_RANGE)
+    nesting_fraction = (max_nesting_depth - nesting_depth) / max_nesting_depth
+    nesting_fraction = max(0.0, min(1.0, nesting_fraction))
+    return MIN_MODULE_PENWIDTH + nesting_fraction * PENWIDTH_RANGE
+
+
+def html_escape(value: str) -> str:
+    """Escape the three Graphviz HTML-label specials.
+
+    Graphviz HTML-like labels reserve ``<``, ``>``, and ``&``; embedding any
+    of those raw breaks the parser.  Mirrors ``html.escape`` minus the
+    ``quote`` argument because Graphviz attribute values are themselves
+    already inside double quotes (no need to escape ``"``).
+    """
+
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def format_node_html(lines: Iterable[str]) -> str:
+    """Wrap pre-escaped label lines into a Graphviz HTML-like label string.
+
+    The caller is responsible for escaping content (use :func:`html_escape`)
+    -- a deliberate choice so callers can embed ``<B>``/``<I>``/``<FONT>``
+    tags where they want emphasis without us double-escaping them.
+    """
+
+    return "<" + "<BR/>".join(lines) + ">"
+
+
+def make_module_cluster_label(
+    title: str,
+    module_type: str | None = None,
+    *,
+    title_already_escaped: bool = False,
+) -> str:
+    """Return the HTML-style label string for a module cluster.
+
+    Mirrors the legacy format used by ``rendering._setup_subgraphs_recurse``:
+    ``<<B>@title</B><br align='left'/>(type)<br align='left'/>>``.  The
+    ``module_type`` line is omitted when no type information is available
+    (which is the case for bundle clusters because the supergraph stores
+    the module path string but not the underlying module class).
+
+    ``title_already_escaped`` lets the ModelLog path keep its existing
+    raw-title behaviour (where the title may itself contain ``:`` and is
+    fed verbatim) while the bundle path can opt-in to escaping arbitrary
+    user-provided strings.
+    """
+
+    title_str = title if title_already_escaped else html_escape(title)
+    if module_type:
+        return (
+            f"<<B>@{title_str}</B><br align='left'/>({html_escape(module_type)})<br align='left'/>>"
+        )
+    return f"<<B>@{title_str}</B><br align='left'/>>"
+
+
+def make_module_cluster_attrs(
+    *,
+    title: str,
+    module_type: str | None,
+    line_style: str,
+    penwidth: float,
+    fillcolor: str = "white",
+    title_already_escaped: bool = False,
+) -> dict[str, str]:
+    """Return the standard cluster attribute dict used by both renderers.
+
+    Centralises the Graphviz attrs that ModelLog and bundle clusters share:
+    HTML label, bottom labelloc, ``filled,<line_style>`` style, fill colour,
+    and depth-aware penwidth.  Module-type information is optional: bundle
+    clusters omit it because the supergraph doesn't preserve the module
+    class, while ModelLog clusters always pass it through.
+    """
+
+    return {
+        "label": make_module_cluster_label(
+            title, module_type, title_already_escaped=title_already_escaped
+        ),
+        "labelloc": "b",
+        "style": f"filled,{line_style}",
+        "fillcolor": fillcolor,
+        "penwidth": str(penwidth),
+    }
 
 
 def render_dot_to_file(

--- a/torchlens/visualization/_render_utils.py
+++ b/torchlens/visualization/_render_utils.py
@@ -1,0 +1,99 @@
+"""Internal Graphviz rendering helpers shared across rendering paths.
+
+Private module: not part of the public API. Provides ModelLog-agnostic
+primitives that the single-trace ``rendering.py`` and the multi-trace
+``multi_trace/visualization.py`` both rely on, so we have one canonical
+implementation of file-format dispatch instead of two divergent copies.
+
+Keep this module narrow on purpose -- only primitives that take no
+ModelLog/Bundle context and can be reasoned about as pure utilities.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import warnings
+from typing import TYPE_CHECKING
+
+import graphviz
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    pass
+
+
+# Recognised file extensions that callers may include on ``vis_outpath``.
+# Mirrors the legacy list in ``rendering.render_graph`` (kept as a tuple
+# so it stays cheap and immutable).
+_KNOWN_EXTS = ("pdf", "png", "jpg", "svg", "jpeg", "bmp", "pic", "tif", "tiff")
+
+# Default subprocess timeout for the dot/sfdp render call. Mirrors the
+# legacy literal that lived inside ``rendering.render_graph``.
+RENDER_TIMEOUT_SECONDS = 120
+
+
+def strip_known_extension(outpath: str) -> str:
+    """Strip a recognised image extension off ``outpath`` if present.
+
+    The Graphviz Python binding wants the basename without an extension --
+    it adds the extension itself based on the requested ``format``. Users
+    who pass ``"out.pdf"`` should still get ``"out.pdf"`` rather than
+    ``"out.pdf.pdf"``, so we trim a trailing recognised extension.
+    """
+
+    parts = outpath.split(".")
+    if len(parts) > 1 and parts[-1].lower() in _KNOWN_EXTS:
+        return ".".join(parts[:-1])
+    return outpath
+
+
+def render_dot_to_file(
+    dot: "graphviz.Digraph",
+    outpath: str,
+    file_format: str,
+    save_only: bool,
+    *,
+    timeout_seconds: int = RENDER_TIMEOUT_SECONDS,
+    timeout_warning: str | None = None,
+) -> str:
+    """Render ``dot`` to ``outpath.<file_format>``, optionally previewing it.
+
+    Mirrors the dot/save/subprocess/view flow used internally by
+    ``rendering.render_graph`` and ``rendering.render_backward_graph``,
+    factored out so the multi-trace renderer can share the same plumbing.
+
+    Returns the DOT source string (``dot.source``) regardless of whether
+    the subprocess render succeeded -- failures are surfaced via
+    ``warnings.warn`` to match existing behaviour.
+    """
+
+    parent = os.path.dirname(os.path.abspath(outpath))
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, exist_ok=True)
+
+    source_path = dot.save(outpath)
+    try:
+        rendered_path = f"{outpath}.{file_format}"
+        cmd = [dot.engine, f"-T{file_format}", "-o", rendered_path, source_path]
+        subprocess.run(
+            cmd,
+            timeout=timeout_seconds,
+            check=True,
+            capture_output=True,
+        )
+        if not save_only:
+            graphviz.backend.viewing.view(rendered_path)
+    except subprocess.TimeoutExpired:
+        warnings.warn(
+            timeout_warning
+            or (
+                f"Graphviz render timed out ({timeout_seconds}s). "
+                f"DOT source saved to '{source_path}'."
+            )
+        )
+    except subprocess.CalledProcessError as exc:
+        warnings.warn(f"Graphviz render failed: {exc.stderr.decode()}")
+    finally:
+        if os.path.exists(source_path):
+            os.remove(source_path)
+    return dot.source

--- a/torchlens/visualization/elk_layout.py
+++ b/torchlens/visualization/elk_layout.py
@@ -1036,9 +1036,8 @@ def render_elk_direct(
         FROZEN_PARAMS_BG_COLOR,
         DEFAULT_BG_COLOR,
         COMMUTE_FUNCS,
-        MIN_MODULE_PENWIDTH,
-        PENWIDTH_RANGE,
     )
+    from ._render_utils import compute_module_penwidth
     from .modes import COLLAPSED_MODE_REGISTRY
     from .node_spec import NodeSpec
 
@@ -1433,8 +1432,7 @@ def render_elk_direct(
         else:
             title = mod_addr
 
-        nf = (max_nest - depth) / max_nest if max_nest > 0 else 1
-        pw = MIN_MODULE_PENWIDTH + nf * PENWIDTH_RANGE
+        pw = compute_module_penwidth(depth, max_nest)
         ls = "solid" if module_has_ancestor.get(mod_key) else "dashed"
 
         cluster_label = f'<<B>@{title}</B><br align="left"/>({mod_type})<br align="left"/>>'

--- a/torchlens/visualization/rendering.py
+++ b/torchlens/visualization/rendering.py
@@ -68,6 +68,11 @@ from ..data_classes.layer_log import LayerLog
 from .modes import COLLAPSED_MODE_REGISTRY, MODE_REGISTRY
 from .node_spec import NodeSpec, render_lines_to_html
 from .code_panel import CodePanelOption, render_code_panel_subgraph, resolve_code_panel_source
+from ._render_utils import (
+    compute_module_penwidth,
+    direction_to_rankdir,
+    make_module_cluster_attrs,
+)
 
 if TYPE_CHECKING:
     from ..data_classes.grad_fn_log import GradFnLog
@@ -180,10 +185,9 @@ DEFAULT_BG_COLOR = "white"
 BOOL_NODE_COLOR = "#F7D460"  # Yellow for terminal boolean layers
 _NOISE_BUFFER_NAMES = frozenset({"running_mean", "running_var", "num_batches_tracked"})
 
-# -- Module subgraph border widths --
-MAX_MODULE_PENWIDTH = 5
-MIN_MODULE_PENWIDTH = 2
-PENWIDTH_RANGE = MAX_MODULE_PENWIDTH - MIN_MODULE_PENWIDTH
+# Module subgraph border widths live in ._render_utils -- both this file
+# and ``multi_trace/visualization.py`` use ``compute_module_penwidth`` so
+# bundle and ModelLog clusters scale identically by depth.
 
 # Commutative functions: argument order doesn't matter, so we skip arg-position
 # labels on their incoming edges to reduce visual clutter.
@@ -502,14 +506,7 @@ def render_graph(
             vis_mode=vis_mode,
         )
 
-    if direction == "bottomup":
-        rankdir = "BT"
-    elif direction == "leftright":
-        rankdir = "LR"
-    elif direction == "topdown":
-        rankdir = "TB"
-    else:
-        raise ValueError("direction must be either 'bottomup', 'topdown', or 'leftright'.")
+    rankdir = direction_to_rankdir(direction)
 
     # Resolve the layout engine early to potentially skip graphviz.Digraph construction.
     from .elk_layout import get_node_placement_engine
@@ -753,14 +750,7 @@ def render_backward_graph(
         raise ValueError("No backward graph is available; call log_backward(loss) first.")
     _ = collapsed_node_spec_fn, vis_node_mode
 
-    if direction == "bottomup":
-        rankdir = "BT"
-    elif direction == "leftright":
-        rankdir = "LR"
-    elif direction == "topdown":
-        rankdir = "TB"
-    else:
-        raise ValueError("direction must be either 'bottomup', 'topdown', or 'leftright'.")
+    rankdir = direction_to_rankdir(direction)
 
     split_outpath = vis_outpath.split(".")
     if split_outpath[-1] in [
@@ -3521,22 +3511,25 @@ def _setup_subgraphs_recurse(
 
     else:  # Leaf of this branch: create the subgraph and add all edges.
         with starting_subgraph.subgraph(name=cluster_name) as s:
-            # Penwidth scales with depth: outermost modules get thickest
-            # borders, deepest modules get thinnest.  Provides visual hierarchy.
-            nesting_fraction = (max_nesting_depth - nesting_depth) / max_nesting_depth
-            pen_width = MIN_MODULE_PENWIDTH + nesting_fraction * PENWIDTH_RANGE
+            # Penwidth + cluster attrs come from ``_render_utils`` so the
+            # bundle renderer in ``multi_trace/visualization.py`` can build
+            # equivalent clusters with the same formula and label format.
+            pen_width = compute_module_penwidth(nesting_depth, max_nesting_depth)
             if module_edge_dict[subgraph_name]["has_input_ancestor"]:
                 line_style = "solid"
             else:
                 line_style = "dashed"
 
-            module_args = {
-                "label": f"<<B>@{subgraph_title}</B><br align='left'/>({module_type})<br align='left'/>>",
-                "labelloc": "b",
-                "style": f"filled,{line_style}",
-                "fillcolor": "white",
-                "penwidth": str(pen_width),
-            }
+            # ``title_already_escaped=True`` preserves the existing byte-level
+            # output: ModelLog subgraph titles never contain HTML specials, so
+            # the title is fed through verbatim, matching the legacy format.
+            module_args = make_module_cluster_attrs(
+                title=subgraph_title,
+                module_type=module_type,
+                line_style=line_style,
+                penwidth=pen_width,
+                title_already_escaped=True,
+            )
 
             for arg_name, arg_val in overrides.module.items():  # type: ignore[union-attr]
                 if callable(arg_val):


### PR DESCRIPTION
## Summary

Phase 2 polish: refactor the bundle renderer to share rendering primitives with `show_model_graph` and bring module-cluster aesthetics into parity. The previous Phase 2 PR (#171) was closed because (1) the bundle renderer reimplemented node/edge/cluster styling instead of routing through shared utilities and (2) bundle clusters lacked penwidth-by-depth and pass-suffix labels. This branch addresses both.

### Three rendering modes (unchanged from 79c57c3)

* `divergence` -- per-node mean pairwise distance, sequential `Reds` colormap.
* `swarm` -- per-node coverage fraction, sequential `viridis` colormap.
* `group_color` -- categorical colouring by trace-group membership, `tab10` palette.
* `auto` -- picks divergence for shared-topology bundles, swarm for divergent.

### Refactor scope

`torchlens/visualization/_render_utils.py` is now the single source of truth for the Graphviz primitives shared between single- and multi-trace rendering:

* `direction_to_rankdir`, `compute_module_penwidth`, `make_module_cluster_attrs`
* `html_escape`, `format_node_html`
* `MAX_MODULE_PENWIDTH` / `MIN_MODULE_PENWIDTH` / `PENWIDTH_RANGE` constants
* The pre-existing `strip_known_extension` and `render_dot_to_file` helpers

`rendering.py` and `elk_layout.py` switched to these helpers; output is byte-equivalent for ModelLog renderings.

The bundle renderer was split into focused modules:

* `multi_trace/_bundle_clusters.py` -- supergraph -> cluster-hierarchy conversion (pass-aware module addresses, parent/child cluster map, rolled-style `(xN)` and `:N` pass-suffix titles).
* `multi_trace/_bundle_styling.py` -- colormap tables, per-node aggregation (divergence / coverage / group), per-mode fill+font dispatch, edge colouring.
* `multi_trace/visualization.py` -- orchestrator (354 lines, down from 779).

### Module cluster aesthetic parity

* Per-depth penwidth scaling via shared `compute_module_penwidth` (5.0 outermost, 2.0 deepest).
* Pass-aware titles: single-pass modules drop `:N`; supergraph clusters spanning distinct call-site occurrences keep `:N`; rolled-mode multi-pass LayerLogs append `(xN)`.
* Nested cluster hierarchy derived from each canonical supergraph node's `containing_modules` chain, matching ModelLog's nesting.
* Bundle clusters omit the `(ModuleType)` label line (the supergraph doesn't preserve module class) -- the only intentional difference from ModelLog.

### Two deferred items added to `.project-context/todos.md`

* `vis_opt='rolled'` for `show_bundle_graph` (currently advisory).
* `direction='backward'` for `show_bundle_graph` (currently raises `ValueError`).

### Quality gates

* `ruff check .` -- clean.
* `mypy torchlens/` -- clean.
* All 21 tests in `test_multi_trace_visualization.py` pass (17 original + 4 new cluster-parity tests).
* All 28 tests in `test_multi_trace.py` (Phase 1 regression) pass.
* All 12 `test_output_aesthetics.py` tests pass (single-trace `show_model_graph` regression).
* All 8 `test_backward_visualization.py` tests pass.
* All 3 `test_dagua_theme.py` tests pass.
* Full non-slow suite (1499 tests) passes.

## Test plan

- [x] Render a small ModelLog and a single-trace bundle from the same trace; cluster penwidths match at the shallowest depth and both renderers produce monotonically non-increasing penwidths.
- [x] Render a recurrent model bundle; cluster titles include `(x3)` suffix.
- [x] Render `NestedModules` bundle; per-pass clusters carry `:1`, `:2`, `:3` labels.
- [x] Render a single-pass model bundle; cluster titles drop the `:N` suffix.
- [x] Confirm `show_model_graph(model_log)` regression tests still pass.