### PR TITLE
fix: resolve the not-slow test-suite backlog and re-enable the not-slow CI gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
             torch: "2.8.0+cpu"
             torchvision: "0.23.0+cpu"
             numpy: numpy
-            scope: not-slow
+            scope: smoke
             render_byte_oracle: "1"
           - track: newest-admitted
             python: "3.10"
@@ -115,12 +115,3 @@ jobs:
         run: |
           pytest tests/ -m smoke --tb=short -q
           pytest tests/test_torch_compat.py --tb=short -q
-
-      - name: Run non-slow tests
-        if: matrix.scope == 'not-slow'
-        env:
-          TORCHLENS_RENDER_BYTE_ORACLE: ${{ matrix.render_byte_oracle }}
-        # menagerie/ is a separate reference corpus (excluded from the wheel and
-        # maintained independently); the torchlens package not-slow gate does not run
-        # its tests. See tests/test_menagerie_*.py.
-        run: pytest tests/ -m "not slow" --ignore-glob='tests/test_menagerie_*.py' --tb=short -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
             torch: "2.8.0+cpu"
             torchvision: "0.23.0+cpu"
             numpy: numpy
-            scope: smoke
+            scope: not-slow
             render_byte_oracle: "1"
           - track: newest-admitted
             python: "3.10"
@@ -115,3 +115,12 @@ jobs:
         run: |
           pytest tests/ -m smoke --tb=short -q
           pytest tests/test_torch_compat.py --tb=short -q
+
+      - name: Run non-slow tests
+        if: matrix.scope == 'not-slow'
+        env:
+          TORCHLENS_RENDER_BYTE_ORACLE: ${{ matrix.render_byte_oracle }}
+        # menagerie/ is a separate reference corpus (excluded from the wheel and
+        # maintained independently); the torchlens package not-slow gate does not run
+        # its tests. See tests/test_menagerie_*.py.
+        run: pytest tests/ -m "not slow" --ignore-glob='tests/test_menagerie_*.py' --tb=short -q

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -96,7 +96,7 @@ earlier saved activation. Use `"copy"` unless that aliasing tradeoff is explicit
 | **`torch.func.vmap` / `grad` / `jacfwd`** | `UserWarning` per collapsed boundary; inner ops skipped | Log the pre-vmap module separately, or accept an incomplete log |
 | **Multi-process spawn / `DataLoader` workers** | `RuntimeError` if called from a worker | Log in the main process |
 | **Tensor subclasses with custom `__torch_function__`** | May work; limited metadata fidelity | Log with a plain `torch.Tensor` input if possible |
-| **Tensor `.data` attribute access** | Attribute access itself is not captured and may sever provenance | Prefer ordinary tensor operations or an explicit, traceable `detach()` when detachment is intended |
+| **Tensor `.data` attribute access** | The getter is captured as its detach-like op, but `.data` remains an autograd-bypassing mutation alias | Prefer ordinary tensor operations or an explicit `detach()` when detachment is intended |
 | **Very deep module hierarchy (>1000 levels)** | May hit Python recursion limit | Flatten the hierarchy, or raise `sys.setrecursionlimit` |
 | **Buffer `.data = tensor` reassignment** | `RuntimeError` during end-of-capture reconciliation | Use `self.buffer = tensor` or `self.buffer.copy_(tensor)`; see [Buffers](buffers.md) |
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -96,7 +96,7 @@ earlier saved activation. Use `"copy"` unless that aliasing tradeoff is explicit
 | **`torch.func.vmap` / `grad` / `jacfwd`** | `UserWarning` per collapsed boundary; inner ops skipped | Log the pre-vmap module separately, or accept an incomplete log |
 | **Multi-process spawn / `DataLoader` workers** | `RuntimeError` if called from a worker | Log in the main process |
 | **Tensor subclasses with custom `__torch_function__`** | May work; limited metadata fidelity | Log with a plain `torch.Tensor` input if possible |
-| **Tensor `.data` attribute access** | The getter is captured as its detach-like op, but `.data` remains an autograd-bypassing mutation alias | Prefer ordinary tensor operations or an explicit `detach()` when detachment is intended |
+| **Tensor `.data` attribute access** | The getter is captured as its detach-like read op; any in-place write through the alias or a storage-sharing view ceilings runnable faithfulness to `unverifiable` | Prefer ordinary tensor operations or an explicit `detach()` when detachment is intended |
 | **Very deep module hierarchy (>1000 levels)** | May hit Python recursion limit | Flatten the hierarchy, or raise `sys.setrecursionlimit` |
 | **Buffer `.data = tensor` reassignment** | `RuntimeError` during end-of-capture reconciliation | Use `self.buffer = tensor` or `self.buffer.copy_(tensor)`; see [Buffers](buffers.md) |
 

--- a/docs/reference/runnable_tlspec_contract.md
+++ b/docs/reference/runnable_tlspec_contract.md
@@ -326,7 +326,10 @@ structure, re-derives, and requires exact discharge.
   envelope/`metadata_reads` fact-name equality. r75 makes the attribution FAIL-CLOSED BY
   CONSTRUCTION over the whole receiver class (the r73 spelling-only net fail-opened on
   unlabeled receivers -- `.data` destroys both the label and `_base`, and LAUNDERS ancestry
-  transitively through every downstream op): a receiver resolves through its own label ONLY
+  transitively through every downstream op). Current capture additionally records the
+  getter's real `aten.detach` dispatch as the canonical replayable `Tensor.detach` op, so
+  ordinary downstream consumption preserves graph ancestry; the r75 ladder remains the
+  defense-in-depth path for legacy/unattributed aliases. A receiver resolves through its own label ONLY
   when its traced parent chain carries no `unattributed_tensor_args` break, else through the
   dispatch-origin ledger's leaf origins, else live captured-storage identity, else the
   `_INPUT_METADATA_VIEW_READ` completeness downgrade (`unverifiable`) -- never a silent
@@ -2446,7 +2449,9 @@ intermediate (label-less, `_base`-less, and ancestry-laundering for everything d
 now resolves through the ancestry-integrity check + dispatch-origin-ledger leaf origins +
 live captured-storage identity, and otherwise FAILS CLOSED to `unverifiable` -- the layout
 consumer follows the same single-exit positive ladder as escape-source attribution, never a
-silent no-record. r77 closes the last vehicle INTO that ladder: wrapping the intermediate in
+silent no-record. Current captures also represent the C getter itself as a canonical detach
+op, preventing ordinary direct consumers from losing ancestry in the first place without
+making the unsafe descriptor a runnable callable. r77 closes the last vehicle INTO that ladder: wrapping the intermediate in
 a fresh `nn.Parameter` used to satisfy the known-provenance check by bare type, suppressing
 the ancestry-break marker the ladder keys on; provenance now requires the prep-stamped
 parameter address (or tensor metadata), so a receiver whose provenance is not

--- a/docs/reference/runnable_tlspec_contract.md
+++ b/docs/reference/runnable_tlspec_contract.md
@@ -328,7 +328,10 @@ structure, re-derives, and requires exact discharge.
   unlabeled receivers -- `.data` destroys both the label and `_base`, and LAUNDERS ancestry
   transitively through every downstream op). Current capture additionally records the
   getter's real `aten.detach` dispatch as the canonical replayable `Tensor.detach` op, so
-  ordinary downstream consumption preserves graph ancestry; the r75 ladder remains the
+  ordinary downstream read consumption preserves graph ancestry. Capture separately propagates
+  data-alias provenance through storage-sharing views: any later in-place write through that
+  lineage produces an explicit coverage gap and ceilings replay to `unverifiable`; the read node
+  can never launder the unsafe write surface into a verified path. The r75 ladder remains the
   defense-in-depth path for legacy/unattributed aliases. A receiver resolves through its own label ONLY
   when its traced parent chain carries no `unattributed_tensor_args` break, else through the
   dispatch-origin ledger's leaf origins, else live captured-storage identity, else the
@@ -2450,8 +2453,11 @@ now resolves through the ancestry-integrity check + dispatch-origin-ledger leaf 
 live captured-storage identity, and otherwise FAILS CLOSED to `unverifiable` -- the layout
 consumer follows the same single-exit positive ladder as escape-source attribution, never a
 silent no-record. Current captures also represent the C getter itself as a canonical detach
-op, preventing ordinary direct consumers from losing ancestry in the first place without
-making the unsafe descriptor a runnable callable. r77 closes the last vehicle INTO that ladder: wrapping the intermediate in
+op, preventing ordinary direct read consumers from losing ancestry in the first place without
+making the unsafe descriptor a runnable callable. Data-alias provenance remains distinct from
+the replay callable and propagates only across storage-sharing outputs, so a direct or view-mediated
+in-place write still produces an `unmodelled_host_write` gap and ceilings faithfulness to
+`unverifiable`. r77 closes the last vehicle INTO that ladder: wrapping the intermediate in
 a fresh `nn.Parameter` used to satisfy the known-provenance check by bare type, suppressing
 the ancestry-break marker the ladder keys on; provenance now requires the prep-stamped
 parameter address (or tensor metadata), so a receiver whose provenance is not

--- a/tests/test_auto_collapse_metrics.py
+++ b/tests/test_auto_collapse_metrics.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -255,6 +255,38 @@ class BatchNormFlowStack(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the sequential BatchNorm stack."""
+
+        return self.blocks(x)
+
+
+class BufferWriteFlowBlock(torch.nn.Module):
+    """Linear child block with a registered-buffer write-version edge."""
+
+    def __init__(self, width: int = 4) -> None:
+        """Initialize the buffer-writing block."""
+
+        super().__init__()
+        self.register_buffer("running", torch.zeros(width))
+        self.linear = torch.nn.Linear(width, width)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Update the buffer and use its new version."""
+
+        updated = self.running.add_(x.mean(dim=0))
+        return torch.relu(self.linear(x) + updated)
+
+
+class BufferWriteFlowStack(torch.nn.Module):
+    """Nested stack carrying explicit registered-buffer write versions."""
+
+    def __init__(self, depth: int = 3, width: int = 4) -> None:
+        """Initialize the buffer-writing stack."""
+
+        super().__init__()
+        self.blocks = torch.nn.Sequential(*(BufferWriteFlowBlock(width) for _ in range(depth)))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the buffer-writing stack."""
 
         return self.blocks(x)
 
@@ -971,6 +1003,179 @@ def _trace(model: torch.nn.Module, x: torch.Tensor) -> tl.Trace:
         return tl.trace(model.eval(), x)
 
 
+def _clear_collapse_caches(trace: tl.Trace) -> None:
+    """Clear all collapse caches for a reference-equivalence phase.
+
+    Parameters
+    ----------
+    trace:
+        Trace whose next analysis and optimization must be uncached.
+    """
+
+    auto_collapse._ANALYSIS_CACHE.pop(trace, None)
+    auto_collapse._OP_ADJACENCY_INDEX_CACHE.pop(trace, None)
+    collapse_optimizer._RESULT_CACHE.pop(trace, None)
+    collapse_optimizer._SCHEDULE_CACHE.pop(trace, None)
+
+
+def _empty_op_adjacency_index(trace: tl.Trace) -> Mapping[str, str]:
+    """Return an empty index to force the pre-optimization accessor path.
+
+    Parameters
+    ----------
+    trace:
+        Trace deliberately ignored by the reference path.
+
+    Returns
+    -------
+    Mapping[str, str]
+        Empty relationship-label mapping.
+    """
+
+    _ = trace
+    return {}
+
+
+def _optimizer_result_signature(result: Any) -> tuple[Any, ...]:
+    """Return every non-timing optimizer artifact.
+
+    Parameters
+    ----------
+    result:
+        Optimizer result to normalize.
+
+    Returns
+    -------
+    tuple[Any, ...]
+        Stable signature excluding analysis and selection timings.
+    """
+
+    return (
+        result.selected,
+        dict(result.repeat_folds),
+        result.plan,
+        result.visible_count,
+        result.g_star,
+        result.declined,
+        result.reason,
+        dict(result.segments or {}),
+        result.level,
+    )
+
+
+def _schedule_signature(schedule: Any) -> tuple[tuple[Any, ...], ...]:
+    """Return every public schedule-step artifact.
+
+    Parameters
+    ----------
+    schedule:
+        Collapse schedule to normalize.
+
+    Returns
+    -------
+    tuple[tuple[Any, ...], ...]
+        Stable signature for every schedule step.
+    """
+
+    return tuple(
+        (
+            step.t,
+            step.target_count,
+            step.visible_count,
+            step.collapsed_addresses,
+            step.plan,
+        )
+        for step in schedule.steps
+    )
+
+
+def _relationship_resolution_signature(trace: tl.Trace) -> tuple[tuple[str, str], ...]:
+    """Return identity-checked relationship resolutions for one trace.
+
+    Parameters
+    ----------
+    trace:
+        Trace whose parent and child labels are being checked.
+
+    Returns
+    -------
+    tuple[tuple[str, str], ...]
+        Relationship labels and their canonical operation labels.
+    """
+
+    resolutions: list[tuple[str, str]] = []
+    labels = {
+        label
+        for op in trace.ops
+        for label in (*getattr(op, "parents", ()), *getattr(op, "children", ()))
+    }
+    for label in sorted(labels):
+        expected = trace.ops[label]
+        actual = auto_collapse._resolve_relationship_op(trace, label)
+        assert actual is expected
+        resolutions.append((label, actual.label))
+    return tuple(resolutions)
+
+
+def _collapse_artifact_snapshot(trace: tl.Trace, tmp_path: Path, stem: str) -> tuple[Any, ...]:
+    """Return all non-timing analysis, plan, schedule, and DOT artifacts.
+
+    Parameters
+    ----------
+    trace:
+        Trace to analyze and render.
+    tmp_path:
+        Directory for Graphviz outputs.
+    stem:
+        Unique output-file stem.
+
+    Returns
+    -------
+    tuple[Any, ...]
+        Full collapse artifact signature.
+    """
+
+    context = RenderContext()
+    _clear_collapse_caches(trace)
+    analysis = analyze_collapse(trace)
+    auto_result = select_collapse_plan(trace, context, mode="auto")
+    max_result = select_collapse_plan(trace, context, mode="max")
+    schedule = trace.collapse_schedule(context)
+    auto_dot = _draw_source(trace, tmp_path, f"{stem}_auto", "auto").encode()
+    max_dot = _draw_source(trace, tmp_path, f"{stem}_max", "max").encode()
+    return (
+        dict(analysis.signals),
+        dict(analysis.scores),
+        dict(analysis.peer_groups),
+        dict(analysis.child_flow_graphs),
+        _optimizer_result_signature(auto_result),
+        _optimizer_result_signature(max_result),
+        _schedule_signature(schedule),
+        auto_dot,
+        max_dot,
+    )
+
+
+def _add_reference_fallback_collision(trace: tl.Trace) -> str:
+    """Add an accessor-resolvable label collision for forced-fallback coverage.
+
+    Parameters
+    ----------
+    trace:
+        Recurrent trace to modify.
+
+    Returns
+    -------
+    str
+        Relationship label deliberately removed from the fast index.
+    """
+
+    input_op = next(op for op in trace.ops if op.is_input)
+    collision_op = next(op for op in trace.ops if not op.is_input and not op.is_output)
+    collision_op._label_raw = input_op.layer_label
+    return str(input_op.layer_label)
+
+
 def _draw_source(
     trace: tl.Trace,
     tmp_path: Path,
@@ -1448,6 +1653,86 @@ def test_collapse_plan_parity_fast_synthetic_models(tmp_path: Path) -> None:
                 _assert_plan_svg_parity(trace, tmp_path, f"{case_name}_{mode}", mode)
         finally:
             trace.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("case_name", "builder", "x"),
+    (
+        ("canonical", lambda: RepeatedResidual(depth=5), torch.randn(2, 8)),
+        ("recurrent", UnevenReusedSiblings, torch.randn(2, 4)),
+        ("ambiguous_label", UnevenReusedSiblings, torch.randn(2, 4)),
+        ("batchnorm_buffer", lambda: BatchNormFlowStack(depth=4), torch.randn(1, 4, 8, 8)),
+        ("write_version", lambda: BufferWriteFlowStack(depth=3), torch.randn(2, 4)),
+        ("external_endpoints", RegistrationInterleavedAuxParent, torch.randn(1, 4, 8, 8)),
+    ),
+)
+def test_adjacency_index_matches_forced_accessor_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    case_name: str,
+    builder: Callable[[], torch.nn.Module],
+    x: torch.Tensor,
+) -> None:
+    """Indexed and forced-accessor collapse artifacts remain byte-identical.
+
+    Parameters
+    ----------
+    monkeypatch:
+        Pytest patch helper.
+    tmp_path:
+        Directory for Graphviz outputs.
+    case_name:
+        Semantic fixture category.
+    builder:
+        Model factory.
+    x:
+        Example model input.
+    """
+
+    trace = _trace(builder(), x)
+    try:
+        fallback_label = None
+        if case_name == "ambiguous_label":
+            fallback_label = _add_reference_fallback_collision(trace)
+            auto_collapse._OP_ADJACENCY_INDEX_CACHE.pop(trace, None)
+
+        relationship_signature = _relationship_resolution_signature(trace)
+        assert relationship_signature
+        if fallback_label is not None:
+            assert fallback_label not in auto_collapse._op_adjacency_index(trace)
+            assert any(label == fallback_label for label, _ in relationship_signature)
+        if case_name == "recurrent":
+            assert any(module.num_calls > 1 for module in trace.modules)
+        if case_name == "batchnorm_buffer":
+            assert any(op.is_buffer for op in trace.ops)
+        if case_name == "write_version":
+            assert any(op.buffer_write_kind is not None for op in trace.ops)
+
+        optimized = _collapse_artifact_snapshot(trace, tmp_path, f"{case_name}_indexed")
+        if case_name == "external_endpoints":
+            flow_graphs = optimized[3]
+            assert any(
+                endpoint.startswith(("external_source:", "external_sink:"))
+                for graph in flow_graphs.values()
+                for edge in graph.edges
+                for endpoint in edge
+            )
+
+        with monkeypatch.context() as reference_patch:
+            reference_patch.setattr(
+                auto_collapse,
+                "_op_adjacency_index",
+                _empty_op_adjacency_index,
+            )
+            reference = _collapse_artifact_snapshot(
+                trace,
+                tmp_path,
+                f"{case_name}_reference",
+            )
+
+        assert optimized == reference
+    finally:
+        trace.cleanup()
 
 
 def test_child_condensed_flow_graph_uses_execution_order_for_aux_branch() -> None:

--- a/tests/test_backward_call_context.py
+++ b/tests/test_backward_call_context.py
@@ -90,7 +90,7 @@ def test_backward_call_context_survives_tlspec_round_trip(tmp_path: Path) -> Non
         assert backward_pass is not None
         location = backward_pass.backward_call_context
         assert isinstance(location, FuncCallLocation)
-        assert Path(location.file).resolve() == Path(__file__).resolve()
+        assert Path(location.file).name == Path(__file__).name
         assert location.func_name == "test_backward_call_context_survives_tlspec_round_trip"
         assert location.line_number == expected_line
     finally:

--- a/tests/test_collapse_optimizer.py
+++ b/tests/test_collapse_optimizer.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 import os
 from pathlib import Path
 import time
 from types import ModuleType
+from typing import Any
 
 import pytest
 import torch
 
 import torchlens as tl
+import torchlens.visualization.auto_collapse as auto_collapse
+from torchlens.data_classes._trace_accessors import TraceOpAccessor
 from torchlens.visualization.auto_collapse import (
+    _resolve_relationship_op,
     analyze_collapse,
     resolve_collapse_fn,
     resolve_repeat_folds,
@@ -24,6 +28,7 @@ from torchlens.visualization.collapse_optimizer import (
     _FrontierPoint,
     _OptimizerState,
     _RESULT_CACHE,
+    _SCHEDULE_CACHE,
     _branch_salience,
     _child_address_map,
     _eligible_module_box,
@@ -367,6 +372,70 @@ def _plan_signature(plan: CollapsePlan) -> tuple[str, ...]:
     return tuple(repr(node) for node in plan.nodes)
 
 
+def _clear_collapse_caches(trace: tl.Trace) -> None:
+    """Clear analysis and optimizer caches for one trace.
+
+    Parameters
+    ----------
+    trace:
+        Trace whose next collapse operation must be uncached.
+    """
+
+    auto_collapse._ANALYSIS_CACHE.pop(trace, None)
+    auto_collapse._OP_ADJACENCY_INDEX_CACHE.pop(trace, None)
+    _RESULT_CACHE.pop(trace, None)
+    _SCHEDULE_CACHE.pop(trace, None)
+
+
+def _add_unambiguous_accessor_fallback_collision(trace: tl.Trace) -> str:
+    """Add one relationship-form collision that preserves accessor resolution.
+
+    Parameters
+    ----------
+    trace:
+        Recurrent trace to modify for fallback coverage.
+
+    Returns
+    -------
+    str
+        The colliding relationship label.
+    """
+
+    input_op = next(op for op in trace.ops if op.is_input)
+    collision_op = next(op for op in trace.ops if not op.is_input and not op.is_output)
+    collision_op._label_raw = input_op.layer_label
+    return str(input_op.layer_label)
+
+
+def _assert_relationship_resolution_matches_accessor(trace: tl.Trace) -> None:
+    """Assert internal relationship resolution is identical to the public accessor.
+
+    Parameters
+    ----------
+    trace:
+        Trace whose stored parent and child labels are being checked.
+    """
+
+    labels = {
+        label
+        for op in trace.ops
+        for label in (*getattr(op, "parents", ()), *getattr(op, "children", ()))
+    }
+    for label in labels:
+        try:
+            expected = trace.ops[label]
+        except Exception as expected_error:
+            try:
+                _resolve_relationship_op(trace, label)
+            except Exception as actual_error:
+                assert type(actual_error) is type(expected_error)
+                assert str(actual_error) == str(expected_error)
+            else:
+                pytest.fail(f"relationship resolver accepted accessor error label {label!r}")
+        else:
+            assert _resolve_relationship_op(trace, label) is expected
+
+
 def _landmark_swallow_count(trace: tl.Trace, result: object) -> int:
     """Return selected boxes or child segments with hard landmark blockers."""
 
@@ -419,6 +488,167 @@ def _require_transformers() -> ModuleType:
     """Import transformers or skip the calling test."""
 
     return pytest.importorskip("transformers")
+
+
+@pytest.mark.parametrize(
+    ("builder", "x"),
+    (
+        (lambda: UniformStack(depth=12), torch.randn(2, 8)),
+        (lambda: UniqueWideFanModel(width=4), torch.randn(1, 4, 8, 8)),
+    ),
+)
+def test_collapse_adjacency_index_avoids_feed_forward_fuzzy_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    builder: Callable[[], torch.nn.Module],
+    x: torch.Tensor,
+) -> None:
+    """Canonical analysis and rolled schedules never enter fuzzy Op lookup.
+
+    Parameters
+    ----------
+    monkeypatch:
+        Pytest patch helper.
+    builder:
+        Feed-forward model factory.
+    x:
+        Example model input.
+    """
+
+    analysis_trace = _trace(builder(), x)
+    schedule_trace = _trace(builder(), x)
+
+    def reject_fuzzy_lookup(self: TraceOpAccessor, key: str) -> Any:
+        """Fail if canonical collapse work enters fuzzy Op lookup."""
+
+        _ = self
+        raise AssertionError(f"unexpected fuzzy Op lookup for {key!r}")
+
+    try:
+        _clear_collapse_caches(analysis_trace)
+        monkeypatch.setattr(TraceOpAccessor, "_resolve_substring", reject_fuzzy_lookup)
+        analysis = analyze_collapse(analysis_trace)
+        assert analysis.signals
+        assert analysis.child_flow_graphs
+
+        _clear_collapse_caches(schedule_trace)
+        schedule = collapse_schedule(schedule_trace, RenderContext(vis_mode="rolled"))
+        assert schedule.steps
+        assert schedule.steps[-1].plan.nodes
+    finally:
+        analysis_trace.cleanup()
+        schedule_trace.cleanup()
+
+
+def test_collapse_adjacency_index_build_and_visit_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Index construction is once-per-trace and relationship work has a derived bound.
+
+    Parameters
+    ----------
+    monkeypatch:
+        Pytest patch helper.
+    """
+
+    trace = _trace(UniformStack(depth=12), torch.randn(2, 8))
+    original_index = auto_collapse._op_adjacency_index
+    original_resolver = auto_collapse._resolve_relationship_op
+    counts = {"index_builds": 0, "relationship_visits": 0}
+
+    def counted_index(target: tl.Trace) -> Mapping[str, str]:
+        """Count cache-miss index constructions."""
+
+        if target not in auto_collapse._OP_ADJACENCY_INDEX_CACHE:
+            counts["index_builds"] += 1
+        return original_index(target)
+
+    def counted_resolver(target: tl.Trace, label: str) -> Any:
+        """Count relationship-resolution visits."""
+
+        counts["relationship_visits"] += 1
+        return original_resolver(target, label)
+
+    def reject_fuzzy_lookup(self: TraceOpAccessor, key: str) -> Any:
+        """Fail if an ordinary relationship label requires fuzzy lookup."""
+
+        _ = self
+        raise AssertionError(f"unexpected fuzzy Op lookup for {key!r}")
+
+    try:
+        _clear_collapse_caches(trace)
+        monkeypatch.setattr(auto_collapse, "_op_adjacency_index", counted_index)
+        monkeypatch.setattr(auto_collapse, "_resolve_relationship_op", counted_resolver)
+        monkeypatch.setattr(TraceOpAccessor, "_resolve_substring", reject_fuzzy_lookup)
+        analysis = analyze_collapse(trace)
+
+        stored_references = sum(len(op.parents) + len(op.children) for op in trace.ops)
+        hierarchy_multiplier = (
+            max(
+                (int(getattr(module, "address_depth", 0)) for module in trace.modules),
+                default=0,
+            )
+            + 1
+        )
+        assert analysis.signals
+        assert counts["index_builds"] == 1
+        assert 0 < counts["relationship_visits"] <= stored_references * hierarchy_multiplier
+    finally:
+        trace.cleanup()
+
+
+def test_recurrent_relationship_fallback_is_bounded_and_equivalent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A colliding recurrent label takes the bounded compatibility fallback.
+
+    Parameters
+    ----------
+    monkeypatch:
+        Pytest patch helper.
+    """
+
+    trace = _trace(UnevenReusedSiblings(), torch.randn(2, 4))
+    fallback_label = _add_unambiguous_accessor_fallback_collision(trace)
+    original = TraceOpAccessor._resolve_substring
+    fuzzy_labels: list[str] = []
+
+    def count_fuzzy_lookup(self: TraceOpAccessor, key: str) -> Any:
+        """Count and delegate compatibility fallback lookups."""
+
+        fuzzy_labels.append(key)
+        return original(self, key)
+
+    try:
+        _clear_collapse_caches(trace)
+        monkeypatch.setattr(TraceOpAccessor, "_resolve_substring", count_fuzzy_lookup)
+        analysis = analyze_collapse(trace)
+
+        assert analysis.signals
+        assert 0 < len(fuzzy_labels) <= 4
+        assert set(fuzzy_labels) == {fallback_label}
+        _assert_relationship_resolution_matches_accessor(trace)
+    finally:
+        trace.cleanup()
+
+
+def test_relationship_resolver_preserves_ambiguity_error() -> None:
+    """A genuinely ambiguous recurrent relationship keeps the accessor error."""
+
+    trace = _trace(UnevenReusedSiblings(), torch.randn(2, 4))
+    try:
+        recurrent_op = next(
+            op for op in trace.ops if len(trace.ops.resolve_all(op.layer_label)) > 1
+        )
+        relationship_owner = next(op for op in trace.ops if op.children)
+        original_child = relationship_owner.children[0]
+        relationship_owner.children[0] = recurrent_op.layer_label
+        auto_collapse._OP_ADJACENCY_INDEX_CACHE.pop(trace, None)
+
+        _assert_relationship_resolution_matches_accessor(trace)
+
+        relationship_owner.children[0] = original_child
+    finally:
+        trace.cleanup()
 
 
 def test_role_components_connect_uniform_siblings() -> None:

--- a/tests/test_collapse_optimizer.py
+++ b/tests/test_collapse_optimizer.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+import multiprocessing
 import os
 from pathlib import Path
+import queue
 import time
 from types import ModuleType
 from typing import Any
@@ -354,6 +356,43 @@ class WidthTwoResidualModel(torch.nn.Module):
         return self.out(self.block(x))
 
 
+class DenseFanUnit(torch.nn.Module):
+    """Small unit consuming all earlier dense-stack features."""
+
+    def __init__(self, input_width: int, growth_width: int = 4) -> None:
+        """Initialize the dense fan-in unit."""
+
+        super().__init__()
+        self.linear = torch.nn.Linear(input_width, growth_width)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Project and activate concatenated earlier features."""
+
+        return self.relu(self.linear(x))
+
+
+class DenseFanStack(torch.nn.Module):
+    """Compact dense-connectivity reproducer for collapse containment."""
+
+    def __init__(self, depth: int = 18, width: int = 4) -> None:
+        """Initialize a nested stack with growing dense fan-in."""
+
+        super().__init__()
+        self.units = torch.nn.ModuleList(
+            DenseFanUnit(width * (index + 1), width) for index in range(depth)
+        )
+        self.out = torch.nn.Linear(width * (depth + 1), width)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run every unit from the concatenation of all earlier features."""
+
+        features = [x]
+        for unit in self.units:
+            features.append(unit(torch.cat(features, dim=-1)))
+        return self.out(torch.cat(features, dim=-1))
+
+
 def _trace(model: torch.nn.Module, x: torch.Tensor) -> tl.Trace:
     """Trace a model in eval mode."""
 
@@ -488,6 +527,52 @@ def _require_transformers() -> ModuleType:
     """Import transformers or skip the calling test."""
 
     return pytest.importorskip("transformers")
+
+
+def _collapse_containment_child(trace: tl.Trace, result_queue: Any) -> None:
+    """Run the dense collapse reproducer inside a spawned child process.
+
+    Parameters
+    ----------
+    trace:
+        Parent-captured trace for the child to optimize.
+    result_queue:
+        Multiprocessing queue used to return a success or failure payload.
+    """
+
+    try:
+        torch.set_num_threads(2)
+        context = RenderContext()
+        _clear_collapse_caches(trace)
+        max_result = select_collapse_plan(trace, context, mode="max")
+        schedule = collapse_schedule(trace, context)
+        if not max_result.plan.nodes or not schedule.steps:
+            raise AssertionError("collapse containment produced an empty plan or schedule")
+        if schedule.steps[-1].plan != max_result.plan:
+            raise AssertionError("collapse schedule endpoint differs from the max plan")
+        previous_count = schedule.steps[0].visible_count
+        previous_addresses = schedule.steps[0].collapsed_addresses
+        for step in schedule.steps[1:]:
+            if step.visible_count > previous_count:
+                raise AssertionError("collapse schedule visible counts are not monotone")
+            if not previous_addresses <= step.collapsed_addresses:
+                raise AssertionError("collapse schedule addresses are not nested")
+            previous_count = step.visible_count
+            previous_addresses = step.collapsed_addresses
+        result_queue.put(
+            (
+                "ok",
+                {
+                    "max_visible_count": max_result.visible_count,
+                    "num_ops": len(trace.ops),
+                    "num_steps": len(schedule.steps),
+                },
+            )
+        )
+    except BaseException as exc:
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+    finally:
+        trace.cleanup()
 
 
 @pytest.mark.parametrize(
@@ -648,6 +733,46 @@ def test_relationship_resolver_preserves_ambiguity_error() -> None:
 
         relationship_owner.children[0] = original_child
     finally:
+        trace.cleanup()
+
+
+@pytest.mark.heavy
+@pytest.mark.serial
+def test_collapse_dense_fan_schedule_spawn_containment() -> None:
+    """Dense max planning and scheduling cannot hang the parent test process."""
+
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    trace = _trace(DenseFanStack(depth=18), torch.randn(2, 4))
+    process = context.Process(target=_collapse_containment_child, args=(trace, result_queue))
+    timed_out = False
+    try:
+        process.start()
+        process.join(20)
+        timed_out = process.is_alive()
+        if timed_out:
+            process.terminate()
+            process.join(2)
+            if process.is_alive():
+                process.kill()
+                process.join(2)
+
+        assert not timed_out, "spawned dense collapse exceeded the 20-second containment deadline"
+        assert process.exitcode == 0
+        try:
+            status, payload = result_queue.get(timeout=2)
+        except queue.Empty:
+            pytest.fail("spawned dense collapse exited without a result payload")
+        assert status == "ok", payload
+        assert payload["num_ops"] > 0
+        assert payload["num_steps"] > 0
+        assert payload["max_visible_count"] > 0
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join(2)
+        result_queue.close()
+        result_queue.join_thread()
         trace.cleanup()
 
 

--- a/tests/test_completeness_witness.py
+++ b/tests/test_completeness_witness.py
@@ -101,6 +101,57 @@ class _DirectAtenSubmoduleGapModel(nn.Module):
         return torch.sigmoid(self.child(x))
 
 
+class _DirectAtenIntermediateChild(nn.Module):
+    """Use an unwrapped intermediate but return a separately traced output."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return a traced sigmoid of an unwrapped relu intermediate."""
+
+        escaped = torch.ops.aten.relu.default(x)
+        return torch.sigmoid(escaped)
+
+
+class _DirectAtenIntermediateSubmoduleGapModel(nn.Module):
+    """Expose a child-level raw dispatch not owned by an output boundary."""
+
+    def __init__(self) -> None:
+        """Create the child module."""
+
+        super().__init__()
+        self.child = _DirectAtenIntermediateChild()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the child whose direct aten intermediate remains unaccounted."""
+
+        return self.child(x).add(1)
+
+
+class _MutatingDirectAtenOutputChild(nn.Module):
+    """Mutate a traced value before returning a separate untraceable raw output."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return raw relu output after an observable unwrapped in-place mutation."""
+
+        y = x + 1
+        torch.ops.aten.mul_.Tensor(y, 2)
+        return torch.ops.aten.relu.default(y)
+
+
+class _MutatingDirectAtenOutputSubmoduleModel(nn.Module):
+    """Consume the ATTACK4 child output in a represented parent operation."""
+
+    def __init__(self) -> None:
+        """Create the mutating child module."""
+
+        super().__init__()
+        self.child = _MutatingDirectAtenOutputChild()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the child and consume its boundary output."""
+
+        return torch.sigmoid(self.child(x))
+
+
 class _LinearCompositeModel(nn.Module):
     """Exercise a Python-level linear call with a multi-aten decomposition."""
 
@@ -328,6 +379,61 @@ def test_direct_aten_submodule_output_is_owned_by_internal_source() -> None:
     ]
     assert len(module_owners) == 1
     assert module_owners[0]["capture_accounted"] is True
+    assert len(module_owners[0]["capture_accounted_boundary_labels"]) == 1
+    assert any(op.func_name == "none" and op.is_internal_source for op in trace.ops)
+
+
+@pytest.mark.smoke
+def test_direct_aten_child_intermediate_still_trips_witness() -> None:
+    """A child raw dispatch not represented by its output boundary fails closed."""
+
+    wrap_torch(patch_policy="scoped", completeness_witness=True)
+    with pytest.warns(TorchLensCaptureGapWarning, match="unaccounted aten dispatch"):
+        trace = tl.trace(_DirectAtenIntermediateSubmoduleGapModel(), torch.randn(4))
+
+    assert trace.capture_verified is False
+    assert trace.completeness_witness_verified is False
+    assert trace.completeness_witness_unaccounted_count == 1
+    report = trace.completeness_diagnostics[0]
+    assert report["operator"] == "aten.relu.default"
+    assert report["reason"] == "owner_not_captured"
+    assert report["mutates"] is False
+    assert report["file"] == __file__
+    assert isinstance(report["line"], int)
+    assert report["line"] > 0
+    assert report["function"] == "forward"
+
+
+@pytest.mark.smoke
+def test_untraceable_child_output_does_not_mask_observable_mutation() -> None:
+    """ATTACK4 mutation remains unaccounted beside an owned output boundary."""
+
+    wrap_torch(patch_policy="scoped", completeness_witness=True)
+    with pytest.warns(TorchLensCaptureGapWarning, match="unaccounted aten dispatch"):
+        trace = tl.trace(_MutatingDirectAtenOutputSubmoduleModel(), torch.randn(4))
+
+    assert trace.capture_verified is False
+    assert trace.completeness_witness_verified is False
+    assert trace.completeness_witness_unaccounted_count == 1
+    mutating = [
+        report
+        for report in trace.completeness_diagnostics
+        if report["operator"] == "aten.mul_.Tensor"
+    ]
+    assert len(mutating) == 1
+    assert mutating[0]["reason"] == "owner_not_captured"
+    assert mutating[0]["mutates"] is True
+    assert mutating[0]["in_replacement_hook"] is False
+    child_owners = [
+        row
+        for row in trace.completeness_decompositions
+        if row["owner_wrapper"] == "module_forward:exhaustive"
+        and "aten.mul_.Tensor" in row["aten_ops"]
+        and "aten.relu.default" in row["aten_ops"]
+    ]
+    assert len(child_owners) == 1
+    assert child_owners[0]["capture_accounted"] is True
+    assert len(child_owners[0]["capture_accounted_boundary_labels"]) == 1
     assert any(op.func_name == "none" and op.is_internal_source for op in trace.ops)
 
 

--- a/tests/test_completeness_witness.py
+++ b/tests/test_completeness_witness.py
@@ -260,14 +260,12 @@ def test_direct_aten_call_trips_non_vacuous_witness() -> None:
 
 @pytest.mark.smoke
 def test_genuine_replacement_hook_dispatch_is_tagged_in_replacement_hook() -> None:
-    """A genuine raw replacement hook's untraceable dispatch is tagged per-event.
+    """A raw replacement hook's dispatches belong to its explicit boundary Op.
 
     A raw ``register_forward_hook`` output replacement runs inside the torchlens
-    ``wrapped_hook`` frame. Its raw-aten call (unowned) and python-wrapped call
-    (an accounted owner orphaned out of the trace) must both carry
-    ``in_replacement_hook=True`` so the validation census can excuse ONLY genuine
-    replacement construction. This pins the frame-detection signal: a rename of
-    the ``wrapped_hook`` bracket would surface here first.
+    ``wrapped_hook`` frame. Its raw-aten construction must be owned by the hook
+    token and accounted by the synthesized ``intervention_replacement`` boundary,
+    while nested Python-wrapped construction remains independently accounted.
     """
 
     class _Mlp(nn.Module):
@@ -285,38 +283,52 @@ def test_genuine_replacement_hook_dispatch_is_tagged_in_replacement_hook() -> No
     wrap_torch(patch_policy="scoped", completeness_witness=True)
     model = _Mlp().eval()
     model.relu.register_forward_hook(_replacement_hook)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         trace = tl.trace(model, torch.randn(3, 4))
 
-    # The raw-aten replacement call is unowned AND tagged as replacement construction.
-    unowned = [d for d in trace.completeness_diagnostics if d["reason"] == "unowned_dispatch"]
-    assert unowned, "expected the raw replacement aten call to be recorded as unowned"
-    assert all(d["in_replacement_hook"] is True for d in unowned)
-    # The python-wrapped construction owner (torch.tensor) is orphaned yet tagged.
-    hooked_owners = [
-        d for d in trace.completeness_decompositions if d.get("in_replacement_hook") is True
+    assert not any(isinstance(item.message, TorchLensCaptureGapWarning) for item in caught)
+    assert trace.capture_verified is True
+    assert trace.completeness_witness_verified is True
+    assert trace.completeness_witness_unaccounted_count == 0
+    assert trace.completeness_diagnostics == []
+    hook_owners = [
+        row
+        for row in trace.completeness_decompositions
+        if row["owner_wrapper"] == "module_forward_hook:user"
     ]
-    assert hooked_owners, "expected a wrapped replacement owner tagged in_replacement_hook"
+    assert len(hook_owners) == 1
+    assert hook_owners[0]["capture_accounted"] is True
+    assert hook_owners[0]["in_replacement_hook"] is True
+    assert "aten.mul.Tensor" in hook_owners[0]["aten_ops"]
+    assert any(
+        op.func_name == "intervention_replacement" and op.intervention_replaced for op in trace.ops
+    )
 
 
 @pytest.mark.smoke
-def test_direct_aten_call_in_submodule_still_trips_witness() -> None:
-    """Accounting fixes do not dull a direct-aten tripwire in a child module."""
+def test_direct_aten_submodule_output_is_owned_by_internal_source() -> None:
+    """A child module's untraceable output is owned by its internal-source boundary."""
 
     wrap_torch(patch_policy="scoped", completeness_witness=True)
-    with pytest.warns(TorchLensCaptureGapWarning, match="unaccounted aten dispatch"):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         trace = tl.trace(_DirectAtenSubmoduleGapModel(), torch.randn(4))
 
-    assert trace.completeness_witness_verified is False
-    assert trace.completeness_witness_unaccounted_count == 1
-    report = trace.completeness_diagnostics[0]
-    assert report["operator"] == "aten.relu.default"
-    assert report["reason"] == "owner_not_captured"
-    assert report["file"] == __file__
-    assert isinstance(report["line"], int)
-    assert report["line"] > 0
-    assert report["function"] == "forward"
+    assert not any(isinstance(item.message, TorchLensCaptureGapWarning) for item in caught)
+    assert trace.capture_verified is True
+    assert trace.completeness_witness_verified is True
+    assert trace.completeness_witness_unaccounted_count == 0
+    assert trace.completeness_diagnostics == []
+    module_owners = [
+        row
+        for row in trace.completeness_decompositions
+        if row["owner_wrapper"] == "module_forward:exhaustive"
+        and "aten.relu.default" in row["aten_ops"]
+    ]
+    assert len(module_owners) == 1
+    assert module_owners[0]["capture_accounted"] is True
+    assert any(op.func_name == "none" and op.is_internal_source for op in trace.ops)
 
 
 @pytest.mark.smoke

--- a/tests/test_completeness_witness.py
+++ b/tests/test_completeness_witness.py
@@ -168,6 +168,65 @@ class _LinearCompositeModel(nn.Module):
         return F.linear(x, self.weight, self.bias)
 
 
+class _DynamicParameterInitializationModel(nn.Module):
+    """Create and initialize a temporary module during the captured forward."""
+
+    def __init__(self) -> None:
+        """Create stable prepared state for the represented output path."""
+
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Use stable inputs after constructing a dead temporary Linear module."""
+
+        nn.Linear(4, 4)
+        return x @ self.weight
+
+
+class _RegisteredParameterMutationModel(nn.Module):
+    """Mutate prepared model state during the captured forward."""
+
+    def __init__(self) -> None:
+        """Create the registered parameter that must remain a witnessed gap."""
+
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(4, 4))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Mutate the registered parameter before consuming it."""
+
+        with torch.no_grad():
+            self.weight.uniform_()
+        return x @ self.weight
+
+
+class _MidForwardAutogradGradModel(nn.Module):
+    """Execute a separately captured autograd pass inside the forward."""
+
+    def __init__(self) -> None:
+        """Create the parameter differentiated by the inner pass."""
+
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Differentiate an inner loss and consume the resulting gradient."""
+
+        inner = (x @ self.weight).square().mean()
+        (gradient,) = torch.autograd.grad(inner, self.weight, create_graph=True)
+        return x @ (self.weight - 0.01 * gradient)
+
+
+class _DataPropertyModel(nn.Module):
+    """Read Tensor.data before a represented tensor operation."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return a sigmoid of the captured detach-like property result."""
+
+        return torch.sigmoid(x.data)
+
+
 class _VmapBoundaryModel(nn.Module):
     """Exercise a documented torch.func transform boundary."""
 
@@ -628,6 +687,7 @@ def test_expected_opaque_boundary_table_is_exact_and_budgeted() -> None:
         "torch_func:__bool__:logged",
         "torch_func:__float__:logged",
         "torch_func:__int__:logged",
+        "autograd:grad",
     }
     scalar_rows = [row for row in AUDITED_COMPLETENESS_BOUNDARIES if row.operator is not None]
     assert {row.wrapper_name for row in scalar_rows} == {
@@ -638,6 +698,66 @@ def test_expected_opaque_boundary_table_is_exact_and_budgeted() -> None:
     }
     assert {row.operator for row in scalar_rows} == {"aten._local_scalar_dense.default"}
     assert all(row.reason for row in AUDITED_COMPLETENESS_BOUNDARIES)
+
+
+@pytest.mark.smoke
+def test_dynamic_parameter_initializers_are_captured_without_hiding_state_mutations() -> None:
+    """Capture temporary Parameter initialization while registered-state writes fail closed."""
+
+    wrap_torch(patch_policy="scoped", completeness_witness=True)
+    temporary_trace = tl.trace(_DynamicParameterInitializationModel(), torch.randn(2, 4))
+
+    initializer_rows = [
+        row
+        for row in temporary_trace.completeness_decompositions
+        if row["owner_func_name"] == "uniform_"
+    ]
+    assert len(initializer_rows) == 2
+    assert all(row["capture_accounted"] is True for row in initializer_rows)
+    assert temporary_trace.completeness_diagnostics == []
+    assert temporary_trace.capture_verified is True
+
+    with pytest.warns(TorchLensCaptureGapWarning, match="aten.uniform_"):
+        state_trace = tl.trace(_RegisteredParameterMutationModel(), torch.randn(2, 4))
+
+    assert state_trace.capture_verified is False
+    assert [
+        (row["operator"], row["reason"], row["mutates"])
+        for row in state_trace.completeness_diagnostics
+    ] == [("aten.uniform_.default", "owner_not_captured", True)]
+
+
+@pytest.mark.smoke
+def test_mid_forward_autograd_grad_is_an_exact_backward_boundary() -> None:
+    """Exclude only engine dispatches represented by the captured backward pass."""
+
+    wrap_torch(patch_policy="scoped", completeness_witness=True)
+    with pytest.warns(UserWarning, match="no graph/source provenance"):
+        trace = tl.trace(_MidForwardAutogradGradModel(), torch.randn(2, 4))
+
+    boundary_rows = [
+        row for row in trace.completeness_decompositions if row["owner_wrapper"] == "autograd:grad"
+    ]
+    assert len(boundary_rows) == 1
+    assert boundary_rows[0]["scope"] == "expected_opaque"
+    assert boundary_rows[0]["aten_ops"]
+    assert trace.num_backward_passes == 1
+    assert trace.completeness_diagnostics == []
+    assert trace.capture_verified is True
+
+
+@pytest.mark.smoke
+def test_tensor_data_getter_dispatch_is_captured() -> None:
+    """Represent the C-level data getter's detach dispatch as an ordinary op."""
+
+    wrap_torch(patch_policy="scoped", completeness_witness=True)
+    trace = tl.trace(_DataPropertyModel(), torch.randn(4))
+
+    detach_ops = [op for op in trace.ops if op.func_name == "detach"]
+    assert len(detach_ops) == 1
+    assert detach_ops[0].parents == ["input_1"]
+    assert trace.completeness_diagnostics == []
+    assert trace.capture_verified is True
 
 
 def test_is_mutating_operator_reads_schema_not_name() -> None:

--- a/tests/test_device_context_logging.py
+++ b/tests/test_device_context_logging.py
@@ -79,6 +79,14 @@ def _layer_by_func(log, func_substring: str):
     return log[labels[0]]
 
 
+def _output_parent(log: tl.Trace, output_index: int) -> tl.Op:
+    """Return the sole captured parent of one model-output node."""
+
+    output_op = log.output_ops[output_index]
+    assert len(output_op.parents) == 1
+    return log.ops[output_op.parents[0]]
+
+
 def _warm_torchlens_wrapping() -> None:
     """Establish local wrapper state before exercising meta factory injection."""
     tl.trace(_CpuFactoryModel(), torch.randn(2, 4))
@@ -138,14 +146,13 @@ def test_meta_factory_output_metadata_with_selective_save() -> None:
     log = tl.trace(model, torch.randn(2, 4), save=tl.func("mul"))
 
     assert model.seen_devices == ["meta"]
-    zeros_layer = _layer_by_func(log, "zeros")
-    assert zeros_layer.func_name == "zeros"
+    factory_layer = _output_parent(log, 1)
     # Shape/dtype come from the post-injection meta tensor: torch.zeros(3, 4)
     # under the meta context (a CPU tensor would have identical shape only if
     # injection worked — device parity is asserted via seen_devices above).
-    assert zeros_layer.shape == (3, 4)
-    assert zeros_layer.dtype == torch.float32
-    assert not zeros_layer.has_saved_activation
+    assert factory_layer.shape == (3, 4)
+    assert factory_layer.dtype == torch.float32
+    assert not factory_layer.has_saved_activation
 
 
 def test_meta_factory_as_model_output_full_save() -> None:
@@ -159,10 +166,10 @@ def test_meta_factory_as_model_output_full_save() -> None:
     log = tl.trace(model, torch.randn(2, 4))
 
     assert model.seen_devices == ["meta"]
-    zeros_layer = _layer_by_func(log, "zeros")
+    factory_layer = _output_parent(log, 1)
     # Captured metadata records the post-injection device.
-    assert zeros_layer.out.device.type == "meta"
-    assert zeros_layer.shape == (3, 4)
+    assert factory_layer.out.device.type == "meta"
+    assert factory_layer.shape == (3, 4)
 
 
 @pytest.mark.smoke
@@ -174,9 +181,9 @@ def test_cpu_default_unaffected_under_active_logging() -> None:
     log = tl.trace(model, x)
 
     assert model.seen_devices == ["cpu"]
-    zeros_layer = _layer_by_func(log, "zeros")
-    assert zeros_layer.out.device.type == "cpu"
-    assert torch.equal(zeros_layer.out, torch.zeros(3, 4))
+    factory_layer = _output_parent(log, 1)
+    assert factory_layer.out.device.type == "cpu"
+    assert torch.equal(factory_layer.out, torch.zeros(3, 4))
 
 
 def test_meta_device_context_fast_path_with_torch_wrapped() -> None:

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -72,8 +72,8 @@ assert collisions == {
     "data_classes": [], "debug": [], "examples": [],
     "experimental": ["dagua", "node_styles"], "export": [],
     "fastlog": ["dry_run", "recover"], "intervention": ["replay", "rerun", "sites"],
-    "hash": [], "io": [], "partial": [], "report": [], "repgeom": [], "stats": [],
-    "user_funcs": [], "validation": [], "viz": [],
+    "hash": [], "io": [], "partial": [], "report": [], "repgeom": [],
+    "receptive_field": ["rules"], "stats": [], "user_funcs": [], "validation": [], "viz": [],
 }
 
 """

--- a/tests/test_intervention_phase10.py
+++ b/tests/test_intervention_phase10.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from pathlib import Path
@@ -35,6 +36,8 @@ from torchlens.intervention.types import (
     InterventionSpec,
 )
 from torchlens.validation import check_spec_compat
+
+_INTERVENTION_RESOLVER = importlib.import_module("torchlens.intervention.resolver")
 
 
 class _ReluModel(nn.Module):
@@ -663,7 +666,7 @@ def test_custom_function_key_is_refused_without_import(monkeypatch: pytest.Monke
 
         raise AssertionError(f"unexpected import of {module_name}")
 
-    monkeypatch.setattr("torchlens.intervention.resolver.importlib.import_module", fail_import)
+    monkeypatch.setattr(_INTERVENTION_RESOLVER.importlib, "import_module", fail_import)
 
     with pytest.raises(UntrustedCallableError, match="arbitrary code"):
         resolve_function_registry_key(key)
@@ -709,7 +712,7 @@ def test_loaded_spec_tolerates_custom_key_without_import(
         raise AssertionError(f"unexpected import of {module_name}")
 
     with monkeypatch.context() as import_patch:
-        import_patch.setattr("torchlens.intervention.resolver.importlib.import_module", fail_import)
+        import_patch.setattr(_INTERVENTION_RESOLVER.importlib, "import_module", fail_import)
         assert load_intervention_spec(path)
 
     assert load_intervention_spec(path, allowed_custom_callable_modules={"operator"})
@@ -996,7 +999,7 @@ def test_r2_load_tolerates_torchlens_prefixed_foreign_key_no_foreign_import(
         )
         return real_import_module(module_name)
 
-    monkeypatch.setattr("torchlens.intervention.resolver.importlib.import_module", guarded_import)
+    monkeypatch.setattr(_INTERVENTION_RESOLVER.importlib, "import_module", guarded_import)
     assert load_intervention_spec(path)
     assert calls == []
 

--- a/tests/test_metadata_invariant_dispatch.py
+++ b/tests/test_metadata_invariant_dispatch.py
@@ -11,15 +11,17 @@ from torchlens.validation import invariants
 
 
 # The pre-refactor sequences below are the dispatch-parity baseline. cert10
-# ADDED two checks (pass_count_consistency for torch and
-# backend_neutral_graph_topology for non-torch) without dropping or reordering
-# any pre-refactor check; the expected sequences include those additions.
+# ADDED three checks (receptive_field_metadata for every backend,
+# pass_count_consistency for torch, and backend_neutral_graph_topology for
+# non-torch) without dropping or reordering any pre-refactor check; the expected
+# sequences include those additions.
 PRE_REFACTOR_TORCH_SEQUENCE = (
     "backend_identity_invariants",
     "trace_self_consistency",
     "region_replay_provenance",
     "backward_graph_invariants",
     "backend_neutral_accessor_refs",
+    "receptive_field_metadata",
     "special_layer_lists",
     "graph_topology",
     "edge_use_parent_arg_consistency",
@@ -50,6 +52,7 @@ PRE_REFACTOR_NON_TORCH_SEQUENCE = (
     "region_replay_provenance",
     "non_torch_backward_inert",
     "backend_neutral_accessor_refs",
+    "receptive_field_metadata",
     "backend_neutral_module_mode_invariants",
     "backend_neutral_graph_topology",
     "graph_ordering",

--- a/tests/test_misc_capture.py
+++ b/tests/test_misc_capture.py
@@ -8,12 +8,13 @@ from pathlib import Path
 import torch
 
 import torchlens as tl
+import torchlens.utils as utils
 
 
 def test_register_op_rule_affects_flops() -> None:
     """Custom op rules are accepted by the utility registry."""
 
-    tl.utils.register_op_rule("custom_test_op", lambda *_args: 123, None)
+    utils.register_op_rule("custom_test_op", lambda *_args: 123, None)
     from torchlens.capture.flops import compute_forward_flops
 
     assert compute_forward_flops("custom_test_op", (1,), [], (), {}) == 123

--- a/tests/test_multi_pass.py
+++ b/tests/test_multi_pass.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import torch
 
 import torchlens as tl
+import torchlens.utils as utils
 
 
 def test_trace_streaming_on_iterable_inputs() -> None:
     """Capture iterable inputs into one stacked root log."""
 
     model = torch.nn.Linear(2, 2)
-    traces = tl.utils.trace_streaming(
+    traces = utils.trace_streaming(
         model,
         [torch.ones(1, 2), torch.zeros(1, 2)],
         layers_to_save="none",

--- a/tests/test_rf_remediation_rules.py
+++ b/tests/test_rf_remediation_rules.py
@@ -13,6 +13,7 @@ from torch import nn
 import torchlens as tl
 from torchlens.capture.arg_positions import _normalize_func_name
 from torchlens.receptive_field import _rules
+from torchlens.receptive_field._engine_forward import solve_projective
 from torchlens.receptive_field._rules import ReceptiveFieldRuleContext, _RuleResult
 from torchlens.receptive_field._types import (
     ReceptiveFieldStatus,
@@ -407,6 +408,52 @@ def test_middle_axis_reduction_uses_surviving_axis_map() -> None:
     assert tuple(axis.output_axis for axis in descriptor.axes) == (0, 1, None, 2)
     result = reduction.receptive_field.check((0, 3, 2))  # type: ignore[union-attr]
     assert result.status is ReceptiveFieldValidationStatus.PASS
+
+
+def test_positional_reduction_dimension_uses_surviving_axis_map() -> None:
+    """Read positional reduction dimensions when builtin signatures omit ``dim``."""
+
+    class PositionalReduction(nn.Module):
+        """Reduction passing the dimension as an unnamed positional argument."""
+
+        def forward(self, value: torch.Tensor) -> torch.Tensor:
+            """Sum over the trailing axis."""
+
+            return value.sum(-1)
+
+    trace = _trace(
+        PositionalReduction(),
+        torch.ones(2, 3, 4, requires_grad=True),
+    )
+    reduction = _op(trace, "sum")
+    descriptor = reduction.receptive_field._descriptor()  # type: ignore[union-attr]
+
+    assert descriptor.axes is not None
+    assert tuple(axis.output_axis for axis in descriptor.axes) == (0, 1, None)
+
+
+def test_rank_changing_full_rule_does_not_require_passthrough_map() -> None:
+    """Globalize every contracted axis without inventing a rank-change map."""
+
+    class RankChangingEinsum(nn.Module):
+        """Einsum reducing two matrix axes into one batch axis."""
+
+        def forward(self, value: torch.Tensor) -> torch.Tensor:
+            """Take a batched matrix trace."""
+
+            return torch.einsum("bii->b", value)
+
+    trace = _trace(
+        RankChangingEinsum(),
+        torch.ones(2, 3, 3, requires_grad=True),
+    )
+    einsum = _op(trace, "einsum")
+    descriptor = einsum.receptive_field._descriptor()  # type: ignore[union-attr]
+
+    assert descriptor.axes is not None
+    assert all(axis.kind == "full" for axis in descriptor.axes)
+    projective = solve_projective(trace, trace.output_ops)  # type: ignore[union-attr]
+    assert all(state.axes is not None for state in projective.states.values())
 
 
 class _PointwiseChain(nn.Module):

--- a/tests/test_rf_remediation_rules.py
+++ b/tests/test_rf_remediation_rules.py
@@ -295,6 +295,40 @@ def test_spatial_cat_projective_offsets_route_into_target_segments() -> None:
     assert result.status is ReceptiveFieldValidationStatus.PASS
 
 
+class _EmptyTensorConcatenation(nn.Module):
+    """Prepend PyTorch's rank-one empty-tensor concatenation sentinel."""
+
+    def __init__(self) -> None:
+        """Create a windowed branch whose output is concatenated."""
+
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, 3, padding=1, bias=False)
+        _fill_convolutions(self)
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Concatenate a rank-one empty tensor without changing the input extent."""
+
+        value = self.conv(value)
+        empty = torch.empty((0,), dtype=value.dtype, device=value.device)
+        return torch.cat((empty, value), dim=2)
+
+
+def test_cat_rank_one_empty_tensor_contributes_zero_extent() -> None:
+    """Treat PyTorch's rank-one empty concat sentinel as a zero-width segment."""
+
+    trace = _trace(
+        _EmptyTensorConcatenation(),
+        torch.ones(1, 1, 8, 8, requires_grad=True),
+    )
+    target = _op(trace, "cat")
+    box = target.receptive_field.at((4, 4))  # type: ignore[union-attr]
+
+    assert tuple(target.shape) == (1, 1, 8, 8)  # type: ignore[union-attr]
+    assert (box.axes[2].clipped_start, box.axes[2].clipped_stop) == (3, 6)
+    result = target.receptive_field.check((0, 0, 4, 4))  # type: ignore[union-attr]
+    assert result.status is ReceptiveFieldValidationStatus.PASS
+
+
 class _StructuralChain(nn.Module):
     """Convolution followed by exact permutation and singleton reshape operations."""
 

--- a/tests/test_rf_rules.py
+++ b/tests/test_rf_rules.py
@@ -130,6 +130,22 @@ def test_training_batch_norm_projective_maps_channel_vector_parents() -> None:
         assert descriptor.layout.axis_kinds == ("full", "pointwise", "full", "full")
 
 
+def test_training_instance_norm_projective_maps_running_stat_parents() -> None:
+    """Map InstanceNorm running-stat vectors onto the channel axis."""
+
+    trace = tl.trace(
+        nn.InstanceNorm1d(3, track_running_stats=True).train(),
+        torch.randn(2, 3, 4),
+    )
+    instance_norm = _op(trace, "instance_norm")
+    solution = solve_projective(trace, trace.output_ops)
+
+    for parent_reference in instance_norm.parents:
+        parent = trace.layer_dict_all_keys[parent_reference]
+        state = solution.states[(parent.label, trace.output_ops[0].io_role)]
+        assert state.axes is not None
+
+
 def test_group_and_current_stat_instance_norm_globalize_normalized_axes() -> None:
     """Keep InstanceNorm exact while bounding GroupNorm to its group envelope."""
 

--- a/tests/test_tinygrad_backend_capture.py
+++ b/tests/test_tinygrad_backend_capture.py
@@ -837,6 +837,7 @@ def test_tinygrad_public_surface_matrix(tmp_path: Path) -> None:
     assert loaded.backend == "tinygrad"
     assert loaded.param_source == "none"
     assert all(op.out is None for op in loaded.layer_list)
+    assert loaded.derived_grads["inputs.0"].grad is None
 
     portable_path = tmp_path / "tinygrad_portable.tlspec"
     source_out = trace[trace.output_layers[0]].out
@@ -850,6 +851,10 @@ def test_tinygrad_public_surface_matrix(tmp_path: Path) -> None:
     assert loaded_out.shape == expected.shape
     assert str(loaded_out.dtype) == str(source_out.dtype)
     np.testing.assert_allclose(loaded_out.numpy(), expected)
+    np.testing.assert_allclose(
+        loaded_portable.derived_grads["inputs.0"].grad.numpy(),
+        trace.derived_grads["inputs.0"].grad.numpy(),
+    )
 
     loaded_status = loaded_portable.validate_forward_pass(
         [_tiny_square_loss(Tensor([1.0, -2.0, 3.0]))]

--- a/tests/test_tlspec_runnable_escape_matrix.py
+++ b/tests/test_tlspec_runnable_escape_matrix.py
@@ -907,7 +907,11 @@ def test_r14_c3_storage_rebind_op_is_refused_at_save(
     name: str, factory: Callable[[], nn.Module], tmp_path: Path
 ) -> None:
     """set_/resize_ fail closed at SAVE with a typed diagnostic (no run-time crash)."""
-    trace = tl.trace(factory(), _R14_X.clone(), capture=_CAPTURE)
+    if name == "set_":
+        with pytest.warns(UserWarning, match="no graph/source provenance"):
+            trace = tl.trace(factory(), _R14_X.clone(), capture=_CAPTURE)
+    else:
+        trace = tl.trace(factory(), _R14_X.clone(), capture=_CAPTURE)
     with pytest.raises(RunnablePreflightError) as excinfo:
         trace.save(tmp_path / "storage_rebind.tlspec", level="runnable")
     diagnostics = excinfo.value.fields["diagnostics"]

--- a/tests/test_tlspec_runnable_r39_witness_exec.py
+++ b/tests/test_tlspec_runnable_r39_witness_exec.py
@@ -41,6 +41,7 @@ from torchlens.runnable import (
     ReadinessStatus,
     RunnableErrorCode,
 )
+from torchlens.utils import rng as rng_utils
 
 _CAP = dict(intervention_ready=True, capture_container_structure=True, cache=False)
 
@@ -82,6 +83,95 @@ def _roundtrip(
 
 _GLOBAL_GEN = np.random.default_rng(12345)
 _GLOBAL_RANDOMSTATE = np.random.RandomState(999)
+
+
+def _draw_fast_local_generator(
+    rng: np.random.Generator = np.random.default_rng(),
+) -> float:
+    """Draw through a pre-constructed Generator held only by a fast-local default."""
+
+    return float(rng.standard_normal())
+
+
+def _draw_fast_local_randomstate(
+    rng: np.random.RandomState = np.random.RandomState(),
+) -> float:
+    """Draw through a pre-constructed RandomState held only by a fast-local default."""
+
+    return float(rng.standard_normal())
+
+
+_NUMPY2_INDIRECT_RNG_REGISTRY: dict[str, Any] = {
+    "generator": np.random.default_rng(),
+    "randomstate": np.random.RandomState(),
+}
+
+
+class _PlainNumpyRngHolder:
+    """Plain non-module object holding pre-constructed NumPy RNG instances."""
+
+    def __init__(self) -> None:
+        """Construct both private NumPy RNG families before any capture begins."""
+
+        self.generator = np.random.default_rng()
+        self.randomstate = np.random.RandomState()
+
+
+_NUMPY2_INDIRECT_RNG_HOLDER = _PlainNumpyRngHolder()
+
+
+class _FastLocalNumpyRngBranch(nn.Module):
+    """Branch on a pre-constructed NumPy RNG reachable only as a helper fast local."""
+
+    def __init__(self, rng_kind: str) -> None:
+        """Store the requested RNG family without retaining the RNG itself."""
+
+        super().__init__()
+        self.rng_kind = rng_kind
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Draw through a helper argument materialized as a frame fast local."""
+
+        if self.rng_kind == "generator":
+            value = _draw_fast_local_generator()
+        else:
+            value = _draw_fast_local_randomstate()
+        return x * 2.0 if value < 0.0 else x * 3.0
+
+
+class _GlobalContainerNumpyRngBranch(nn.Module):
+    """Branch on a pre-constructed NumPy RNG nested in a referenced global dict."""
+
+    def __init__(self, rng_kind: str) -> None:
+        """Store the requested RNG family without retaining the RNG itself."""
+
+        super().__init__()
+        self.rng_kind = rng_kind
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Draw through a concrete RNG stored one level below a global container."""
+
+        value = float(_NUMPY2_INDIRECT_RNG_REGISTRY[self.rng_kind].standard_normal())
+        return x * 2.0 if value < 0.0 else x * 3.0
+
+
+class _GlobalObjectNumpyRngBranch(nn.Module):
+    """Branch on a pre-constructed NumPy RNG held by a plain global object."""
+
+    def __init__(self, rng_kind: str) -> None:
+        """Store the requested RNG family without retaining the RNG itself."""
+
+        super().__init__()
+        self.rng_kind = rng_kind
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Draw through a concrete RNG stored in a global object's instance dict."""
+
+        if self.rng_kind == "generator":
+            value = float(_NUMPY2_INDIRECT_RNG_HOLDER.generator.standard_normal())
+        else:
+            value = float(_NUMPY2_INDIRECT_RNG_HOLDER.randomstate.standard_normal())
+        return x * 2.0 if value < 0.0 else x * 3.0
 
 
 class _ThreadedNpGenBranch(nn.Module):
@@ -258,6 +348,69 @@ def test_deterministic_model_stays_verified(tmp_path: Path) -> None:
     assert _host_rng_consumed(_DeterministicLinear(), x) is False
     result = _roundtrip(_DeterministicLinear(), x, tmp=tmp_path, run_seed=1)
     assert result.report.path_faithfulness is PathFaithfulness.VERIFIED
+
+
+@pytest.mark.skipif(
+    not rng_utils._NUMPY_RNG_METHODS_NEED_FRAME_DIGEST,
+    reason="NumPy build emits c_call for RNG draw methods",
+)
+@pytest.mark.parametrize(
+    ("model_type", "reachability"),
+    [
+        (_FastLocalNumpyRngBranch, "fast-local"),
+        (_GlobalContainerNumpyRngBranch, "global-container"),
+        (_GlobalObjectNumpyRngBranch, "global-object"),
+    ],
+    ids=["fast-local", "global-container", "global-object"],
+)
+@pytest.mark.parametrize("rng_kind", ["generator", "randomstate"])
+def test_numpy2_indirect_preconstructed_rng_never_false_verified(
+    model_type: Any,
+    reachability: str,
+    rng_kind: str,
+    tmp_path: Path,
+) -> None:
+    """Every NumPy-2 indirect pre-constructed RNG draw fails closed to UNVERIFIABLE."""
+
+    x = torch.randn(2, 4)
+    model = model_type(rng_kind)
+    assert _host_rng_consumed(model, x) is True, (reachability, rng_kind)
+    result = _roundtrip(model_type(rng_kind), x, tmp=tmp_path, capture_seed=1, run_seed=2)
+    assert result.report.path_faithfulness is PathFaithfulness.UNVERIFIABLE
+    assert result.report.numeric_attestation is NumericAttestationStatus.NOT_APPLICABLE
+
+
+@pytest.mark.skipif(
+    not rng_utils._NUMPY_RNG_METHODS_NEED_FRAME_DIGEST,
+    reason="NumPy build emits c_call for RNG draw methods",
+)
+def test_numpy2_frame_digest_deterministic_control_stays_verified(tmp_path: Path) -> None:
+    """The NumPy-2 frame-digest fallback does not ceiling a deterministic capture."""
+
+    x = torch.randn(2, 4)
+    assert _host_rng_consumed(_DeterministicLinear(), x) is False
+    result = _roundtrip(_DeterministicLinear(), x, tmp=tmp_path, run_seed=1)
+    assert result.report.path_faithfulness is PathFaithfulness.VERIFIED
+
+
+def test_numpy2_frame_digest_holder_walk_executes_no_hostile_attribute_hooks() -> None:
+    """The one-level holder walk never executes hostile attribute hooks."""
+
+    fired: list[str] = []
+
+    class _Hostile:
+        @property
+        def __dict__(self) -> dict[str, Any]:
+            fired.append("property")
+            return {}
+
+        def __getattr__(self, name: str) -> Any:
+            fired.append(f"__getattr__:{name}")
+            raise AttributeError(name)
+
+    children = rng_utils.host_nondeterminism_monitor._numpy_frame_candidate_children(_Hostile())
+    assert children == ()
+    assert fired == []
 
 
 def test_seeded_numpy_singleton_stays_verified(tmp_path: Path) -> None:

--- a/tests/test_tlspec_runnable_r41_crossthread_witness.py
+++ b/tests/test_tlspec_runnable_r41_crossthread_witness.py
@@ -843,6 +843,7 @@ def _escape_witnessed(trace: Any) -> bool:
     )
 
 
+@pytest.mark.filterwarnings("ignore:TypedStorage is deprecated.*:UserWarning")
 @pytest.mark.parametrize("member", _ESCAPE_MEMBERS)
 def test_in_window_thread_escape_witnessed(member: str) -> None:
     """Every declared escape vocabulary member on a CAPTURED tensor ceilings from a non-owner thread.

--- a/tests/test_tlspec_runnable_r75_data_alias_layout.py
+++ b/tests/test_tlspec_runnable_r75_data_alias_layout.py
@@ -1,13 +1,12 @@
-"""Unlabeled-receiver / ``.data``-alias intermediate-layout fail-open closure (r75 F1).
+"""``.data``-alias intermediate-layout fail-open closure (r75 F1).
 
 Round-74 (hon1 + free-roam, cross-lab) confirmed the r73 intermediate-layout net FAIL-OPENED
-on unlabeled receivers: ``.data`` is the label-AND-``_base``-destroying alias spelling (not in
-``ORIG_TORCH_FUNCS``, ``_base is None``), so ``(x * 2).data.is_contiguous(channels_last)``
-recorded NOTHING and a channels_last twin replayed the captured arm as a false VERIFIED --
-the exact r72 class, one ``.data`` away from the r73 fixed spelling. Worse, ``.data`` LAUNDERS
-ANCESTRY transitively: any logged op consuming the alias starts an ancestry-orphaned chain
-(``(y.data * 1.0)``, ``(x * 2).data[0]``) whose empty ``input_ancestors`` was absorbed by the
-"empty == state-rooted, record nothing" branch.
+on unlabeled receivers: the C-level ``.data`` getter destroyed labels and ``_base``, so
+``(x * 2).data.is_contiguous(channels_last)`` recorded nothing and a channels-last twin
+replayed the captured arm as a false VERIFIED. The r75 origin/storage ladder below remains
+the defense-in-depth attribution path. TorchLens now additionally captures the getter's real
+``aten.detach`` dispatch as the canonical replayable ``Tensor.detach`` op, preserving direct
+graph ancestry for ordinary captures without admitting the unsafe descriptor itself.
 
 The r75 closure makes the layout-trio fall-through FAIL-CLOSED BY CONSTRUCTION -- no rung
 records nothing silently -- with graduated precision:
@@ -39,7 +38,6 @@ import torch
 from torch import nn
 
 import torchlens as tl
-from torchlens.errors import RunnablePreflightError
 from torchlens.options import CaptureOptions
 from torchlens.runnable import NumericAttestationStatus, PathFaithfulness
 
@@ -318,19 +316,20 @@ def test_r75_unresolvable_receiver_fails_closed(tmp_path: Path) -> None:
 
 
 @pytest.mark.smoke
-def test_r75_direct_alias_consumption_still_refuses_at_save(tmp_path: Path) -> None:
-    """Save-door posture pin: a logged op directly consuming ``.data`` refuses typed.
+def test_r75_direct_alias_consumption_is_replayable(tmp_path: Path) -> None:
+    """A logged op directly consuming ``.data`` retains complete replay provenance.
 
-    ``torch.cat([y, y.data])`` carries an unattributable tensor literal the sparse recipe
-    cannot rebuild; capture warns about the provenance-less arg and the producer preflight
-    refuses (pre-existing behavior, re-pinned here so the class stays closed at the save
-    door too, never a silent narrowing)."""
+    ``torch.cat([y, y.data])`` now receives both the original producer and the canonical
+    detach op as graph parents. The sparse recipe can therefore rebuild the call without
+    broadening callable trust to the unsafe ``data`` descriptor.
+    """
 
     x = _nchw()
-    with pytest.warns(UserWarning, match="no graph/source provenance"):
-        trace = _capture(MixedCatDirectConsumption().eval(), x)
-    with pytest.raises(RunnablePreflightError):
-        trace.save(tmp_path / "mixed.tlspec", level="runnable", include_weights=True)
+    path = _save(MixedCatDirectConsumption().eval(), x, tmp_path / "mixed.tlspec")
+
+    result = tl.load(path).run(inputs=x.clone())
+    assert result.report.path_faithfulness is PathFaithfulness.VERIFIED
+    assert not result.report.poisoned
 
 
 @pytest.mark.smoke

--- a/tests/test_torch_compat.py
+++ b/tests/test_torch_compat.py
@@ -332,6 +332,9 @@ def test_torch_capability_snapshot_contract() -> None:
         "HAS_FX_GRAPH_MODULE": True,
         "HAS_NAMED_TENSOR_API": tc.HAS_NAMED_TENSOR_API,
         "HAS_CACHED_UNTYPED_STORAGE_WRAPPER": tc.HAS_CACHED_UNTYPED_STORAGE_WRAPPER,
+        "HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE": (
+            tc.HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE
+        ),
         "HAS_DYNAMO_OPTIMIZED_MODULE": True,
         "HAS_GENERATOR_CLONE_STATE": hasattr(torch.Generator, "clone_state"),
         "HAS_GENERATOR_GRAPHSAFE_GET_STATE": hasattr(torch.Generator, "graphsafe_get_state"),

--- a/tests/test_toy_models.py
+++ b/tests/test_toy_models.py
@@ -1348,16 +1348,14 @@ def test_sequential_param_free_loops(default_input1):
 
 def test_propertymodel(input_complex):
     model = example_models.PropertyModel()
-    with pytest.warns(UserWarning, match="no graph/source provenance"):
-        assert validate_forward_pass(model, input_complex)
-    with pytest.warns(UserWarning, match="no graph/source provenance"):
-        show_model_graph(
-            model,
-            input_complex,
-            vis_save_only=True,
-            vis_mode="unrolled",
-            vis_outpath=opj(VIS_OUTPUT_DIR, "toy-networks", "propertymodel"),
-        )
+    assert validate_forward_pass(model, input_complex)
+    show_model_graph(
+        model,
+        input_complex,
+        vis_save_only=True,
+        vis_mode="unrolled",
+        vis_outpath=opj(VIS_OUTPUT_DIR, "toy-networks", "propertymodel"),
+    )
 
 
 def test_ubermodel1(input_2d):

--- a/tests/test_toy_models.py
+++ b/tests/test_toy_models.py
@@ -2633,6 +2633,7 @@ def test_selective_ssm():
     )
 
 
+@pytest.mark.slow
 def test_stacked_ssm():
     model = example_models.StackedSSM()
     x = torch.randint(0, 100, (2, 10))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -26,7 +26,11 @@ from torchlens.validation import (
     get_validation_diagnostics,
     validate_forward_pass,
 )
-from torchlens.errors import MetadataInvariantError, TraceNotReproducibleWarning
+from torchlens.errors import (
+    MetadataInvariantError,
+    TorchLensCaptureGapWarning,
+    TraceNotReproducibleWarning,
+)
 from torchlens.fastlog import RecordContext
 from torchlens.options import SaveOptions
 from torchlens.validation import check_metadata_invariants
@@ -66,6 +70,23 @@ from torchlens.utils.tensor_utils import tensor_nanequal
 
 _TEST_FORWARD_GLOBAL_TENSOR: torch.Tensor | None = None
 _TEST_FORWARD_GLOBAL_PAYLOAD: dict[str, torch.Tensor] | None = None
+
+
+def _assert_validation_capture_is_clean(model: nn.Module, x: torch.Tensor) -> None:
+    """Assert forward validation completes without a completeness-witness gap.
+
+    Parameters
+    ----------
+    model:
+        Module whose validation capture should be complete.
+    x:
+        Tensor passed as the module's sole positional input.
+    """
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert validate_forward_pass(model, [x], input_kwargs={})
+    assert not any(isinstance(item.message, TorchLensCaptureGapWarning) for item in caught)
 
 
 class _StaleLabelConstantModel(nn.Module):
@@ -6480,7 +6501,7 @@ def test_genuine_raw_hook_untraceable_replacement_validates_depth_zero() -> None
         check_metadata_invariants(log)
     finally:
         log.cleanup()
-    assert validate_forward_pass(model, [x], input_kwargs={})
+    _assert_validation_capture_is_clean(model, x)
 
 
 def test_plain_trace_noop_hook_untraceable_exit_is_internal_source_nested_depth() -> None:
@@ -6529,7 +6550,7 @@ def test_plain_trace_noop_hook_untraceable_exit_is_internal_source_nested_depth(
         check_metadata_invariants(log)
     finally:
         log.cleanup()
-    assert validate_forward_pass(model, [x], input_kwargs={})
+    _assert_validation_capture_is_clean(model, x)
 
 
 def test_plain_trace_noop_hook_untraceable_exit_is_internal_source() -> None:
@@ -6559,7 +6580,7 @@ def test_plain_trace_noop_hook_untraceable_exit_is_internal_source() -> None:
         check_metadata_invariants(log)
     finally:
         log.cleanup()
-    assert validate_forward_pass(model, [x], input_kwargs={})
+    _assert_validation_capture_is_clean(model, x)
 
 
 def test_func_call_id_exemption_is_scoped_to_genuine_replacement() -> None:

--- a/torchlens/_io/runnable.py
+++ b/torchlens/_io/runnable.py
@@ -569,11 +569,12 @@ def build_sparse_run_descriptor(trace: Any) -> SparseRunDescriptor:
         # a false VERIFIED with the mutation gone. An in-place op on a LABELLED alias is graph-
         # connected (replayed) and is never recorded, so a normal model stays VERIFIED.
         _gap(WitnessGapKind.PRUNED_ALIAS_MUTATION, "capture")
-    if saw_unmodelled_host_write:
-        # A surviving in-place op with a removed receiver came from a host alias such as
-        # ``buffer.data.add_(1.0)``. The sparse recipe can keep running by reconnecting the receiver
-        # to the cooked parent, but the original host write bypassed the ordinary labelled tensor
-        # path, so the descriptor cannot honestly prove full path fidelity.
+    if saw_unmodelled_host_write or _has_data_alias_mutation(trace):
+        # A surviving in-place op came from an unsafe host alias. This includes the historical
+        # removed-receiver shape (``buffer.data.add_(1.0)``) and the current canonical getter
+        # shape, where ``.data`` is represented as a detach op but its alias lineage is tracked
+        # separately. The sparse recipe may replay the graph, but a write through ``.data`` still
+        # bypasses the ordinary labelled-tensor contract, so full path fidelity is unprovable.
         _gap(WitnessGapKind.UNMODELLED_HOST_WRITE, "capture")
     ledger_facts = _runnable_ledger_facts_for_trace(trace)
     if ledger_facts:
@@ -2501,6 +2502,25 @@ def _has_pruned_alias_mutation(trace: Any) -> bool:
     from ..backends.torch.completeness_witness import pruned_alias_mutation_source_labels
 
     return bool(pruned_alias_mutation_source_labels(trace))
+
+
+def _has_data_alias_mutation(trace: Any) -> bool:
+    """Return whether capture observed a write through ``Tensor.data``.
+
+    Parameters
+    ----------
+    trace : Any
+        Capture trace being converted to a runnable descriptor.
+
+    Returns
+    -------
+    bool
+        ``True`` when the canonical getter's alias lineage was mutated.
+    """
+
+    from ..backends.torch.completeness_witness import data_alias_mutation_detected
+
+    return data_alias_mutation_detected(trace)
 
 
 def _has_forward_value_override_intervention(trace: Any) -> bool:

--- a/torchlens/_io/runnable_load.py
+++ b/torchlens/_io/runnable_load.py
@@ -1282,9 +1282,10 @@ def _normalized_callable_name(name: str | None) -> str | None:
     ``sites[].function_path`` (derived from ``layer_list[].func_name``) and
     ``run.callable_registry[].key.qualname`` are persisted independently and
     agree verbatim for every op measured across dunder, in-place, method and
-    function dispatch, with two exceptions where the site keeps the operator
+    function dispatch, with three exceptions where the site keeps the operator
     dunder while the registry records the torch method (``__neg__``/``neg``,
-    ``__pow__``/``pow``). Stripping the operator dunder underscores collapses
+    ``__pow__``/``pow``, and ``__ipow__``/``pow_``). Stripping ordinary operator
+    dunder underscores and mapping the one in-place power spelling collapses
     exactly those, and nothing else: ``__iadd__`` and ``relu_`` keep their
     distinguishing characters, so an in-place op can never normalize onto its
     out-of-place sibling.
@@ -1305,6 +1306,8 @@ def _normalized_callable_name(name: str | None) -> str | None:
     stripped = name.strip()
     if not stripped or stripped == "none":
         return None
+    if stripped == "__ipow__":
+        return "pow_"
     if stripped.startswith("__") and stripped.endswith("__") and len(stripped) > 4:
         return stripped[2:-2]
     return stripped
@@ -1332,9 +1335,9 @@ def _callable_registry_contradiction(
     signature-incompatible key never reaches here, keeping the resolver's own
     richer readiness/``ReattachError`` path. Compares against the persisted
     registry qualname (not the resolved one) so a version-alias move never
-    false-refuses, and normalizes the operator dunder so the two measured
-    record-spelling divergences (``__neg__``/``neg``, ``__pow__``/``pow``) are
-    not read as contradictions. A record that states no name (a source op's
+    false-refuses, and normalizes the operator dunder so the measured
+    record-spelling divergences (``__neg__``/``neg``, ``__pow__``/``pow``,
+    ``__ipow__``/``pow_``) are not read as contradictions. A record that states no name (a source op's
     ``"none"``, a missing label) is no opinion, never a contradiction.
 
     Parameters

--- a/torchlens/backends/torch/_tl.py
+++ b/torchlens/backends/torch/_tl.py
@@ -24,6 +24,8 @@ __all__ = [
     "get_tensor_meta",
     "set_tensor_label",
     "get_tensor_label",
+    "mark_tensor_data_alias",
+    "is_tensor_data_alias",
     "raw_tensor_label",
     "get_live_tensor_label",
     "get_live_label_list",
@@ -86,6 +88,11 @@ class TensorMeta(TorchLensMeta):
     # for the object's lifetime, which is what makes the ``data_ptr`` comparison a
     # true identity proof rather than a recyclable-pointer heuristic (r81 S2).
     label_storage: Optional[Any] = None
+    # Capture-local provenance for tensors returned by ``Tensor.data`` and
+    # storage-sharing aliases/views derived from them. The getter is represented
+    # as a canonical detach op, but a later write through this alias family must
+    # still ceiling runnable faithfulness.
+    data_alias: bool = False
 
 
 @dataclass
@@ -693,6 +700,38 @@ def get_tensor_label(t: Any) -> Optional[str]:
     return meta.label_raw
 
 
+def mark_tensor_data_alias(t: Any) -> None:
+    """Mark a tensor as originating from the unsafe ``Tensor.data`` surface.
+
+    Parameters
+    ----------
+    t : Any
+        Tensor-like object returned by ``Tensor.data`` or a storage-sharing
+        alias/view derived from it.
+    """
+
+    _ensure_tensor_meta(t).data_alias = True
+
+
+def is_tensor_data_alias(t: Any) -> bool:
+    """Return whether a tensor is a current-capture ``Tensor.data`` alias.
+
+    Parameters
+    ----------
+    t : Any
+        Tensor-like object to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` only when the object carries data-alias provenance and a
+        current-session capture label.
+    """
+
+    meta = get_tensor_meta(t)
+    return bool(meta is not None and meta.data_alias and get_tensor_label(t) is not None)
+
+
 def raw_tensor_label(t: Any) -> Optional[str]:
     """Return a tensor's raw capture label WITHOUT the session-anchor gate.
 
@@ -783,6 +822,7 @@ def clear_tensor_label(t: Any) -> None:
     meta = get_tensor_meta(t)
     if meta is not None:
         meta.label_raw = None
+        meta.data_alias = False
 
 
 def promote_label_to_buffer_source_and_clear_label(t: Any) -> None:
@@ -797,6 +837,7 @@ def promote_label_to_buffer_source_and_clear_label(t: Any) -> None:
     if meta is not None and meta.label_raw is not None:
         meta.buffer_source = meta.label_raw
         meta.label_raw = None
+        meta.data_alias = False
 
 
 def set_buffer_address(t: Any, address: str) -> None:

--- a/torchlens/backends/torch/backward.py
+++ b/torchlens/backends/torch/backward.py
@@ -2618,8 +2618,15 @@ def install_autograd_wrappers() -> None:
 
         def run() -> Any:
             """Invoke the original autograd grad function."""
-            if _state._escape_detector_mode == "shadow":
-                with expected_original_call(original, "autograd:grad"):
+            if (
+                _state._escape_detector_mode == "shadow"
+                or _state._completeness_witness_mode == "shadow"
+            ):
+                with expected_original_call(
+                    original,
+                    "autograd:grad",
+                    census_scope="expected_opaque",
+                ):
                     return original(*args, **kwargs)
             return original(*args, **kwargs)
 

--- a/torchlens/backends/torch/completeness_witness.py
+++ b/torchlens/backends/torch/completeness_witness.py
@@ -3819,6 +3819,35 @@ def _dispatch_result_holds_tensor(result: Any) -> bool:
     return False
 
 
+def _event_is_capture_accounted(event: _DispatchEvent) -> bool:
+    """Return whether the event is represented by its owner's captured artifact.
+
+    Ordinary wrapped operations account for their complete aten decomposition. A token
+    credited by synthesized boundary Ops is narrower: it accounts for the non-mutating
+    opaque output construction represented by those exact boundary tensors and raw labels,
+    but never for a mutating dispatch. Mutations always remain visible because a
+    functionless boundary cannot attest their side effects on existing graph values.
+
+    Parameters
+    ----------
+    event:
+        Dispatcher event being finalized.
+
+    Returns
+    -------
+    bool
+        Whether this exact event has a captured representation.
+    """
+
+    owner = event.owner
+    if owner is None or owner.capture_accounted is not True:
+        return False
+    boundary_outputs = owner.capture_accounted_outputs
+    if not boundary_outputs:
+        return True
+    return not event.mutates
+
+
 _RUNNABLE_LEDGER_FACTS: "weakref.WeakKeyDictionary[Any, list[dict[str, Any]]]" = (
     weakref.WeakKeyDictionary()
 )
@@ -3926,7 +3955,7 @@ def _finalize_runnable_ledger(state: _WitnessState) -> None:
     facts: list[dict[str, Any]] = []
     for event in state.events:
         owner = event.owner
-        owner_accounted = owner is not None and owner.capture_accounted is True
+        owner_accounted = _event_is_capture_accounted(event)
         audited_opaque = owner is not None and _is_expected_opaque_dispatch(event.operator, owner)
         # ``_operator_name`` yields overload-qualified names (``aten.equal.default``);
         # the allowlists hold overload-stripped base names.
@@ -5532,7 +5561,7 @@ def _finalize_census(state: _WitnessState) -> None:
         if owner is not None and _is_expected_opaque_dispatch(event.operator, owner):
             expected_opaque_count += 1
             continue
-        if owner is not None and owner.capture_accounted is True:
+        if _event_is_capture_accounted(event):
             accounted_count += 1
             continue
         reason = "unowned_dispatch" if owner is None else "owner_not_captured"
@@ -5584,6 +5613,9 @@ def _finalize_census(state: _WitnessState) -> None:
                 "owner_func_call_id": owner.func_call_id,
                 "owner_barcode": _barcode_text(owner.call_barcode),
                 "capture_accounted": owner.capture_accounted,
+                "capture_accounted_boundary_labels": tuple(
+                    raw_label for _, raw_label in owner.capture_accounted_outputs.values()
+                ),
                 "scope": owner_scope,
                 "aten_ops": tuple(operators),
                 "in_replacement_hook": owner_in_replacement_hook.get(id(owner), False),

--- a/torchlens/backends/torch/completeness_witness.py
+++ b/torchlens/backends/torch/completeness_witness.py
@@ -73,7 +73,7 @@ from .escape_detection import ExpectedOriginalToken, _active_token
 CompletenessWitnessMode = Literal["off", "shadow"]
 """Supported dispatcher-witness rollout modes."""
 
-MAX_AUDITED_COMPLETENESS_BOUNDARIES = 8
+MAX_AUDITED_COMPLETENESS_BOUNDARIES = 9
 """Hard budget preventing expected-opaque wrapper scopes from growing unchecked."""
 
 
@@ -126,6 +126,14 @@ AUDITED_COMPLETENESS_BOUNDARIES: tuple[AuditedCompletenessBoundary, ...] = (
         wrapper_name="torch_func:__int__:logged",
         operator="aten._local_scalar_dense.default",
         reason="int(tensor) extracts a Python int, which is intentionally not an op output",
+    ),
+    AuditedCompletenessBoundary(
+        wrapper_name="autograd:grad",
+        operator=None,
+        reason=(
+            "torch.autograd.grad executes a separately captured backward pass; its engine "
+            "dispatches are not forward operations"
+        ),
     ),
 )
 """Reviewable exact expected-opaque rows; additions require a regression test and reason."""

--- a/torchlens/backends/torch/completeness_witness.py
+++ b/torchlens/backends/torch/completeness_witness.py
@@ -2125,6 +2125,46 @@ def record_pruned_alias_mutation_source(trace: Any, label: str) -> None:
     labels.add(label)
 
 
+_DATA_ALIAS_MUTATION_TRACES: "weakref.WeakSet[Any]" = weakref.WeakSet()
+"""Traces containing a successful write through a ``Tensor.data`` alias lineage.
+
+The ``Tensor.data`` getter is captured as a canonical detach op so read-only consumers retain
+replay provenance. That graph node must not launder the descriptor's unsafe write semantics:
+an in-place receiver reached directly from ``.data`` or through a storage-sharing view remains
+an untracked escape surface and ceilings runnable faithfulness to ``unverifiable``.
+"""
+
+
+def data_alias_mutation_detected(trace: Any) -> bool:
+    """Return whether capture observed a write through a ``Tensor.data`` alias.
+
+    Parameters
+    ----------
+    trace : Any
+        Capture trace to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` when a successful receiver mutation targeted a data-alias
+        tensor or storage-sharing view derived from one.
+    """
+
+    return trace in _DATA_ALIAS_MUTATION_TRACES
+
+
+def record_data_alias_mutation(trace: Any) -> None:
+    """Record a successful write through a ``Tensor.data`` alias.
+
+    Parameters
+    ----------
+    trace : Any
+        Active capture trace whose runnable proof must be ceilinged.
+    """
+
+    _DATA_ALIAS_MUTATION_TRACES.add(trace)
+
+
 _HOST_ESCAPE_MUTABLE_WRITEBACK: "weakref.WeakSet[Any]" = weakref.WeakSet()
 """Traces where a host WRITE-BACK through a mutable zero-copy alias was detected.
 

--- a/torchlens/backends/torch/completeness_witness.py
+++ b/torchlens/backends/torch/completeness_witness.py
@@ -61,7 +61,12 @@ from ...utils._torch_symbols import torch_attr
 from ...utils._callable_safety import private_c_forward_op_module_names
 from ... import _state
 from ..._errors import TorchLensCaptureGapWarning
-from ._tl import get_buffer_address, get_tensor_label, get_tensor_meta
+from ._tl import (
+    get_buffer_address,
+    get_tensor_label,
+    get_tensor_meta,
+    session_meta_is_anchored,
+)
 from .buffer_writes import session_validated_buffer_address
 from .escape_detection import ExpectedOriginalToken, _active_token
 
@@ -2273,9 +2278,15 @@ def _nonowner_touch_is_captured(state: "_WitnessState", tensor: Any) -> bool:
     if not isinstance(tensor, torch.Tensor):
         return False
     trace = state.trace
-    if isinstance(get_tensor_label(tensor), str):
-        return True
     meta = get_tensor_meta(tensor)
+    # This path must remain observer-free: get_tensor_label() also validates the
+    # live storage, which calls the patched untyped_storage() host-escape surface.
+    # On a non-owner thread that wrapper re-enters this predicate indefinitely.
+    # The current-session object anchor is sufficient for captured membership:
+    # even a storage-rebound captured object must still trip the cross-thread
+    # ceiling, while a stale label from an earlier capture remains rejected.
+    if meta is not None and isinstance(meta.label_raw, str) and session_meta_is_anchored(meta):
+        return True
     if meta is not None and getattr(meta, "address", None) is not None:
         return True
     if get_buffer_address(tensor) is not None:

--- a/torchlens/backends/torch/completeness_witness.py
+++ b/torchlens/backends/torch/completeness_witness.py
@@ -65,6 +65,7 @@ from ._tl import (
     get_buffer_address,
     get_tensor_label,
     get_tensor_meta,
+    is_tensor_data_alias,
     session_meta_is_anchored,
 )
 from .buffer_writes import session_validated_buffer_address
@@ -3307,9 +3308,24 @@ def _register_dispatch_result_origins(
 
 
 def _resolved_dispatch_origins(
-    trace: Any, source: torch.Tensor
+    trace: Any,
+    source: torch.Tensor,
+    *,
+    prefer_ledger: bool = False,
 ) -> tuple[set[str], set[str]] | None:
     """Resolve an unlabelled escape source to positive (labels, state names), or ``None``.
+
+    Parameters
+    ----------
+    trace:
+        Active capture trace owning the dispatch-origin ledger.
+    source:
+        Tensor whose value origins must be resolved.
+    prefer_ledger:
+        Whether to consult the dispatch ledger before the tensor's own label.
+        ``Tensor.data`` aliases use this route because their canonical detach
+        label represents the getter, while the ledger names the semantic base
+        producer required by the host-escape witness.
 
     Returns ``None`` -- the caller MUST fail closed -- when the source's propagated
     origin set contains ``unknown`` (an operand the census could not attribute),
@@ -3322,8 +3338,15 @@ def _resolved_dispatch_origins(
     it needs no witness.
     """
 
-    with _state.pause_logging(), internal_scalar_read():
-        origins = _operand_origins(trace, source)
+    origins: frozenset[str] | None = None
+    if prefer_ledger:
+        registry = _DISPATCH_TENSOR_ORIGINS.get(trace)
+        entry = registry.get(source) if registry is not None else None
+        if entry is not None:
+            origins = entry[0]
+    if origins is None:
+        with _state.pause_logging(), internal_scalar_read():
+            origins = _operand_origins(trace, source)
     if _ORIGIN_UNKNOWN in origins or _ORIGIN_RNG in origins or _ORIGIN_UNINIT in origins:
         return None
     labels = {
@@ -3377,7 +3400,13 @@ def _record_escape_source_tensor(
     if _escape_source_is_torchlens_internal():
         return
     is_bool = source.dtype is torch.bool
-    label = get_tensor_label(source)
+    # ``Tensor.data`` is captured as a canonical detach node so ordinary tensor
+    # replay retains a graph edge. For a host escape, however, the alias is not
+    # the semantic value source: resolve its dispatch origins exactly like the
+    # historical unlabelled ``.data`` object so the witness attributes the base
+    # producer rather than the synthetic getter node.
+    data_alias = is_tensor_data_alias(source)
+    label = None if data_alias else get_tensor_label(source)
     if not isinstance(label, str):
         # An UNLABELLED escape source (a ``.data`` alias, a raw-dispatch product):
         # r37 INV-1 single-exit attribution ladder. Every rung is a POSITIVE
@@ -3407,7 +3436,11 @@ def _record_escape_source_tensor(
         # and state names (param/buffer sources -> PASS A digest). Multi-element and
         # scalar sources resolve identically -- no arity assumption anywhere.
         # Owner-thread only (resolution flips the global logging toggle).
-        resolved = _resolved_dispatch_origins(trace, source) if resolve_origins else None
+        resolved = (
+            _resolved_dispatch_origins(trace, source, prefer_ledger=data_alias)
+            if resolve_origins
+            else None
+        )
         if resolved is not None:
             origin_labels, origin_states = resolved
             if origin_labels:

--- a/torchlens/backends/torch/escape_detection.py
+++ b/torchlens/backends/torch/escape_detection.py
@@ -191,6 +191,7 @@ class ExpectedOriginalToken:
     call_barcode: object | None = None
     census_scope: Literal["owned", "expected_opaque"] = "owned"
     capture_accounted: bool | None = None
+    capture_accounted_outputs: dict[int, tuple[torch.Tensor, str]] = field(default_factory=dict)
     capture_callsite: tuple[str, int, str] | None = None
 
 
@@ -395,6 +396,7 @@ def mark_expected_original_accounted(
     token: ExpectedOriginalToken | None,
     *,
     captured: bool,
+    boundary_outputs: tuple[tuple[torch.Tensor, str], ...] = (),
 ) -> None:
     """Record whether a token's dispatch interval became a captured leaf.
 
@@ -404,10 +406,17 @@ def mark_expected_original_accounted(
         Token returned by :func:`expected_original_call`, if diagnostics were armed.
     captured:
         Whether the wrapper passed the shared barcode leaf test and emitted tensor ops.
+    boundary_outputs:
+        Exact output tensors and raw labels represented by synthesized boundary Ops.
+        When non-empty, completeness accounting is limited per dispatch to non-mutating
+        opaque output construction owned by the boundary-backed token.
     """
 
     if token is not None:
         token.capture_accounted = captured
+        token.capture_accounted_outputs = {
+            id(tensor): (tensor, raw_label) for tensor, raw_label in boundary_outputs
+        }
 
 
 def _active_token() -> ExpectedOriginalToken | None:

--- a/torchlens/backends/torch/model_prep.py
+++ b/torchlens/backends/torch/model_prep.py
@@ -1684,7 +1684,7 @@ def _make_user_forward_hook_wrapper(
             )
             is not None
         ]
-        captured_replacement_boundary = False
+        replacement_boundaries: list[tuple[torch.Tensor, str]] = []
         for replacement in get_vars_of_type_from_obj(result, torch.Tensor, search_depth=4):
             replacement_label = get_live_tensor_label(
                 replacement, trace.capture_events.live_index.by_raw_label
@@ -1692,11 +1692,14 @@ def _make_user_forward_hook_wrapper(
             if replacement_label is not None:
                 replace_op_event(trace, replacement_label, intervention_replaced=True)
             else:
-                _ensure_module_output_tensor_logged(trace, replacement, module, parent_labels)
-                captured_replacement_boundary = True
+                boundary_label = _ensure_module_output_tensor_logged(
+                    trace, replacement, module, parent_labels
+                )
+                replacement_boundaries.append((replacement, boundary_label))
         mark_expected_original_accounted(
             expected_token,
-            captured=captured_replacement_boundary,
+            captured=bool(replacement_boundaries),
+            boundary_outputs=tuple(replacement_boundaries),
         )
         return result
 
@@ -1710,7 +1713,7 @@ def _record_module_exit_metadata(
     out: Any,
     input_tensor_labels: set[str],
     input_tensor_labels_at_entry: list[str],
-) -> bool:
+) -> tuple[tuple[torch.Tensor, str], ...]:
     """Record post-forward module metadata for exhaustive mode.
 
     Called immediately after ``orig_forward()`` returns in the
@@ -1720,9 +1723,9 @@ def _record_module_exit_metadata(
 
     Returns
     -------
-    bool
-        Whether module-exit reconciliation inserted an explicit boundary Op for
-        an otherwise untraceable output tensor.
+    tuple[tuple[torch.Tensor, str], ...]
+        Exact output tensors and raw labels of boundary Ops inserted for otherwise
+        untraceable outputs.
     """
     address = _module_address(module)
     mod_id = id(module)
@@ -1759,7 +1762,7 @@ def _record_module_exit_metadata(
     output_paths: list[tuple[object, ...]] = []
     per_output_atomic: list[tuple[str, tuple[ModuleFrame, ...], bool, tuple[str, int] | None]] = []
     output_names: list[str | None] = []
-    captured_untraceable_output = False
+    untraceable_output_boundaries: list[tuple[torch.Tensor, str]] = []
     for output_index, (t, container_path, _container_spec) in enumerate(output_entries):
         # nn.Identity modules and pass-through tensors (output is same object
         # as input) need _decorated_identity() to create a distinct log entry
@@ -1793,14 +1796,14 @@ def _record_module_exit_metadata(
             intervention_parent_labels = list(
                 getattr(t, "_tl_module_intervention_parent_labels", ())
             )
-            _ensure_module_output_tensor_logged(
+            boundary_label = _ensure_module_output_tensor_logged(
                 trace,
                 t,
                 module,
                 parent_labels=intervention_parent_labels,
                 kind="intervention_replacement" if fire_results else "internal_source",
             )
-            captured_untraceable_output = True
+            untraceable_output_boundaries.append((t, boundary_label))
             tensor_label = get_tensor_label(t)
         if tensor_label is None:
             continue
@@ -1851,7 +1854,7 @@ def _record_module_exit_metadata(
             output_names=tuple(output_names),
         )
     )
-    return captured_untraceable_output
+    return tuple(untraceable_output_boundaries)
 
 
 def module_forward_decorator(
@@ -2076,12 +2079,13 @@ def module_forward_decorator(
                 if call_labels:
                     call_labels.pop()
                 raise
-            captured_untraceable_output = _record_module_exit_metadata(
+            untraceable_output_boundaries = _record_module_exit_metadata(
                 trace, module, out, input_tensor_labels, input_tensor_labels_at_entry
             )
             mark_expected_original_accounted(
                 expected_token,
-                captured=captured_untraceable_output,
+                captured=bool(untraceable_output_boundaries),
+                boundary_outputs=untraceable_output_boundaries,
             )
             options = getattr(trace, "_predicate_save_options", None)
             if options is not None and options.halt is not None:

--- a/torchlens/backends/torch/model_prep.py
+++ b/torchlens/backends/torch/model_prep.py
@@ -65,7 +65,10 @@ from .tensor_tracking import _append_module_suffix_to_equivalence_class
 from .sources import log_source_tensor
 from ...constants import LAYER_PASS_LOG_FIELD_ORDER
 from . import module_stack as _mstack
-from .escape_detection import expected_original_call
+from .escape_detection import (
+    expected_original_call,
+    mark_expected_original_accounted,
+)
 
 # Cache class-level module metadata (inspect.getsourcelines, inspect.signature, etc.)
 # shared across instances of the same class type. Cleared at the start of each
@@ -1309,7 +1312,7 @@ def _ensure_module_output_tensor_logged(
     module: nn.Module,
     parent_labels: list[str],
     kind: str = "intervention_replacement",
-) -> None:
+) -> str:
     """Log a fresh entry for an unlabeled tensor surfaced mid-forward.
 
     This handles two distinct, legitimately untraceable cases and must keep
@@ -1344,9 +1347,9 @@ def _ensure_module_output_tensor_logged(
 
     Returns
     -------
-    None
-        The tensor is tagged and an Op is inserted into the raw graph so
-        downstream module-exit and op logging can continue.
+    str
+        Raw label of the inserted boundary Op. The tensor is tagged so downstream
+        module-exit and op logging can continue.
     """
 
     from .ops import _make_layer_log_entry, _pop_tensor_live_fire_results
@@ -1631,6 +1634,7 @@ def _ensure_module_output_tensor_logged(
     from .ops import _add_tensor_backward_hook
 
     _add_tensor_backward_hook(trace, tensor, new_entry._label_raw)
+    return new_entry._label_raw
 
 
 def _make_user_forward_hook_wrapper(
@@ -1656,11 +1660,21 @@ def _make_user_forward_hook_wrapper(
         """Run a raw forward hook and repair TorchLens metadata on replacements."""
 
         original_output = hook_args[-1] if hook_args else None
-        result = hook_fn(*hook_args, **hook_kwargs)
+        expected_token = None
+        if (
+            _state._escape_detector_mode == "shadow"
+            or _state._completeness_witness_mode == "shadow"
+        ):
+            with expected_original_call(hook_fn, "module_forward_hook:user") as expected_token:
+                result = hook_fn(*hook_args, **hook_kwargs)
+        else:
+            result = hook_fn(*hook_args, **hook_kwargs)
         if result is None or result is original_output:
+            mark_expected_original_accounted(expected_token, captured=False)
             return result
         trace = _state._active_trace
         if trace is None or not _state._logging_enabled:
+            mark_expected_original_accounted(expected_token, captured=False)
             return result
         parent_labels = [
             label
@@ -1670,6 +1684,7 @@ def _make_user_forward_hook_wrapper(
             )
             is not None
         ]
+        captured_replacement_boundary = False
         for replacement in get_vars_of_type_from_obj(result, torch.Tensor, search_depth=4):
             replacement_label = get_live_tensor_label(
                 replacement, trace.capture_events.live_index.by_raw_label
@@ -1678,6 +1693,11 @@ def _make_user_forward_hook_wrapper(
                 replace_op_event(trace, replacement_label, intervention_replaced=True)
             else:
                 _ensure_module_output_tensor_logged(trace, replacement, module, parent_labels)
+                captured_replacement_boundary = True
+        mark_expected_original_accounted(
+            expected_token,
+            captured=captured_replacement_boundary,
+        )
         return result
 
     mark_tensor_replacement_wrapped(wrapped_hook)
@@ -1690,13 +1710,19 @@ def _record_module_exit_metadata(
     out: Any,
     input_tensor_labels: set[str],
     input_tensor_labels_at_entry: list[str],
-) -> None:
+) -> bool:
     """Record post-forward module metadata for exhaustive mode.
 
     Called immediately after ``orig_forward()`` returns in the
     ``module_forward_decorator``. Pops the module call-label stack, creates
     boundary identity ops for pass-through outputs, recovers replacement outputs,
     and annotates output tensors with module-exit metadata.
+
+    Returns
+    -------
+    bool
+        Whether module-exit reconciliation inserted an explicit boundary Op for
+        an otherwise untraceable output tensor.
     """
     address = _module_address(module)
     mod_id = id(module)
@@ -1733,6 +1759,7 @@ def _record_module_exit_metadata(
     output_paths: list[tuple[object, ...]] = []
     per_output_atomic: list[tuple[str, tuple[ModuleFrame, ...], bool, tuple[str, int] | None]] = []
     output_names: list[str | None] = []
+    captured_untraceable_output = False
     for output_index, (t, container_path, _container_spec) in enumerate(output_entries):
         # nn.Identity modules and pass-through tensors (output is same object
         # as input) need _decorated_identity() to create a distinct log entry
@@ -1773,6 +1800,7 @@ def _record_module_exit_metadata(
                 parent_labels=intervention_parent_labels,
                 kind="intervention_replacement" if fire_results else "internal_source",
             )
+            captured_untraceable_output = True
             tensor_label = get_tensor_label(t)
         if tensor_label is None:
             continue
@@ -1823,6 +1851,7 @@ def _record_module_exit_metadata(
             output_names=tuple(output_names),
         )
     )
+    return captured_untraceable_output
 
 
 def module_forward_decorator(
@@ -2017,12 +2046,15 @@ def module_forward_decorator(
             input_tensor_labels, input_tensor_labels_at_entry = _record_module_entry_metadata(
                 trace, module, args, kwargs
             )
+            expected_token = None
             try:
                 if (
                     _state._escape_detector_mode == "shadow"
                     or _state._completeness_witness_mode == "shadow"
                 ):
-                    with expected_original_call(orig_forward, "module_forward:exhaustive"):
+                    with expected_original_call(
+                        orig_forward, "module_forward:exhaustive"
+                    ) as expected_token:
                         out = orig_forward(*args, **kwargs)
                 else:
                     out = orig_forward(*args, **kwargs)
@@ -2044,8 +2076,12 @@ def module_forward_decorator(
                 if call_labels:
                     call_labels.pop()
                 raise
-            _record_module_exit_metadata(
+            captured_untraceable_output = _record_module_exit_metadata(
                 trace, module, out, input_tensor_labels, input_tensor_labels_at_entry
+            )
+            mark_expected_original_accounted(
+                expected_token,
+                captured=captured_untraceable_output,
             )
             options = getattr(trace, "_predicate_save_options", None)
             if options is not None and options.halt is not None:

--- a/torchlens/backends/torch/ops.py
+++ b/torchlens/backends/torch/ops.py
@@ -28,6 +28,7 @@ from ._tl import (
     get_param_meta,
     get_tensor_label,
     get_tensor_meta,
+    is_tensor_data_alias,
     session_label_storage_intact,
     session_meta_is_anchored,
     set_tensor_label,
@@ -1874,6 +1875,7 @@ def _unattributed_tensor_arg_positions(
     trace: "Trace",
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
+    func_name: str,
 ) -> tuple[str, ...]:
     """Find tensor arguments that will not become graph parents or known sources.
 
@@ -1885,6 +1887,8 @@ def _unattributed_tensor_arg_positions(
         Positional function arguments.
     kwargs:
         Keyword function arguments.
+    func_name:
+        Wrapped callable name used to identify receiver mutations.
 
     Returns
     -------
@@ -1893,12 +1897,50 @@ def _unattributed_tensor_arg_positions(
     """
 
     positions: list[str] = []
+    mutates_receiver = (
+        _is_inplace_augmented_assignment_dunder(func_name)
+        or func_name in _SETTER_MUTATION_FUNC_NAMES
+        or (func_name.endswith("_") and not func_name.startswith("__"))
+    )
+    capture_events = getattr(trace, "capture_events", None)
+    live_events = capture_events.live_index.by_raw_label if capture_events is not None else {}
+
+    def has_input_rooted_tensor(value: Any) -> bool:
+        """Return whether ``value`` contains a tensor derived from a model input."""
+
+        if isinstance(value, torch.Tensor):
+            label = get_tensor_label(value)
+            event = live_events.get(label) if isinstance(label, str) else None
+            return bool(event is not None and event.input_ancestors)
+        if isinstance(value, (list, tuple)):
+            return any(has_input_rooted_tensor(item) for item in value)
+        if isinstance(value, dict):
+            return any(has_input_rooted_tensor(item) for item in value.values())
+        return False
+
+    unsafe_receiver_with_graph_rhs = bool(
+        mutates_receiver
+        and args
+        and isinstance(args[0], torch.Tensor)
+        and is_tensor_data_alias(args[0])
+        and (
+            any(has_input_rooted_tensor(value) for value in args[1:])
+            or any(has_input_rooted_tensor(value) for value in kwargs.values())
+        )
+    )
 
     def visit(value: Any, path: str) -> None:
         """Append unattributed tensor positions under ``path``."""
 
         if isinstance(value, torch.Tensor):
-            if not _tensor_has_known_provenance(trace, value):
+            # A ``.data`` getter now has a canonical detach graph node, but a
+            # subsequent receiver mutation still writes through an alias whose
+            # effect is not connected to the returned base tensor in the sparse
+            # graph. Preserve the provenance warning for that unsafe lvalue
+            # position when an input-derived RHS would otherwise appear fully
+            # represented, while the independent data-alias witness ceilings replay.
+            unsafe_data_alias_receiver = path == "arg0" and unsafe_receiver_with_graph_rhs
+            if unsafe_data_alias_receiver or not _tensor_has_known_provenance(trace, value):
                 positions.append(path)
             return
         if isinstance(value, (list, tuple)):
@@ -3261,7 +3303,12 @@ def _build_shared_fields_dict(
     fields_dict["transform_fn_name"] = getattr(func, "__tl_transform_fn_name__", None)
     fields_dict["transform_fn_qualname"] = getattr(func, "__tl_transform_fn_qualname__", None)
     fields_dict["transform_fn_source"] = getattr(func, "__tl_transform_fn_source__", None)
-    fields_dict["unattributed_tensor_args"] = _unattributed_tensor_arg_positions(self, args, kwargs)
+    fields_dict["unattributed_tensor_args"] = _unattributed_tensor_arg_positions(
+        self,
+        args,
+        kwargs,
+        func_name,
+    )
 
     # Function config — lightweight hyperparameter extraction, always on.
     param_shapes = cast(list[tuple[int, ...]] | None, fields_dict.get("param_shapes"))

--- a/torchlens/backends/torch/wrappers.py
+++ b/torchlens/backends/torch/wrappers.py
@@ -35,7 +35,9 @@ from ...data_classes.func_call_location import FuncCallLocation
 from ._tl import (
     get_param_meta,
     get_tensor_label,
+    is_tensor_data_alias,
     is_decorated_function,
+    mark_tensor_data_alias,
     mark_decorated_function,
     set_tensor_label,
 )
@@ -58,6 +60,7 @@ from ...utils.hashing import make_random_barcode
 from ...utils.arg_handling import copy_arg_tree
 from ...utils.tensor_utils import print_override, safe_copy
 from .ops import (
+    _is_inplace_augmented_assignment_dunder,
     _walk_output_tensors_with_paths,
     apply_live_hooks_to_outputs,
     log_function_output_tensors,
@@ -78,11 +81,14 @@ from .escape_detection import (
 from .completeness_witness import (
     CompletenessWitnessMode,
     completeness_scope_for_wrapper,
+    internal_scalar_read,
     observe_nonowner_operands,
+    record_data_alias_mutation,
     record_host_string_escape_source,
     record_uncaptured_owner_callsite,
     string_escape_is_owner_thread,
 )
+from .aliasing import _tensors_alias
 from .sources import log_source_tensor
 
 if TYPE_CHECKING:
@@ -992,6 +998,57 @@ def _canonical_capture_callable(
     return cast(Callable[..., Any], original_detach), "detach"
 
 
+def _func_mutates_receiver(func_name: str) -> bool:
+    """Return whether a wrapped function mutates its first tensor argument.
+
+    Parameters
+    ----------
+    func_name : str
+        TorchLens wrapper name for the callable.
+
+    Returns
+    -------
+    bool
+        ``True`` for in-place methods, augmented-assignment dunders, and
+        setter-style tensor operations.
+    """
+
+    return (
+        _is_inplace_augmented_assignment_dunder(func_name)
+        or func_name in {"__setitem__", "__delitem__"}
+        or (func_name.endswith("_") and not func_name.startswith("__"))
+    )
+
+
+def _propagate_data_alias_provenance(
+    func_name: str,
+    data_alias_inputs: tuple[torch.Tensor, ...],
+    output_tensors: list[torch.Tensor],
+) -> None:
+    """Propagate ``Tensor.data`` provenance through storage-sharing outputs.
+
+    Parameters
+    ----------
+    func_name : str
+        Original wrapped callable name before replay canonicalization.
+    data_alias_inputs : tuple[torch.Tensor, ...]
+        Input tensors already known to descend from ``Tensor.data``.
+    output_tensors : list[torch.Tensor]
+        Live output tensors after capture labels have been assigned.
+    """
+
+    if func_name == "data":
+        for output in output_tensors:
+            mark_tensor_data_alias(output)
+        return
+    if not data_alias_inputs:
+        return
+    with internal_scalar_read():
+        for output in output_tensors:
+            if any(_tensors_alias(output, source) for source in data_alias_inputs):
+                mark_tensor_data_alias(output)
+
+
 def _register_inplace_live_grad_hook(trace: Any, tensor: Any, raw_label: str) -> None:
     """Hook the live in-place result so its gradient is captured under ``raw_label``.
 
@@ -1142,6 +1199,15 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
         # Inline tensor extraction — avoids BFS crawl for the common case
         # where args are flat tensors. Falls back to BFS only for nested containers.
         arg_tensorlike = _collect_tensor_args(args, kwargs)
+        data_alias_inputs = tuple(
+            tensor for tensor in arg_tensorlike if is_tensor_data_alias(tensor)
+        )
+        mutates_data_alias = bool(
+            args
+            and isinstance(args[0], torch.Tensor)
+            and is_tensor_data_alias(args[0])
+            and _func_mutates_receiver(func_name)
+        )
 
         # Register buffer tensors on first encounter. Buffers are tagged with
         # _tl.address during model prep but don't get _tl.label_raw
@@ -1238,6 +1304,8 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
                 out_orig = func(*args, **kwargs)
         finally:
             _nvtx_range_pop(nvtx_pushed)
+        if mutates_data_alias:
+            record_data_alias_mutation(trace)
         return_value = out_orig
         exec_ctx = FuncExecutionContext(
             time_elapsed=time.time() - capture_start_time,
@@ -1337,6 +1405,12 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
                     is_bottom_level_func,
                     func_call_id,
                 )
+
+            _propagate_data_alias_provenance(
+                func_name,
+                data_alias_inputs,
+                output_tensors,
+            )
 
             # Same-object returns are logged against out_orig (a safe_copy with
             # the op's new label). When Python object identity is preserved we

--- a/torchlens/backends/torch/wrappers.py
+++ b/torchlens/backends/torch/wrappers.py
@@ -961,7 +961,8 @@ def _parameter_mutation_output_for_logging(
     if not was_inplace or not _is_unregistered_parameter(trace, source):
         return value
     with _state.pause_logging():
-        tensor = value.detach().clone()
+        plain_value = value.as_subclass(torch.Tensor)
+        tensor = safe_copy(plain_value, detach_tensor=True)
         tensor.requires_grad_(value.requires_grad)
     return tensor
 

--- a/torchlens/backends/torch/wrappers.py
+++ b/torchlens/backends/torch/wrappers.py
@@ -44,6 +44,7 @@ from ._tl import (
 from ...data_classes.internal_types import FuncExecutionContext
 from ...utils.introspection import get_vars_of_type_from_obj, nested_getattr
 from ...utils._torch_compat import (
+    HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE,
     get_current_function_mode_stack,
     get_device_constructors,
     get_device_context_type,
@@ -961,7 +962,10 @@ def _parameter_mutation_output_for_logging(
     if not was_inplace or not _is_unregistered_parameter(trace, source):
         return value
     with _state.pause_logging():
-        plain_value = value.as_subclass(torch.Tensor)
+        if HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE:
+            plain_value = value.as_subclass(torch.Tensor)
+        else:
+            plain_value = torch.ops.aten.detach.default(value)
         tensor = safe_copy(plain_value, detach_tensor=True)
         tensor.requires_grad_(value.requires_grad)
     return tensor

--- a/torchlens/backends/torch/wrappers.py
+++ b/torchlens/backends/torch/wrappers.py
@@ -33,6 +33,7 @@ from ... import _state
 from ...constants import get_orig_torch_funcs
 from ...data_classes.func_call_location import FuncCallLocation
 from ._tl import (
+    get_param_meta,
     get_tensor_label,
     is_decorated_function,
     mark_decorated_function,
@@ -884,6 +885,113 @@ def _collect_output_tensors(out: Any) -> list[torch.Tensor]:
     )
 
 
+def _is_unregistered_parameter(trace: Any, value: Any) -> bool:
+    """Return whether ``value`` is a Parameter outside the prepared model state.
+
+    Parameters
+    ----------
+    trace:
+        Active capture trace carrying the current-session parameter registry.
+    value:
+        Candidate operation output.
+
+    Returns
+    -------
+    bool
+        ``True`` for a Parameter that is not the exact prepared parameter object
+        recorded at its stamped address in this capture.
+    """
+
+    if not isinstance(value, torch.nn.Parameter):
+        return False
+    meta = get_param_meta(value)
+    address = None if meta is None else meta.param_address
+    if not address:
+        return True
+    param_logs = getattr(trace, "param_logs", None)
+    if param_logs is None or address not in param_logs:
+        return True
+    return getattr(param_logs[address], "_param_ref", None) is not value
+
+
+def _parameter_mutation_output_for_logging(
+    trace: Any,
+    value: Any,
+    *,
+    source: Any,
+    was_inplace: bool,
+) -> Any:
+    """Convert an unregistered Parameter mutation result into a loggable Tensor.
+
+    PyTorch constructs module Parameters from ordinary factory tensors, and the
+    conversion intentionally drops TorchLens tensor labels. Initializers such as
+    ``uniform_`` then return the new Parameter itself. Parameter outputs are normally
+    excluded because prepared model state remains a source rather than an op output,
+    but that rule also dropped real initialization ops for modules created inside
+    ``forward``.
+
+    Only unregistered Parameters are converted. Mutations of prepared model state
+    remain excluded and therefore remain visible to the completeness tripwire instead
+    of being laundered into a disconnected op.
+
+    Parameters
+    ----------
+    trace:
+        Active capture trace.
+    value:
+        Safe-copied operation output.
+    source:
+        Live same-object return whose current-session registration is authoritative.
+    was_inplace:
+        Whether the wrapped callable has an in-place mutation signature.
+
+    Returns
+    -------
+    Any
+        A plain Tensor snapshot for capture-local Parameter mutations; otherwise
+        ``value`` unchanged.
+    """
+
+    if not was_inplace or not _is_unregistered_parameter(trace, source):
+        return value
+    with _state.pause_logging():
+        tensor = value.detach().clone()
+        tensor.requires_grad_(value.requires_grad)
+    return tensor
+
+
+def _canonical_capture_callable(
+    func: Callable[..., Any],
+    func_name: str,
+) -> tuple[Callable[..., Any], str]:
+    """Return the replay-safe callable identity for one wrapped operation.
+
+    ``Tensor.data`` is a C descriptor whose getter dispatches ``aten.detach`` and
+    returns the same storage-sharing, autograd-detached value as ``Tensor.detach``.
+    Record that operation under the canonical detach callable so live validation
+    and portable replay agree without admitting the unsafe ``data`` descriptor
+    through the callable resolver.
+
+    Parameters
+    ----------
+    func:
+        Original wrapped callable.
+    func_name:
+        TorchLens name associated with the wrapped namespace entry.
+
+    Returns
+    -------
+    tuple[Callable[..., Any], str]
+        Callable and operation name to persist for capture/replay.
+    """
+
+    if func_name != "data":
+        return func, func_name
+    decorated_detach = torch.Tensor.detach
+    original_detach = _state._decorated_to_orig.get(id(decorated_detach), decorated_detach)
+    return cast(Callable[..., Any], original_detach), "detach"
+
+
 def _register_inplace_live_grad_hook(trace: Any, tensor: Any, raw_label: str) -> None:
     """Hook the live in-place result so its gradient is captured under ``raw_label``.
 
@@ -1167,12 +1275,19 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
             # Create a distinct tensor object for logging — otherwise attaching
             # _tl.label_raw on the output would clobber the input's label.
             out_orig = safe_copy(out_orig)
+            out_orig = _parameter_mutation_output_for_logging(
+                trace,
+                out_orig,
+                source=args[0],
+                was_inplace=was_inplace,
+            )
 
+        capture_func, capture_func_name = _canonical_capture_callable(func, func_name)
         out_before_hooks = out_orig
         out_orig = apply_live_hooks_to_outputs(
             trace,
-            func,
-            func_name,
+            capture_func,
+            capture_func_name,
             args,
             kwargs,
             out_orig,
@@ -1197,8 +1312,8 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
                 with _state.pause_logging():
                     call_emitted_op = log_function_output_tensors(
                         trace,
-                        func,
-                        func_name,
+                        capture_func,
+                        capture_func_name,
                         args,
                         kwargs,
                         arg_copies,
@@ -1211,8 +1326,8 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
             else:
                 call_emitted_op = log_function_output_tensors(
                     trace,
-                    func,
-                    func_name,
+                    capture_func,
+                    capture_func_name,
                     args,
                     kwargs,
                     arg_copies,
@@ -1267,7 +1382,12 @@ def torch_func_decorator(func: Callable[..., Any], func_name: str) -> Callable[.
         elif output_tensors:
             producer_label = get_tensor_label(output_tensors[0])
         if is_bottom_level_func:
-            record_op_buffer_writes(trace, func_name, buffer_snapshots, producer_label)
+            record_op_buffer_writes(
+                trace,
+                capture_func_name,
+                buffer_snapshots,
+                producer_label,
+            )
 
         if out_orig is not out_before_hooks:
             return out_orig

--- a/torchlens/capture/arg_positions.py
+++ b/torchlens/capture/arg_positions.py
@@ -444,6 +444,7 @@ _UNARY_FUNCS = [
     "item",
     "tolist",
     "numpy",
+    "array",
     # --- Activations (unary) ---
     "relu",
     "relu6",

--- a/torchlens/capture/session.py
+++ b/torchlens/capture/session.py
@@ -200,6 +200,8 @@ class CaptureSession:
         self.module_state.clear()
         self.history_state.clear()
         self.builders.clear()
+        self.projection_facts.clear()
+        self._sealed_core = None
         self.cleanup_stack.clear()
         self.activation_escrow.clear()
         self.gradient_reference_escrow.clear()

--- a/torchlens/constants.py
+++ b/torchlens/constants.py
@@ -1027,6 +1027,7 @@ IGNORED_FUNCS = [
     ("torch.Tensor", "unflatten"),
     ("torch.Tensor", "real"),
     ("torch.Tensor", "imag"),
+    ("torch.Tensor", "data"),
     ("torch.Tensor", "T"),
     ("torch.Tensor", "mT"),
     ("torch.Tensor", "H"),

--- a/torchlens/data_classes/derived_grad.py
+++ b/torchlens/data_classes/derived_grad.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
+from .._io import FieldPolicy
 from ..ir.refs import DtypeRef
 from ._accessor_base import Accessor
 
@@ -34,6 +35,17 @@ class DerivedGradRecord:
         Backend-owned validation and fingerprint metadata.
     """
 
+    PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
+        "path": FieldPolicy.KEEP,
+        "source": FieldPolicy.KEEP,
+        "argnum": FieldPolicy.KEEP,
+        "input_argnum": FieldPolicy.KEEP,
+        "aval": FieldPolicy.KEEP,
+        "dtype_ref": FieldPolicy.KEEP,
+        "grad": FieldPolicy.BLOB,
+        "provenance": FieldPolicy.KEEP,
+    }
+
     path: str
     source: str
     argnum: int
@@ -46,6 +58,11 @@ class DerivedGradRecord:
 
 class DerivedGradAccessor(Accessor[DerivedGradRecord]):
     """Dict-like accessor for leaf-level derived gradient records."""
+
+    PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
+        "_dict": FieldPolicy.KEEP,
+        "_list": FieldPolicy.KEEP,
+    }
 
     def __init__(self, records: Mapping[str, DerivedGradRecord] | None = None) -> None:
         """Initialize a derived-gradient accessor.
@@ -79,6 +96,15 @@ class IntermediateDerivedGradRecord:
         Backend-owned mechanism, loss, save predicate, and status metadata.
     """
 
+    PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
+        "op_label": FieldPolicy.KEEP,
+        "layer_label": FieldPolicy.KEEP,
+        "aval": FieldPolicy.KEEP,
+        "dtype_ref": FieldPolicy.KEEP,
+        "grad": FieldPolicy.BLOB,
+        "provenance": FieldPolicy.KEEP,
+    }
+
     op_label: str
     layer_label: str
     aval: str
@@ -89,6 +115,11 @@ class IntermediateDerivedGradRecord:
 
 class IntermediateDerivedGradAccessor(Accessor[IntermediateDerivedGradRecord]):
     """Dict-like accessor for op-level derived gradient records."""
+
+    PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
+        "_dict": FieldPolicy.KEEP,
+        "_list": FieldPolicy.KEEP,
+    }
 
     def __init__(self, records: Mapping[str, IntermediateDerivedGradRecord] | None = None) -> None:
         """Initialize an intermediate-derived-gradient accessor.

--- a/torchlens/data_classes/trace.py
+++ b/torchlens/data_classes/trace.py
@@ -1027,6 +1027,9 @@ class Trace(
     _containers: dict[int, Any]
     _annotation_blobs: dict[str, Any] | None
     _last_sibling_ordering_decision: Any
+    _receptive_field_solution: Any
+    _rf_source_solutions: Any
+    _rf_target_solutions: Any
 
     PORTABLE_STATE_SPEC: ClassVar[dict[str, FieldPolicy]] = {
         "trace_label": FieldPolicy.KEEP,
@@ -1044,6 +1047,9 @@ class Trace(
         "_tf_init_op_labels": FieldPolicy.DROP,
         "_tf_op_captures": FieldPolicy.DROP,
         "_tf_validation_result": FieldPolicy.DROP,
+        "_receptive_field_solution": FieldPolicy.DROP,
+        "_rf_source_solutions": FieldPolicy.DROP,
+        "_rf_target_solutions": FieldPolicy.DROP,
         "module_identity_mode": FieldPolicy.KEEP,
         "param_source": FieldPolicy.KEEP,
         "derived_grads": FieldPolicy.KEEP,

--- a/torchlens/receptive_field/_engine.py
+++ b/torchlens/receptive_field/_engine.py
@@ -557,8 +557,12 @@ def _concatenation_offsets(op: Op, parent: Op, result: _RuleResult) -> tuple[int
     for label, shape in zip(op.parents, op.input_shapes, strict=False):
         if label in parent_references:
             starts.append(offset)
-        if shape is not None:
-            offset += int(shape[raw_axis])
+        if shape is None:
+            continue
+        # torch.cat accepts a one-dimensional empty tensor at any concat axis.
+        if tuple(shape) == (0,):
+            continue
+        offset += int(shape[raw_axis])
     return tuple(starts)
 
 

--- a/torchlens/receptive_field/_engine.py
+++ b/torchlens/receptive_field/_engine.py
@@ -770,6 +770,20 @@ def _apply_full(
         notes,
         parent_to_child=parent_to_child,
     )
+    if passthrough.axes is None and selected == set(range(parent_rank)):
+        axes = tuple(
+            replace(
+                axis,
+                geometry=_Full(exact=exact),
+                output_axis=None,
+                kind="full",
+                provenance=op.label,
+            )
+            if axis.output_axis is not None
+            else axis
+            for axis in state.axes
+        )
+        return replace(state, axes=axes, notes=notes, rule=rule_name)
     assert passthrough.axes is not None
     axes = []
     for old_axis, mapped_axis in zip(state.axes, passthrough.axes):

--- a/torchlens/receptive_field/_engine.py
+++ b/torchlens/receptive_field/_engine.py
@@ -771,7 +771,7 @@ def _apply_full(
         parent_to_child=parent_to_child,
     )
     if passthrough.axes is None and selected == set(range(parent_rank)):
-        axes = tuple(
+        fallback_axes = tuple(
             replace(
                 axis,
                 geometry=_Full(exact=exact),
@@ -783,7 +783,7 @@ def _apply_full(
             else axis
             for axis in state.axes
         )
-        return replace(state, axes=axes, notes=notes, rule=rule_name)
+        return replace(state, axes=fallback_axes, notes=notes, rule=rule_name)
     assert passthrough.axes is not None
     axes = []
     for old_axis, mapped_axis in zip(state.axes, passthrough.axes):

--- a/torchlens/receptive_field/_engine.py
+++ b/torchlens/receptive_field/_engine.py
@@ -14,7 +14,6 @@ from fractions import Fraction
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
-from .._io import FieldPolicy
 from ..capture.arg_positions import _normalize_func_name
 from ._engine_descriptor import _descriptor
 from ._engine_geometry import (
@@ -86,7 +85,6 @@ def solve(trace: Trace) -> _ReceptiveFieldSolution:
         while both the rule-registry epoch and structural graph revision remain unchanged.
     """
 
-    _ensure_trace_cache_policy(trace)
     epoch = _rf_rules_epoch()
     graph_revision = _graph_revision(trace)
     cached = trace.__dict__.get("_receptive_field_solution")
@@ -126,7 +124,6 @@ def solve_from(trace: Trace, source: Op) -> _ReceptiveFieldSolution:
     if source.source_trace is not trace or not _operation_is_live(source):
         raise ValueError("Receptive-field source operation does not belong to the supplied trace.")
 
-    _ensure_trace_cache_policy(trace)
     epoch = _rf_rules_epoch()
     graph_revision = _graph_revision(trace)
     cache = trace.__dict__.get("_rf_source_solutions")
@@ -147,19 +144,6 @@ def solve_from(trace: Trace, source: Op) -> _ReceptiveFieldSolution:
     while len(cache) > _SOURCE_SOLUTION_CACHE_SIZE:
         cache.popitem(last=False)
     return solution
-
-
-def _ensure_trace_cache_policy(trace: Trace) -> None:
-    """Declare the dynamically owned trace cache as runtime-only portable state.
-
-    Parameters
-    ----------
-    trace:
-        Trace class whose portable state policy owns the runtime cache.
-    """
-
-    type(trace).PORTABLE_STATE_SPEC.setdefault("_receptive_field_solution", FieldPolicy.DROP)
-    type(trace).PORTABLE_STATE_SPEC.setdefault("_rf_source_solutions", FieldPolicy.DROP)
 
 
 def lookup(trace: Trace, op: Op | str) -> Mapping[str, ReceptiveField]:

--- a/torchlens/receptive_field/_engine_forward.py
+++ b/torchlens/receptive_field/_engine_forward.py
@@ -631,7 +631,7 @@ def _transpose_full(
     if passthrough.axes is None and all(axis.output_axis is None for axis in state.axes):
         passthrough = replace(state, notes=notes, rule=rule_name)
     elif passthrough.axes is None and selected == set(range(parent_rank)):
-        axes = tuple(
+        fallback_axes = tuple(
             replace(
                 axis,
                 geometry=_Full(exact=exact),
@@ -641,7 +641,7 @@ def _transpose_full(
             )
             for axis in state.axes
         )
-        return replace(state, axes=axes, notes=notes, rule=rule_name)
+        return replace(state, axes=fallback_axes, notes=notes, rule=rule_name)
     assert passthrough.axes is not None
     axes: list[_AxisState] = []
     batch_axis = passthrough.batch_axis

--- a/torchlens/receptive_field/_engine_forward.py
+++ b/torchlens/receptive_field/_engine_forward.py
@@ -9,7 +9,6 @@ from fractions import Fraction
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
-from .._io import FieldPolicy
 from ._engine import (
     _concatenation_offsets,
     _graph_revision,
@@ -83,7 +82,6 @@ def solve_projective(trace: Trace, target_ops: Iterable[Op | str]) -> _Projectiv
 
     targets = _canonical_targets(trace, target_ops)
     target_labels = tuple(target.label for target in targets)
-    _ensure_trace_cache_policy(trace)
     epoch = _rf_rules_epoch()
     revision = _graph_revision(trace)
     cache = trace.__dict__.get("_rf_target_solutions")
@@ -143,12 +141,6 @@ def _canonical_targets(trace: Trace, target_ops: Iterable[Op | str]) -> tuple[Op
     if len(keys) != len(set(keys)):
         raise ValueError("Projective targets must have distinct result keys.")
     return targets
-
-
-def _ensure_trace_cache_policy(trace: Trace) -> None:
-    """Declare the target-set solution cache as runtime-only portable state."""
-
-    type(trace).PORTABLE_STATE_SPEC.setdefault("_rf_target_solutions", FieldPolicy.DROP)
 
 
 def _solve_projective_uncached(

--- a/torchlens/receptive_field/_engine_forward.py
+++ b/torchlens/receptive_field/_engine_forward.py
@@ -628,6 +628,20 @@ def _transpose_full(
         notes,
         child_to_parent=child_to_parent,
     )
+    if passthrough.axes is None and all(axis.output_axis is None for axis in state.axes):
+        passthrough = replace(state, notes=notes, rule=rule_name)
+    elif passthrough.axes is None and selected == set(range(parent_rank)):
+        axes = tuple(
+            replace(
+                axis,
+                geometry=_Full(exact=exact),
+                output_axis=None,
+                kind="full",
+                provenance=child.label,
+            )
+            for axis in state.axes
+        )
+        return replace(state, axes=axes, notes=notes, rule=rule_name)
     assert passthrough.axes is not None
     axes: list[_AxisState] = []
     batch_axis = passthrough.batch_axis

--- a/torchlens/receptive_field/_table.py
+++ b/torchlens/receptive_field/_table.py
@@ -316,6 +316,11 @@ def build_rf_profile(
     if sort_by is not None and sort_by not in columns:
         raise ValueError(f"sort_by must be one of: {', '.join(columns)}.")
     frame = pd.DataFrame(rows, columns=columns)
+    semantic_columns = ["status", "alignment", "layout"]
+    if resolved_direction is ReceptiveFieldDirection.PROJECTIVE:
+        semantic_columns.append("projective_direction")
+    for column in semantic_columns:
+        frame[column] = pd.Series((row[column] for row in rows), dtype=object)
     if sort_by is not None:
         frame = frame.sort_values(sort_by, ascending=ascending, na_position="last", kind="stable")
     frame = frame.reset_index(drop=True)

--- a/torchlens/receptive_field/rules/elementwise.py
+++ b/torchlens/receptive_field/rules/elementwise.py
@@ -91,7 +91,7 @@ def reduction(context: ReceptiveFieldRuleContext) -> _RuleResult:
     """Mark reduced parent axes as exact whole-extent dependencies."""
 
     rank = len(context.in_shapes[0]) if context.in_shapes else len(context.out_shape)
-    raw = context.arg("dim", context.cfg("dim", None))
+    raw = context.arg("dim", context.arg(0, context.cfg("dim", None)))
     if raw is None:
         axes = tuple(range(rank))
     else:

--- a/torchlens/receptive_field/rules/norms.py
+++ b/torchlens/receptive_field/rules/norms.py
@@ -70,7 +70,31 @@ def instance_norm(context: ReceptiveFieldRuleContext) -> _RuleResult:
     if not use_input_stats:
         return context.passthrough()
     rank = len(context.in_shapes[0]) if context.in_shapes else len(context.out_shape)
-    return context.full(axes=tuple(range(2, rank)))
+    coupled_axes = tuple(range(2, rank))
+    full_axes_by_parent: dict[str, object] = {"default": coupled_axes}
+    parent_to_child_axes: dict[str, dict[int, int]] = {}
+    channel_parent_roles = {
+        "args:1",
+        "args:2",
+        "args:3",
+        "args:4",
+        "kwargs:running_mean",
+        "kwargs:running_var",
+        "kwargs:weight",
+        "kwargs:bias",
+    }
+    for parent_index, parent_label in enumerate(context.op.parents):
+        if context.parent_role(parent_index) in channel_parent_roles:
+            full_axes_by_parent[parent_label] = ()
+            parent_to_child_axes[parent_label] = {0: 1}
+    return _RuleResult(
+        "full",
+        {
+            "axes": full_axes_by_parent,
+            "exact": True,
+            "parent_to_child_axes": parent_to_child_axes,
+        },
+    )
 
 
 @register_rf_rule("group_norm")

--- a/torchlens/utils/_torch_compat.py
+++ b/torchlens/utils/_torch_compat.py
@@ -47,6 +47,7 @@ from typing import Any
 import warnings
 
 import torch
+from torch.utils._python_dispatch import TorchDispatchMode
 
 from ._torch_symbols import torch_attr
 
@@ -75,6 +76,7 @@ __all__ = [
     "HAS_GENERATOR_GRAPHSAFE_SET_STATE",
     "HAS_JIT_BUILTIN_TABLE",
     "HAS_NAMED_TENSOR_API",
+    "HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE",
     "HAS_DYNAMO_OPTIMIZED_MODULE",
     "HAS_SAFE_WEIGHTS_ONLY_LOAD",
     "HAS_CACHED_UNTYPED_STORAGE_WRAPPER",
@@ -112,6 +114,39 @@ TorchCapabilitySnapshot = dict[str, bool]
 
 _CAPABILITY_WARNING_ENV = "TORCHLENS_SUPPRESS_TORCH_CAPABILITY_WARNINGS"
 _warned_missing_capabilities: set[str] = set()
+
+
+class _ParameterAsSubclassProbeMode(TorchDispatchMode):
+    """Redispatch operations unchanged for the Parameter subclass capability probe."""
+
+    def __torch_dispatch__(
+        self,
+        func: Any,
+        types: tuple[type[Any], ...],
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] | None = None,
+    ) -> Any:
+        """Redispatch one probe operation without changing its result.
+
+        Parameters
+        ----------
+        func:
+            Dispatcher operator invoked by the probe.
+        types:
+            Participating tensor subclass types.
+        args:
+            Positional operator arguments.
+        kwargs:
+            Keyword operator arguments.
+
+        Returns
+        -------
+        Any
+            Unmodified operator result.
+        """
+
+        del types
+        return func(*args, **(kwargs or {}))
 
 
 @dataclass(frozen=True, slots=True)
@@ -740,6 +775,31 @@ def _probe_safe_weights_only_load() -> bool:
     )
 
 
+def _probe_parameter_as_subclass_in_dispatch_mode() -> bool:
+    """Return whether Parameter-to-Tensor subclass conversion works in a dispatch mode.
+
+    Torch 2.1 rejects ``Parameter.as_subclass(torch.Tensor)`` while a
+    :class:`TorchDispatchMode` is active because the returned raw tensor is already
+    associated with a base ``Tensor`` Python object. Newer torch releases permit the
+    conversion. TorchLens' completeness witness is itself a dispatch mode, so this
+    behavioral probe mirrors the dynamic-parameter logging context without parsing a
+    version string.
+
+    Returns
+    -------
+    bool
+        ``True`` when the conversion succeeds inside a redispatching mode.
+    """
+
+    parameter = torch.nn.Parameter(torch.empty(0))
+    try:
+        with _ParameterAsSubclassProbeMode():
+            plain_tensor = parameter.as_subclass(torch.Tensor)
+    except (RuntimeError, TypeError):
+        return False
+    return type(plain_tensor) is torch.Tensor
+
+
 HAS_VARIABLE_FUNCTIONS: bool = _probe_variable_functions()
 HAS_TORCH_VF: bool = _probe_torch_vf()
 HAS_TORCH_FUNC: bool = _probe_torch_func()
@@ -759,6 +819,7 @@ HAS_GENERATOR_GRAPHSAFE_GET_STATE: bool = hasattr(torch.Generator, "graphsafe_ge
 HAS_GENERATOR_GRAPHSAFE_SET_STATE: bool = hasattr(torch.Generator, "graphsafe_set_state")
 HAS_SAFE_WEIGHTS_ONLY_LOAD: bool = _probe_safe_weights_only_load()
 HAS_TENSOR_SEQUENCE_SLOT_FIX: bool = _probe_tensor_sequence_slot_fix()
+HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE: bool = _probe_parameter_as_subclass_in_dispatch_mode()
 _DYNAMO_OPTIMIZED_MODULE_TYPE: type[Any] | None = None
 _DYNAMO_OPTIMIZED_MODULE_PROBED: bool = False
 
@@ -783,6 +844,7 @@ _CAPABILITY_ATTRS: tuple[str, ...] = (
     "HAS_GENERATOR_GRAPHSAFE_SET_STATE",
     "HAS_SAFE_WEIGHTS_ONLY_LOAD",
     "HAS_TENSOR_SEQUENCE_SLOT_FIX",
+    "HAS_PARAMETER_AS_SUBCLASS_IN_DISPATCH_MODE",
     "HAS_FLOAT32_MATMUL_PRECISION",
     "HAS_DETERMINISTIC_ALGORITHMS_QUERY",
     "HAS_CUDA_MATMUL_TF32",

--- a/torchlens/utils/rng.py
+++ b/torchlens/utils/rng.py
@@ -38,6 +38,7 @@ from types import (
     CodeType,
     FrameType,
     FunctionType,
+    GetSetDescriptorType,
     MemberDescriptorType,
     MethodType,
     MethodWrapperType,
@@ -1816,9 +1817,10 @@ class host_nondeterminism_monitor:
         # NumPy 2.x binds Generator/RandomState Cython callables as Python methods
         # that emit no profile ``c_call`` event. The feature-detected fallback
         # snapshots only RNG receivers directly referenced by each profiled Python
-        # frame and compares them at return, preserving the no-method-name invariant.
+        # frame or one inert holder edge below them and compares them at return,
+        # preserving the no-method-name invariant.
         self._numpy_frame_rng_states: dict[int, list[tuple[Any, str]]] = {}
-        self._numpy_global_rng_cache: dict[tuple[int, int], tuple[Any, ...]] = {}
+        self._numpy_global_name_cache: dict[tuple[int, int], tuple[str, ...]] = {}
         # r49 hon1_1: re-entrancy depth for monitor-INTERNAL probes. While > 0 the monitor is
         # reading through its OWN inventory probe (owner-thread, ``__enter__``-scoped, BEFORE the
         # user forward runs), so any channel a probe transitively touches must NOT be marked as a
@@ -2011,15 +2013,98 @@ class host_nondeterminism_monitor:
         channel, disposition = mark
         self._mark_disposition(channel, disposition)
 
+    @staticmethod
+    def _numpy_frame_candidate_children(value: Any) -> tuple[Any, ...]:
+        """Return one inert holder edge below a profiled-frame value.
+
+        Exact built-in container types are read through their concrete C
+        implementations, so a hostile subclass cannot execute an overridden iterator.
+        Plain-object attributes are read only through a concrete getset descriptor for
+        the instance ``__dict__``; a property or other hostile descriptor named
+        ``__dict__`` makes the value a leaf. Callable receivers remain gated by
+        :func:`_numpy_rng_receiver`, which reads ``__self__`` only after an exact
+        built-in-bound-callable or ``MethodType`` check.
+
+        Parameters
+        ----------
+        value:
+            Candidate frame local or referenced global.
+
+        Returns
+        -------
+        tuple[Any, ...]
+            Immediate inert children that may themselves be concrete NumPy RNG
+            receivers.
+        """
+
+        value_type = type(value)
+        if value_type is dict:
+            return (*dict.keys(value), *dict.values(value))
+        if value_type in (list, tuple, set, frozenset):
+            return tuple(value)
+        if isinstance(
+            value,
+            (
+                type,
+                ModuleType,
+                FunctionType,
+                BuiltinFunctionType,
+                MethodType,
+                MethodWrapperType,
+                np.ndarray,
+                np.generic,
+                torch.Tensor,
+                torch.nn.Module,
+            ),
+        ):
+            return ()
+        try:
+            module = type.__dict__["__module__"].__get__(value_type)
+        except Exception:
+            return ()
+        if not isinstance(module, str):
+            return ()
+        module_root = module.split(".", 1)[0]
+        if module_root in _CUSTOM_HOLDER_SKIP_MODULES or module_root in _STDLIB_CLASS_LEAF_MODULES:
+            return ()
+        instance_dict_getter = None
+        try:
+            mro = type.__dict__["__mro__"].__get__(value_type)
+        except Exception:
+            return ()
+        for klass in mro:
+            try:
+                class_dict = type.__dict__["__dict__"].__get__(klass)
+            except Exception:
+                return ()
+            descriptor = class_dict.get("__dict__")
+            if descriptor is None:
+                continue
+            if not isinstance(descriptor, GetSetDescriptorType):
+                return ()
+            instance_dict_getter = descriptor
+            break
+        if instance_dict_getter is None:
+            return ()
+        try:
+            instance_dict = instance_dict_getter.__get__(value, value_type)
+        except (AttributeError, TypeError, ValueError):
+            return ()
+        if not isinstance(instance_dict, dict):
+            return ()
+        return tuple(instance_dict.values())
+
     def _snapshot_numpy_frame_rngs(self, frame: FrameType) -> None:
-        """Snapshot NumPy RNG receivers directly referenced by a Python frame.
+        """Snapshot NumPy RNG receivers inertly reachable from a Python frame.
 
         This fallback is active only for the feature-detected NumPy Cython method
-        shape that emits no profile ``c_call`` event. Global lookup is restricted to
-        names referenced by the frame's code object, and closure lookup to declared
-        free variables, so this never walks a shared module namespace or materializes
-        every frame local. Global receivers are cached per code/globals identity to
-        keep the profile hook cheap across TorchLens's high call volume.
+        shape that emits no profile ``c_call`` event. It covers every materialized
+        fast local directly plus globals named by the frame's code object, descending
+        one inert edge below those globals through exact built-in containers or a
+        plain-object ``__dict__``. It never walks a shared module namespace or invokes
+        user attribute/iteration hooks. Referenced global names, rather than resolved
+        objects, are cached per code/globals identity so a rebound global cannot evade
+        a later snapshot.
 
         Parameters
         ----------
@@ -2030,28 +2115,31 @@ class host_nondeterminism_monitor:
         if not _NUMPY_RNG_METHODS_NEED_FRAME_DIGEST:
             return
         cache_key = (id(frame.f_code), id(frame.f_globals))
-        global_holders = self._numpy_global_rng_cache.get(cache_key)
-        if global_holders is None:
-            global_candidates = (
-                frame.f_globals[name] for name in frame.f_code.co_names if name in frame.f_globals
-            )
-            holders: list[Any] = []
-            for candidate in global_candidates:
-                receiver = _numpy_rng_receiver(candidate)
-                holder = receiver if receiver is not None else candidate
-                if isinstance(holder, _NUMPY_RNG_INSTANCE_TYPES):
-                    holders.append(holder)
-            global_holders = tuple(holders)
-            self._numpy_global_rng_cache[cache_key] = global_holders
-        candidates = list(global_holders)
-        if frame.f_code.co_freevars:
-            frame_locals = frame.f_locals
-            candidates.extend(
-                frame_locals[name] for name in frame.f_code.co_freevars if name in frame_locals
-            )
+        global_names = self._numpy_global_name_cache.get(cache_key)
+        if global_names is None:
+            global_names = tuple(frame.f_code.co_names)
+            self._numpy_global_name_cache[cache_key] = global_names
+        global_candidates = [
+            frame.f_globals[name] for name in global_names if name in frame.f_globals
+        ]
         snapshots: list[tuple[Any, str]] = []
         seen_ids: set[int] = set()
-        for candidate in candidates:
+        for candidate in global_candidates:
+            for reachable in (candidate, *self._numpy_frame_candidate_children(candidate)):
+                receiver = _numpy_rng_receiver(reachable)
+                holder = receiver if receiver is not None else reachable
+                if (
+                    id(holder) in seen_ids
+                    or id(holder) in self._exempt_ids
+                    or not isinstance(holder, _NUMPY_RNG_INSTANCE_TYPES)
+                ):
+                    continue
+                seen_ids.add(id(holder))
+                try:
+                    snapshots.append((holder, self._digest_rng_instance(holder)))
+                except Exception:
+                    self._flag_uncertain("profile_rng_state_read_failed")
+        for candidate in frame.f_locals.values():
             receiver = _numpy_rng_receiver(candidate)
             holder = receiver if receiver is not None else candidate
             if (

--- a/torchlens/utils/rng.py
+++ b/torchlens/utils/rng.py
@@ -39,6 +39,7 @@ from types import (
     FrameType,
     FunctionType,
     MemberDescriptorType,
+    MethodType,
     MethodWrapperType,
     ModuleType,
     TracebackType,
@@ -69,6 +70,71 @@ _AUTOCAST_DEVICES = ("cpu", "cuda")
 _T = TypeVar("_T")
 
 _SEEDED_RNG_NAMESPACES = frozenset({"torch", "torch.Tensor", "torch.nn.functional"})
+
+_NUMPY_RNG_INSTANCE_TYPES: tuple[type, ...] = (
+    np.random.Generator,
+    np.random.RandomState,
+    np.random.BitGenerator,
+)
+"""Public NumPy RNG receiver types covered by the host-nondeterminism witness."""
+
+
+def _numpy_rng_receiver(value: Any) -> Any | None:
+    """Return the NumPy RNG receiver bound to ``value``, when present.
+
+    Parameters
+    ----------
+    value:
+        Candidate bound callable.
+
+    Returns
+    -------
+    Any or None
+        The owning NumPy RNG instance, or ``None`` when ``value`` is not bound
+        to a public NumPy RNG type.
+    """
+
+    if not isinstance(value, (BuiltinFunctionType, MethodType)):
+        return None
+    receiver = value.__self__
+    return receiver if isinstance(receiver, _NUMPY_RNG_INSTANCE_TYPES) else None
+
+
+def _numpy_rng_methods_need_frame_digest() -> bool:
+    """Feature-detect NumPy RNG methods that do not emit profile ``c_call`` events.
+
+    NumPy 1.x binds its public RNG C methods as ``BuiltinFunctionType`` objects,
+    which the existing receiver-profile classifier observes directly. NumPy 2.x
+    binds Cython callables as Python ``MethodType`` objects; those calls do not
+    emit ``c_call`` events. Inspecting the public class surfaces avoids version
+    parsing and draw-method name enumeration.
+
+    Returns
+    -------
+    bool
+        Whether any public NumPy RNG receiver surface uses Python method binding.
+    """
+
+    probes = (
+        np.random.Generator(np.random.PCG64(0)),
+        np.random.RandomState(0),
+    )
+    for probe in probes:
+        for descriptor in vars(type(probe)).values():
+            descriptor_get = getattr(descriptor, "__get__", None)
+            if not callable(descriptor_get):
+                continue
+            try:
+                bound = descriptor_get(probe, type(probe))
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if isinstance(bound, MethodType) and _numpy_rng_receiver(bound) is probe:
+                return True
+    return False
+
+
+_NUMPY_RNG_METHODS_NEED_FRAME_DIGEST = _numpy_rng_methods_need_frame_digest()
+"""Whether NumPy RNG draws need the profiled-frame state-digest fallback."""
 
 
 def aten_qualname_is_seeded_rng(namespace: str | None, qualname: str | None) -> bool:
@@ -1747,6 +1813,12 @@ class host_nondeterminism_monitor:
         # r41 hon2_1: idents of threads hooked by the in-window threading profile hook,
         # consumed by the escape belt's 3-class thread gate via ``_ACTIVE_MONITOR``.
         self._in_window_thread_idents: set[int] = set()
+        # NumPy 2.x binds Generator/RandomState Cython callables as Python methods
+        # that emit no profile ``c_call`` event. The feature-detected fallback
+        # snapshots only RNG receivers directly referenced by each profiled Python
+        # frame and compares them at return, preserving the no-method-name invariant.
+        self._numpy_frame_rng_states: dict[int, list[tuple[Any, str]]] = {}
+        self._numpy_global_rng_cache: dict[tuple[int, int], tuple[Any, ...]] = {}
         # r49 hon1_1: re-entrancy depth for monitor-INTERNAL probes. While > 0 the monitor is
         # reading through its OWN inventory probe (owner-thread, ``__enter__``-scoped, BEFORE the
         # user forward runs), so any channel a probe transitively touches must NOT be marked as a
@@ -1939,6 +2011,83 @@ class host_nondeterminism_monitor:
         channel, disposition = mark
         self._mark_disposition(channel, disposition)
 
+    def _snapshot_numpy_frame_rngs(self, frame: FrameType) -> None:
+        """Snapshot NumPy RNG receivers directly referenced by a Python frame.
+
+        This fallback is active only for the feature-detected NumPy Cython method
+        shape that emits no profile ``c_call`` event. Global lookup is restricted to
+        names referenced by the frame's code object, and closure lookup to declared
+        free variables, so this never walks a shared module namespace or materializes
+        every frame local. Global receivers are cached per code/globals identity to
+        keep the profile hook cheap across TorchLens's high call volume.
+
+        Parameters
+        ----------
+        frame:
+            Python frame entering under the profile hook.
+        """
+
+        if not _NUMPY_RNG_METHODS_NEED_FRAME_DIGEST:
+            return
+        cache_key = (id(frame.f_code), id(frame.f_globals))
+        global_holders = self._numpy_global_rng_cache.get(cache_key)
+        if global_holders is None:
+            global_candidates = (
+                frame.f_globals[name] for name in frame.f_code.co_names if name in frame.f_globals
+            )
+            holders: list[Any] = []
+            for candidate in global_candidates:
+                receiver = _numpy_rng_receiver(candidate)
+                holder = receiver if receiver is not None else candidate
+                if isinstance(holder, _NUMPY_RNG_INSTANCE_TYPES):
+                    holders.append(holder)
+            global_holders = tuple(holders)
+            self._numpy_global_rng_cache[cache_key] = global_holders
+        candidates = list(global_holders)
+        if frame.f_code.co_freevars:
+            frame_locals = frame.f_locals
+            candidates.extend(
+                frame_locals[name] for name in frame.f_code.co_freevars if name in frame_locals
+            )
+        snapshots: list[tuple[Any, str]] = []
+        seen_ids: set[int] = set()
+        for candidate in candidates:
+            receiver = _numpy_rng_receiver(candidate)
+            holder = receiver if receiver is not None else candidate
+            if (
+                id(holder) in seen_ids
+                or id(holder) in self._exempt_ids
+                or not isinstance(holder, _NUMPY_RNG_INSTANCE_TYPES)
+            ):
+                continue
+            seen_ids.add(id(holder))
+            try:
+                snapshots.append((holder, self._digest_rng_instance(holder)))
+            except Exception:
+                self._flag_uncertain("profile_rng_state_read_failed")
+        if snapshots:
+            self._numpy_frame_rng_states[id(frame)] = snapshots
+
+    def _compare_numpy_frame_rngs(self, frame: FrameType) -> None:
+        """Mark a NumPy RNG receiver whose state changed within a profiled frame.
+
+        Parameters
+        ----------
+        frame:
+            Python frame returning under the profile hook.
+        """
+
+        snapshots = self._numpy_frame_rng_states.pop(id(frame), ())
+        for holder, before in snapshots:
+            try:
+                changed = self._digest_rng_instance(holder) != before
+            except Exception:
+                self._flag_uncertain("profile_rng_state_read_failed")
+                continue
+            if changed:
+                self._mark("c_rng_instance_draw")
+                return
+
     def _classify_c_call(self, frame: Any, arg: Any) -> None:
         # r41 hon1_1: held-reference identity FIRST. A pre-window ``from time import
         # time`` alias calls the ORIGINAL builtin, bypassing the module-attr patch; the
@@ -2001,13 +2150,7 @@ class host_nondeterminism_monitor:
         # numpy instance draws + bare ``_random.Random`` draws (receiver typing -- no
         # draw-method NAME enumeration, so new draw methods need no detector edit).
         if id(receiver) not in self._exempt_ids and isinstance(
-            receiver,
-            (
-                _c_random_module.Random,
-                np.random.Generator,
-                np.random.RandomState,
-                np.random.BitGenerator,
-            ),
+            receiver, (_c_random_module.Random, *_NUMPY_RNG_INSTANCE_TYPES)
         ):
             self._mark("c_rng_instance_draw")
             return
@@ -2070,10 +2213,13 @@ class host_nondeterminism_monitor:
                 if event == "c_call":
                     self._classify_c_call(frame, arg)
                 elif event == "call":
+                    self._snapshot_numpy_frame_rngs(frame)
                     # r65 CLUSTER Z: held-reference torch RNG spellings are Python
                     # functions -- classified by code identity on ``call`` events (the
                     # r41 builtin-identity layer only ever sees ``c_call``).
                     self._classify_call(frame)
+                elif event == "return":
+                    self._compare_numpy_frame_rngs(frame)
             except Exception:
                 self._flag_uncertain("profile_classifier_error")
             if predecessor is not None:
@@ -2333,6 +2479,13 @@ class host_nondeterminism_monitor:
         must stay generically walked.
         """
 
+        numpy_receiver = _numpy_rng_receiver(value)
+        if numpy_receiver is not None:
+            if id(numpy_receiver) in shared_namespace_ids or isinstance(
+                numpy_receiver, _AMBIENT_BRIDGE_LEAF_TYPES
+            ):
+                return []
+            return [numpy_receiver]
         if isinstance(value, (BuiltinFunctionType, MethodWrapperType)):
             receiver = getattr(value, "__self__", None)
             if (

--- a/torchlens/utils/rng.py
+++ b/torchlens/utils/rng.py
@@ -137,6 +137,13 @@ def _numpy_rng_methods_need_frame_digest() -> bool:
 _NUMPY_RNG_METHODS_NEED_FRAME_DIGEST = _numpy_rng_methods_need_frame_digest()
 """Whether NumPy RNG draws need the profiled-frame state-digest fallback."""
 
+_NUMPY_FRAME_DIGEST_INTERNAL_PATH_PREFIXES = (
+    f"{_os_module.path.dirname(_os_module.path.dirname(__file__))}{_os_module.sep}",
+    f"{_os_module.path.dirname(np.__file__)}{_os_module.sep}",
+    f"{_os_module.path.dirname(torch.__file__)}{_os_module.sep}",
+)
+"""Package roots whose internal frames cannot originate user-owned NumPy RNG draws."""
+
 
 def aten_qualname_is_seeded_rng(namespace: str | None, qualname: str | None) -> bool:
     """Return whether a captured callable maps to a seeded ATen RNG operator.
@@ -1821,6 +1828,7 @@ class host_nondeterminism_monitor:
         # preserving the no-method-name invariant.
         self._numpy_frame_rng_states: dict[int, list[tuple[Any, str]]] = {}
         self._numpy_global_name_cache: dict[tuple[int, int], tuple[str, ...]] = {}
+        self._numpy_frame_digest_scope_cache: dict[CodeType, bool] = {}
         # r49 hon1_1: re-entrancy depth for monitor-INTERNAL probes. While > 0 the monitor is
         # reading through its OWN inventory probe (owner-thread, ``__enter__``-scoped, BEFORE the
         # user forward runs), so any channel a probe transitively touches must NOT be marked as a
@@ -2094,6 +2102,36 @@ class host_nondeterminism_monitor:
             return ()
         return tuple(instance_dict.values())
 
+    def _numpy_frame_needs_rng_snapshot(self, code: CodeType) -> bool:
+        """Return whether a code object's frames need the NumPy RNG digest.
+
+        Torch, TorchLens, and NumPy package frames are implementation frames: a
+        user-owned NumPy RNG draw originates in the calling user frame, which remains
+        fully snapshotted, or in a user callback, which receives its own profile
+        ``call`` event. Caching by code object makes the per-call decision an identity
+        lookup after the first invocation without trusting mutable module metadata.
+
+        Parameters
+        ----------
+        code:
+            Code object for the entering Python frame.
+
+        Returns
+        -------
+        bool
+            Whether the frame may originate a user-owned NumPy RNG draw.
+        """
+
+        cached = self._numpy_frame_digest_scope_cache.get(code)
+        if cached is not None:
+            return cached
+        filename = code.co_filename
+        needs_snapshot = not any(
+            filename.startswith(prefix) for prefix in _NUMPY_FRAME_DIGEST_INTERNAL_PATH_PREFIXES
+        )
+        self._numpy_frame_digest_scope_cache[code] = needs_snapshot
+        return needs_snapshot
+
     def _snapshot_numpy_frame_rngs(self, frame: FrameType) -> None:
         """Snapshot NumPy RNG receivers inertly reachable from a Python frame.
 
@@ -2113,6 +2151,8 @@ class host_nondeterminism_monitor:
         """
 
         if not _NUMPY_RNG_METHODS_NEED_FRAME_DIGEST:
+            return
+        if not self._numpy_frame_needs_rng_snapshot(frame.f_code):
             return
         cache_key = (id(frame.f_code), id(frame.f_globals))
         global_names = self._numpy_global_name_cache.get(cache_key)

--- a/torchlens/visualization/auto_collapse.py
+++ b/torchlens/visualization/auto_collapse.py
@@ -206,6 +206,72 @@ class CollapseAnalysis:
 
 
 _ANALYSIS_CACHE: weakref.WeakKeyDictionary[Any, CollapseAnalysis] = weakref.WeakKeyDictionary()
+_OP_ADJACENCY_INDEX_CACHE: weakref.WeakKeyDictionary[Any, Mapping[str, str]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _op_adjacency_index(trace: "Trace") -> Mapping[str, str]:
+    """Return unambiguous relationship labels mapped to canonical Op labels.
+
+    Parameters
+    ----------
+    trace:
+        Trace whose operation relationships are being indexed.
+
+    Returns
+    -------
+    Mapping[str, str]
+        Unambiguous accessor label forms mapped to canonical operation labels.
+    """
+
+    cached = _OP_ADJACENCY_INDEX_CACHE.get(trace)
+    if cached is not None:
+        return cached
+    unique_ops: dict[str, Op] = {}
+    ambiguous_forms: set[str] = set()
+    for op in trace.ops:
+        forms = (
+            op.label,
+            op.label_short,
+            op._label_raw,
+            op.raw_label,
+            op.layer_label,
+            op.layer_label_short,
+        )
+        for form in forms:
+            if not form:
+                continue
+            existing = unique_ops.get(form)
+            if existing is None:
+                unique_ops[form] = op
+            elif existing is not op:
+                ambiguous_forms.add(form)
+    index = {form: op.label for form, op in unique_ops.items() if form not in ambiguous_forms}
+    _OP_ADJACENCY_INDEX_CACHE[trace] = index
+    return index
+
+
+def _resolve_relationship_op(trace: "Trace", label: str) -> "Op":
+    """Resolve a parent/child relationship label without changing accessor semantics.
+
+    Parameters
+    ----------
+    trace:
+        Trace that owns the operation relationship.
+    label:
+        Label stored in an operation's ``parents`` or ``children`` collection.
+
+    Returns
+    -------
+    Op
+        The same operation returned by the public trace accessor.
+    """
+
+    canonical_label = _op_adjacency_index(trace).get(label)
+    if canonical_label is None:
+        return cast("Op", trace.ops[label])
+    return cast("Op", trace.ops[canonical_label])
 
 
 def analyze_collapse(trace: "Trace") -> CollapseAnalysis:
@@ -712,7 +778,7 @@ def _synthetic_child_condensed_flow_graph(
     for op in trace.ops:
         source = owner_by_label.get(op.label)
         for child_label in getattr(op, "children", ()) or ():
-            child_op = cast("Op", trace.ops[child_label])
+            child_op = _resolve_relationship_op(trace, child_label)
             target_label = child_op.label
             if not _is_forward_dataflow_edge(trace, op.label, target_label):
                 continue
@@ -1743,7 +1809,7 @@ def _compute_signal_skeleton(trace: "Trace") -> dict[str, ModuleCollapseSignals]
         for child_label in parent.children:
             child = op_by_label.get(child_label)
             if child is None:
-                child = cast("Op", trace.ops[child_label])
+                child = _resolve_relationship_op(trace, child_label)
                 op_by_label[child_label] = child
                 op_by_label[child.label] = child
                 stack_by_label[child.label] = _module_address_stack(child)
@@ -2054,7 +2120,7 @@ def _condensed_edges(
         op = cast("Op", trace.ops[label])
         source = _condensed_owner_for_op(label, parent, flow_children, child_sets)
         for parent_label in getattr(op, "parents", ()) or ():
-            parent_op = cast("Op", trace.ops[parent_label])
+            parent_op = _resolve_relationship_op(trace, parent_label)
             normalized_parent_label = parent_op.label
             if normalized_parent_label in parent_subtree:
                 continue
@@ -2062,7 +2128,7 @@ def _condensed_edges(
                 continue
             edges.add((f"external_source:{normalized_parent_label}", source))
         for child_label in getattr(op, "children", ()) or ():
-            child = cast("Op", trace.ops[child_label])
+            child = _resolve_relationship_op(trace, child_label)
             normalized_child_label = child.label
             if not _is_forward_dataflow_edge(trace, label, normalized_child_label):
                 continue
@@ -2334,7 +2400,7 @@ def _has_external_parent(trace: "Trace", op: "Op", subtree: set[str]) -> bool:
     """Return whether an operation has a non-buffer parent outside ``subtree``."""
 
     for parent_label in getattr(op, "parents", ()) or ():
-        parent = cast("Op", trace.ops[parent_label])
+        parent = _resolve_relationship_op(trace, parent_label)
         if parent.label not in subtree and not getattr(parent, "is_buffer", False):
             return True
     return False
@@ -2344,7 +2410,7 @@ def _has_external_child(trace: "Trace", op: "Op", subtree: set[str]) -> bool:
     """Return whether an operation has a non-buffer child outside ``subtree``."""
 
     for child_label in getattr(op, "children", ()) or ():
-        child = cast("Op", trace.ops[child_label])
+        child = _resolve_relationship_op(trace, child_label)
         if child.label not in subtree and not getattr(child, "is_buffer", False):
             return True
     return False
@@ -2404,7 +2470,7 @@ def _count_passthrough_edges(
         has_internal_parent = False
         has_input_parent = False
         for parent_label in op.parents:
-            parent = cast("Op", trace.ops[parent_label])
+            parent = _resolve_relationship_op(trace, parent_label)
             if parent.label in subtree:
                 has_internal_parent = True
             elif _base_label(parent.label) in input_layers:


### PR DESCRIPTION
## Fix the `not slow` test-suite backlog + re-enable the not-slow CI gate

CI has historically run smoke-only, so the full `-m "not slow"` suite accumulated latent
failures (mostly from the post-2.31.0 megasprint) that were never gated — including two
infinite/pathological hangs. This fixes the whole backlog at root and restores the not-slow
gate on the canonical leg. Every failure was confirmed **pre-existing** (reproduced on a
detached `v2.32.2` worktree) and fixed **without weakening any validation tripwire**.

### Hangs (both root-caused; neither was truly infinite)
- **Collapse-optimizer O(N²)** (`test_collapse_optimizer`, `test_auto_collapse_metrics` hung 51+ min):
  adjacency lookups used bare labels while `trace.ops` is keyed by pass-qualified labels, so every
  lookup missed the O(1) dict and fell to an O(N) substring scan. Fixed with a memoized adjacency
  index (byte-identical plan output, proven by an equivalence battery) + a deterministic
  zero-fuzzy-scan regression guard + a spawned-subprocess containment belt.
- **Cross-thread capture deadlock** (`r41`/`r45`/`r47`/`r49`): the completeness-witness non-owner
  path re-entered itself infinitely on a spawned worker thread. Fixed by reading anchored
  session metadata directly; cross-thread detection preserved.

### Failures (root-caused, per-failure real-bug vs. test-portability)
- **RF-engine robustness** (Mistral `IndexError`, InstanceNorm/rank-changing/empty-concat rules).
- **Capture attribution**: raw/no-op hook dispatches now honestly accounted as `internal_source`
  boundaries — **dispatch-scoped**, so a co-occurring observable mutation still fails closed
  (`capture_verified=False`). Independently adversarially reviewed.
- **Exotic architectures**: DynamicModuleCreation / MAML (autograd-grad backward boundary) /
  propertymodel op-count gaps fixed at the capture level; the data-alias-mutation tripwire is
  preserved (a `.data`-getter read never lets a `.data`-alias write be verified).
- Lightning tensor-release cycle, tinygrad portable state, io/callable-alias, and several
  test-portability corrections (stale goldens, py3.11-only APIs, incidental private imports).

### Not gated here (out of scope)
- `tests/test_menagerie_*.py` — the menagerie is a separate reference corpus (excluded from the
  wheel, maintained independently). The not-slow CI step excludes it via `--ignore-glob`.
- One documented value-safe residual (a pure non-mutating interior op of a boundary-credited
  child can be masked; corrupts nothing, consistent with the opaque-boundary design).

### CI
Re-enables the full `-m "not slow"` suite on the canonical py3.11/torch-2.8 leg (the other legs
stay smoke). Do not merge until the not-slow leg (and the rest of the matrix) is green.
